### PR TITLE
Add required flag for event option categories

### DIFF
--- a/components/dashboard/event-form/shared/fields/EventOptionsFields.tsx
+++ b/components/dashboard/event-form/shared/fields/EventOptionsFields.tsx
@@ -120,6 +120,28 @@ const EventOptionsFields = ({
                   />
                 </div>
 
+                <div className="flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    id={`category-required-${categoryIndex}`}
+                    checked={category.required || false}
+                    onChange={(e) =>
+                      actions.updateOptionCategory(
+                        categoryIndex,
+                        "required",
+                        e.target.checked
+                      )
+                    }
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  />
+                  <label
+                    htmlFor={`category-required-${categoryIndex}`}
+                    className="text-sm font-medium text-gray-700"
+                  >
+                    Required - customer must choose an option at checkout
+                  </label>
+                </div>
+
                 {/* Choices */}
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">

--- a/components/dashboard/event-form/shared/hooks/useEventForm.ts
+++ b/components/dashboard/event-form/shared/hooks/useEventForm.ts
@@ -138,6 +138,7 @@ export const useEventForm = ({
     const newCategory = {
       categoryName: "",
       categoryDescription: "",
+      required: false,
       choices: [{ name: "", price: undefined as number | undefined }],
     };
 
@@ -185,7 +186,7 @@ export const useEventForm = ({
   );
 
   const updateOptionCategory = useCallback(
-    (categoryIndex: number, field: string, value: string) => {
+    (categoryIndex: number, field: string, value: string | boolean) => {
       setFormData((prev) => {
         const newCategories = [...prev.optionCategories];
         newCategories[categoryIndex] = {
@@ -276,6 +277,7 @@ export const useEventForm = ({
               options: formData.optionCategories.map((category) => ({
                 categoryName: category.categoryName,
                 categoryDescription: category.categoryDescription,
+                required: category.required || false,
                 choices: category.choices.map((choice) => ({
                   name: choice.name,
                   price: choice.price || 0,

--- a/components/dashboard/event-form/shared/types/eventForm.types.ts
+++ b/components/dashboard/event-form/shared/types/eventForm.types.ts
@@ -3,6 +3,7 @@ import { Dayjs } from "dayjs";
 export interface EventOptionCategory {
   categoryName: string;
   categoryDescription?: string;
+  required?: boolean;
   choices: Array<{ name: string; price?: number }>;
 }
 
@@ -62,7 +63,11 @@ export interface EventFormActions {
   removeOptionCategory: (index: number) => void;
   addChoiceToCategory: (categoryIndex: number) => void;
   removeChoiceFromCategory: (categoryIndex: number, choiceIndex: number) => void;
-  updateOptionCategory: (categoryIndex: number, field: string, value: string) => void;
+  updateOptionCategory: (
+    categoryIndex: number,
+    field: string,
+    value: string | boolean
+  ) => void;
   updateChoice: (
     categoryIndex: number,
     choiceIndex: number,

--- a/components/payment/BillingForm.tsx
+++ b/components/payment/BillingForm.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent } from "react";
 interface EventOption {
   categoryName: string;
   categoryDescription?: string;
+  required?: boolean;
   choices: Array<{
     name: string;
     price?: number;
@@ -321,6 +322,9 @@ const BillingForm: React.FC<BillingFormProps> = ({
                 >
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     {option.categoryName}
+                    {option.required && (
+                      <span className="text-red-500 ml-0.5">*</span>
+                    )}
                     {option.categoryDescription && (
                       <span className="text-gray-500 text-xs ml-1">
                         - {option.categoryDescription}
@@ -338,6 +342,9 @@ const BillingForm: React.FC<BillingFormProps> = ({
                     }
                     className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 focus:ring-primary focus:border-primary transition"
                   >
+                    {option.required && (
+                      <option value="">-- Select an option --</option>
+                    )}
                     {option.choices.map((choice, choiceIndex) => (
                       <option key={choiceIndex} value={choice.name}>
                         {formatChoiceDisplay(choice)}
@@ -412,6 +419,11 @@ const BillingForm: React.FC<BillingFormProps> = ({
                             <div key={optionIndex}>
                               <label className="block text-sm text-gray-700 mb-1">
                                 {option.categoryName}
+                                {option.required && (
+                                  <span className="text-red-500 ml-0.5">
+                                    *
+                                  </span>
+                                )}
                               </label>
                               <select
                                 value={
@@ -419,7 +431,9 @@ const BillingForm: React.FC<BillingFormProps> = ({
                                     (so) =>
                                       so.categoryName === option.categoryName
                                   )?.choiceName ||
-                                  option.choices[0]?.name ||
+                                  (option.required
+                                    ? ""
+                                    : option.choices[0]?.name) ||
                                   ""
                                 }
                                 onChange={(e) => {
@@ -458,6 +472,11 @@ const BillingForm: React.FC<BillingFormProps> = ({
                                 }}
                                 className="w-full p-2 border border-gray-300 rounded-md"
                               >
+                                {option.required && (
+                                  <option value="">
+                                    -- Select an option --
+                                  </option>
+                                )}
                                 {option.choices.map((choice, choiceIndex) => (
                                   <option key={choiceIndex} value={choice.name}>
                                     {formatChoiceDisplay(choice)}
@@ -566,6 +585,11 @@ const BillingForm: React.FC<BillingFormProps> = ({
                               <div key={optionIndex}>
                                 <label className="block text-sm text-gray-700 mb-1">
                                   {option.categoryName}
+                                  {option.required && (
+                                    <span className="text-red-500 ml-0.5">
+                                      *
+                                    </span>
+                                  )}
                                 </label>
                                 <select
                                   value={
@@ -573,7 +597,9 @@ const BillingForm: React.FC<BillingFormProps> = ({
                                       (so) =>
                                         so.categoryName === option.categoryName
                                     )?.choiceName ||
-                                    option.choices[0]?.name ||
+                                    (option.required
+                                      ? ""
+                                      : option.choices[0]?.name) ||
                                     ""
                                   }
                                   onChange={(e) => {
@@ -630,6 +656,11 @@ const BillingForm: React.FC<BillingFormProps> = ({
                                   }}
                                   className="w-full p-2 border border-gray-300 rounded-md"
                                 >
+                                  {option.required && (
+                                    <option value="">
+                                      -- Select an option --
+                                    </option>
+                                  )}
                                   {option.choices.map((choice, choiceIndex) => (
                                     <option
                                       key={choiceIndex}

--- a/components/payment/Payment.tsx
+++ b/components/payment/Payment.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { submitPayment } from "@/app/actions/actions";
-import { useState, ChangeEvent, useEffect } from "react";
+import { useState, ChangeEvent, useEffect, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import RegistrationHeader from "./RegistrationHeader";
 import EventPreview from "./EventPreview";
@@ -38,6 +38,7 @@ interface ReservationBooking {
 interface EventOption {
   categoryName: string;
   categoryDescription?: string;
+  required?: boolean;
   choices: Array<{
     name: string;
     price?: number;
@@ -655,6 +656,7 @@ export default function Payment() {
             if (eventData) {
               if (eventData.options && eventData.options.length > 0) {
                 const newOptions = eventData.options;
+
                 if (
                   JSON.stringify(newOptions) !== JSON.stringify(eventOptions)
                 ) {
@@ -663,7 +665,12 @@ export default function Payment() {
                   const initialSelectedOptions = newOptions.map(
                     (option: EventOption) => ({
                       categoryName: option.categoryName,
-                      choiceName: option.choices[0]?.name || "",
+                      // Required categories start unselected so the customer
+                      // must make an explicit choice; optional categories
+                      // default to the first choice.
+                      choiceName: option.required
+                        ? ""
+                        : option.choices[0]?.name || "",
                     })
                   );
                   setSelectedOptions(initialSelectedOptions);
@@ -814,6 +821,41 @@ export default function Payment() {
     calculateTotalOptionCosts,
   ]);
 
+  // Returns an error message if any required option category has no choice
+  // selected (for the primary registrant or any participant), else null.
+  const getRequiredOptionsError = useCallback((): string | null => {
+    const requiredCategories = eventOptions.filter((o) => o.required);
+    if (requiredCategories.length === 0) return null;
+
+    const hasChoice = (
+      opts: Array<{ categoryName: string; choiceName: string }> | undefined,
+      categoryName: string
+    ): boolean => {
+      const selected = opts?.find((so) => so.categoryName === categoryName);
+      return !!selected && selected.choiceName.trim() !== "";
+    };
+
+    if (isSigningUpForSelf) {
+      const missing = requiredCategories.find(
+        (cat) => !hasChoice(selectedOptions, cat.categoryName)
+      );
+      if (missing) {
+        return `Please select an option for "${missing.categoryName}".`;
+      }
+    }
+
+    const participantMissing = participants.some((participant) =>
+      requiredCategories.some(
+        (cat) => !hasChoice(participant.selectedOptions, cat.categoryName)
+      )
+    );
+    if (participantMissing) {
+      return "Please select all required event options for each participant.";
+    }
+
+    return null;
+  }, [eventOptions, isSigningUpForSelf, selectedOptions, participants]);
+
   useEffect(() => {
     const isContactProvided =
       billingDetails.email.trim() !== "" ||
@@ -834,10 +876,17 @@ export default function Payment() {
         participant.lastName.trim() !== ""
     );
 
-    setFormValid(areRequiredFieldsFilled && areParticipantNamesFilled);
-  }, [billingDetails, participants]);
+    setFormValid(
+      areRequiredFieldsFilled &&
+        areParticipantNamesFilled &&
+        getRequiredOptionsError() === null
+    );
+  }, [billingDetails, participants, getRequiredOptionsError]);
 
   const getParticipantValidationError = (): string | null => {
+    const optionsError = getRequiredOptionsError();
+    if (optionsError) return optionsError;
+
     const missingNames = participants.filter(
       (participant) =>
         participant.firstName.trim() === "" ||

--- a/lib/models/Event.ts
+++ b/lib/models/Event.ts
@@ -32,6 +32,7 @@ export interface IEvent extends Document {
   options?: Array<{
     categoryName: string;
     categoryDescription?: string;
+    required?: boolean;
     choices: Array<{
       name: string;
       price?: number;
@@ -142,6 +143,10 @@ const OptionSchema = new Schema({
   },
   categoryDescription: {
     type: String,
+  },
+  required: {
+    type: Boolean,
+    default: false,
   },
   choices: {
     type: [OptionChoiceSchema],


### PR DESCRIPTION
Lets admins mark an option category as required so customers must make an explicit choice at checkout instead of accepting an auto-selected default. Required categories render with a placeholder and block payment until a choice is made; optional categories are unchanged. Backward compatible: existing options default to not required.