### PR TITLE
Bring options hotfix into develop (free choice + explicit selection)

### DIFF
--- a/components/dashboard/event-form/shared/fields/EventOptionsFields.tsx
+++ b/components/dashboard/event-form/shared/fields/EventOptionsFields.tsx
@@ -120,27 +120,9 @@ const EventOptionsFields = ({
                   />
                 </div>
 
-                <div className="flex items-center space-x-2">
-                  <input
-                    type="checkbox"
-                    id={`category-required-${categoryIndex}`}
-                    checked={category.required || false}
-                    onChange={(e) =>
-                      actions.updateOptionCategory(
-                        categoryIndex,
-                        "required",
-                        e.target.checked
-                      )
-                    }
-                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                  />
-                  <label
-                    htmlFor={`category-required-${categoryIndex}`}
-                    className="text-sm font-medium text-gray-700"
-                  >
-                    Required - customer must choose an option at checkout
-                  </label>
-                </div>
+                <p className="text-xs text-gray-500">
+                  Customers must choose one option in this category at checkout.
+                </p>
 
                 {/* Choices */}
                 <div>
@@ -148,74 +130,90 @@ const EventOptionsFields = ({
                     Choices <span className="text-red-500">*</span>
                   </label>
                   <div className="space-y-2">
-                    {category.choices.map((choice, choiceIndex) => (
-                      <div
-                        key={choiceIndex}
-                        className="flex space-x-2 items-end"
-                      >
-                        <div className="flex-1">
-                          <input
-                            type="text"
-                            value={choice.name}
-                            onChange={(e) =>
-                              actions.updateChoice(
-                                categoryIndex,
-                                choiceIndex,
-                                "name",
-                                e.target.value
-                              )
-                            }
-                            autoComplete="new-password"
-                            autoCapitalize="none"
-                            autoCorrect="off"
-                            spellCheck="false"
-                            data-lpignore="true"
-                            data-form-type="other"
-                            className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            placeholder="Choice name and price (optional)"
-                          />
-                        </div>
-                        <div className="w-32">
-                          <input
-                            type="text"
-                            value={choice.price?.toString() || ""}
-                            onChange={(e) => {
-                              const value = e.target.value;
-                              if (formatNumberInput(value) === value) {
+                    {category.choices.map((choice, choiceIndex) => {
+                      // choices[0] is the guaranteed free option: renameable,
+                      // always $0, and not removable.
+                      const isFreeOption = choiceIndex === 0;
+
+                      return (
+                        <div
+                          key={choiceIndex}
+                          className="flex space-x-2 items-end"
+                        >
+                          <div className="flex-1">
+                            <input
+                              type="text"
+                              value={choice.name}
+                              onChange={(e) =>
                                 actions.updateChoice(
                                   categoryIndex,
                                   choiceIndex,
-                                  "price",
-                                  value ? Number(value) : undefined
-                                );
+                                  "name",
+                                  e.target.value
+                                )
                               }
-                            }}
-                            autoComplete="new-password"
-                            autoCapitalize="none"
-                            autoCorrect="off"
-                            spellCheck="false"
-                            data-lpignore="true"
-                            data-form-type="other"
-                            className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            placeholder="0.00"
-                          />
+                              autoComplete="new-password"
+                              autoCapitalize="none"
+                              autoCorrect="off"
+                              spellCheck="false"
+                              data-lpignore="true"
+                              data-form-type="other"
+                              className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                              placeholder={
+                                isFreeOption
+                                  ? "None"
+                                  : "Choice name and price (optional)"
+                              }
+                            />
+                          </div>
+                          <div className="w-32">
+                            {isFreeOption ? (
+                              <div className="w-full border border-gray-200 bg-gray-100 text-gray-500 rounded-md px-3 py-2 text-center">
+                                Free
+                              </div>
+                            ) : (
+                              <input
+                                type="text"
+                                value={choice.price?.toString() || ""}
+                                onChange={(e) => {
+                                  const value = e.target.value;
+                                  if (formatNumberInput(value) === value) {
+                                    actions.updateChoice(
+                                      categoryIndex,
+                                      choiceIndex,
+                                      "price",
+                                      value ? Number(value) : undefined
+                                    );
+                                  }
+                                }}
+                                autoComplete="new-password"
+                                autoCapitalize="none"
+                                autoCorrect="off"
+                                spellCheck="false"
+                                data-lpignore="true"
+                                data-form-type="other"
+                                className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="0.00"
+                              />
+                            )}
+                          </div>
+                          {!isFreeOption && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                actions.removeChoiceFromCategory(
+                                  categoryIndex,
+                                  choiceIndex
+                                )
+                              }
+                              className="px-3 py-2 text-red-600 hover:text-red-800"
+                            >
+                              Remove
+                            </button>
+                          )}
                         </div>
-                        {category.choices.length > 1 && (
-                          <button
-                            type="button"
-                            onClick={() =>
-                              actions.removeChoiceFromCategory(
-                                categoryIndex,
-                                choiceIndex
-                              )
-                            }
-                            className="px-3 py-2 text-red-600 hover:text-red-800"
-                          >
-                            Remove
-                          </button>
-                        )}
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
 
                   <button

--- a/components/dashboard/event-form/shared/hooks/useEventData.ts
+++ b/components/dashboard/event-form/shared/hooks/useEventData.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { EventFormState } from "../types/eventForm.types";
 import { formatDateForInput } from "../utils/dateHelpers";
+import { ensureFreeOptions } from "@/lib/utils/optionHelpers";
 import dayjs from "dayjs";
 
 interface UseEventDataReturn {
@@ -62,7 +63,8 @@ export const useEventData = (eventId: string | null): UseEventDataReturn => {
             ? formatDateForInput(event.dates.recurringEndDate)
             : "",
           hasOptions: Boolean(event.options && event.options.length > 0),
-          optionCategories: event.options || [],
+          // Normalize legacy categories so each has a free option (choices[0]).
+          optionCategories: ensureFreeOptions(event.options),
           isDiscountAvailable: event.isDiscountAvailable || false,
           discount: event.discount,
           image: undefined,

--- a/components/dashboard/event-form/shared/hooks/useEventForm.ts
+++ b/components/dashboard/event-form/shared/hooks/useEventForm.ts
@@ -12,6 +12,10 @@ import {
 } from "../types/eventForm.types";
 import { validateEventForm } from "../utils/validationHelpers";
 import { prepareDateForSubmit } from "../utils/dateHelpers";
+import {
+  ensureFreeOptions,
+  DEFAULT_FREE_CHOICE_NAME,
+} from "@/lib/utils/optionHelpers";
 
 const getInitialFormState = (
   eventType: EventFormState["eventType"] = "adult-class"
@@ -138,8 +142,14 @@ export const useEventForm = ({
     const newCategory = {
       categoryName: "",
       categoryDescription: "",
-      required: false,
-      choices: [{ name: "", price: undefined as number | undefined }],
+      // Every category is always required for the customer to choose; a free
+      // option is always included so they can opt out without paying.
+      required: true,
+      choices: [
+        // choices[0] is the guaranteed free option (renameable, always $0).
+        { name: DEFAULT_FREE_CHOICE_NAME, price: 0 as number | undefined },
+        { name: "", price: undefined as number | undefined },
+      ],
     };
 
     setFormData((prev) => ({
@@ -274,15 +284,23 @@ export const useEventForm = ({
           },
           ...(formData.hasOptions &&
             formData.optionCategories.length > 0 && {
-              options: formData.optionCategories.map((category) => ({
-                categoryName: category.categoryName,
-                categoryDescription: category.categoryDescription,
-                required: category.required || false,
-                choices: category.choices.map((choice) => ({
-                  name: choice.name,
-                  price: choice.price || 0,
-                })),
-              })),
+              options: ensureFreeOptions(formData.optionCategories).map(
+                (category) => ({
+                  categoryName: category.categoryName,
+                  categoryDescription: category.categoryDescription,
+                  // All categories are always required for the customer.
+                  required: true,
+                  choices: category.choices.map((choice, choiceIndex) => ({
+                    // The free option (choices[0]) defaults to "None" if the
+                    // admin left its name blank, and is always priced $0.
+                    name:
+                      choiceIndex === 0
+                        ? choice.name?.trim() || DEFAULT_FREE_CHOICE_NAME
+                        : choice.name,
+                    price: choiceIndex === 0 ? 0 : choice.price || 0,
+                  })),
+                })
+              ),
             }),
           ...(formData.isDiscountAvailable &&
             formData.discount && {

--- a/components/payment/BillingForm.tsx
+++ b/components/payment/BillingForm.tsx
@@ -322,9 +322,7 @@ const BillingForm: React.FC<BillingFormProps> = ({
                 >
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     {option.categoryName}
-                    {option.required && (
-                      <span className="text-red-500 ml-0.5">*</span>
-                    )}
+                    <span className="text-red-500 ml-0.5">*</span>
                     {option.categoryDescription && (
                       <span className="text-gray-500 text-xs ml-1">
                         - {option.categoryDescription}
@@ -342,9 +340,7 @@ const BillingForm: React.FC<BillingFormProps> = ({
                     }
                     className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 focus:ring-primary focus:border-primary transition"
                   >
-                    {option.required && (
-                      <option value="">-- Select an option --</option>
-                    )}
+                    <option value="">-- Select an option --</option>
                     {option.choices.map((choice, choiceIndex) => (
                       <option key={choiceIndex} value={choice.name}>
                         {formatChoiceDisplay(choice)}
@@ -419,22 +415,14 @@ const BillingForm: React.FC<BillingFormProps> = ({
                             <div key={optionIndex}>
                               <label className="block text-sm text-gray-700 mb-1">
                                 {option.categoryName}
-                                {option.required && (
-                                  <span className="text-red-500 ml-0.5">
-                                    *
-                                  </span>
-                                )}
+                                <span className="text-red-500 ml-0.5">*</span>
                               </label>
                               <select
                                 value={
                                   participant.selectedOptions?.find(
                                     (so) =>
                                       so.categoryName === option.categoryName
-                                  )?.choiceName ||
-                                  (option.required
-                                    ? ""
-                                    : option.choices[0]?.name) ||
-                                  ""
+                                  )?.choiceName || ""
                                 }
                                 onChange={(e) => {
                                   const newParticipants = [...participants];
@@ -472,11 +460,9 @@ const BillingForm: React.FC<BillingFormProps> = ({
                                 }}
                                 className="w-full p-2 border border-gray-300 rounded-md"
                               >
-                                {option.required && (
-                                  <option value="">
-                                    -- Select an option --
-                                  </option>
-                                )}
+                                <option value="">
+                                  -- Select an option --
+                                </option>
                                 {option.choices.map((choice, choiceIndex) => (
                                   <option key={choiceIndex} value={choice.name}>
                                     {formatChoiceDisplay(choice)}
@@ -585,22 +571,14 @@ const BillingForm: React.FC<BillingFormProps> = ({
                               <div key={optionIndex}>
                                 <label className="block text-sm text-gray-700 mb-1">
                                   {option.categoryName}
-                                  {option.required && (
-                                    <span className="text-red-500 ml-0.5">
-                                      *
-                                    </span>
-                                  )}
+                                  <span className="text-red-500 ml-0.5">*</span>
                                 </label>
                                 <select
                                   value={
                                     participant.selectedOptions?.find(
                                       (so) =>
                                         so.categoryName === option.categoryName
-                                    )?.choiceName ||
-                                    (option.required
-                                      ? ""
-                                      : option.choices[0]?.name) ||
-                                    ""
+                                    )?.choiceName || ""
                                   }
                                   onChange={(e) => {
                                     const newParticipants = [...participants];
@@ -656,11 +634,9 @@ const BillingForm: React.FC<BillingFormProps> = ({
                                   }}
                                   className="w-full p-2 border border-gray-300 rounded-md"
                                 >
-                                  {option.required && (
-                                    <option value="">
-                                      -- Select an option --
-                                    </option>
-                                  )}
+                                  <option value="">
+                                    -- Select an option --
+                                  </option>
                                   {option.choices.map((choice, choiceIndex) => (
                                     <option
                                       key={choiceIndex}

--- a/components/payment/Payment.tsx
+++ b/components/payment/Payment.tsx
@@ -13,6 +13,7 @@ import EventPreview from "./EventPreview";
 import BillingForm from "./BillingForm";
 import PaymentProcessor from "./PaymentProcessor";
 import ReservationSummary from "./ReservationSummary";
+import { ensureFreeOptions } from "@/lib/utils/optionHelpers";
 
 interface PaymentConfig {
   applicationId: string;
@@ -509,7 +510,11 @@ export default function Payment() {
 
             if (eventData) {
               if (eventData.options && eventData.options.length > 0) {
-                const newOptions = eventData.options;
+                // Normalize so each category has a free option (choices[0]),
+                // including legacy events saved before this rule existed.
+                const newOptions = ensureFreeOptions(
+                  eventData.options
+                ) as EventOption[];
 
                 if (
                   JSON.stringify(newOptions) !== JSON.stringify(eventOptions)
@@ -519,12 +524,9 @@ export default function Payment() {
                   const initialSelectedOptions = newOptions.map(
                     (option: EventOption) => ({
                       categoryName: option.categoryName,
-                      // Required categories start unselected so the customer
-                      // must make an explicit choice; optional categories
-                      // default to the first choice.
-                      choiceName: option.required
-                        ? ""
-                        : option.choices[0]?.name || "",
+                      // All categories require an explicit choice, so start
+                      // unselected. The free option is always available.
+                      choiceName: "",
                     })
                   );
                   setSelectedOptions(initialSelectedOptions);
@@ -678,7 +680,8 @@ export default function Payment() {
   // Returns an error message if any required option category has no choice
   // selected (for the primary registrant or any participant), else null.
   const getRequiredOptionsError = useCallback((): string | null => {
-    const requiredCategories = eventOptions.filter((o) => o.required);
+    // Every option category now requires an explicit choice from the customer.
+    const requiredCategories = eventOptions;
     if (requiredCategories.length === 0) return null;
 
     const hasChoice = (
@@ -770,7 +773,8 @@ export default function Payment() {
           lastName: "",
           selectedOptions: eventOptions.map((option) => ({
             categoryName: option.categoryName,
-            choiceName: option.choices[0]?.name || "",
+            // Start unselected so the customer must explicitly choose.
+            choiceName: "",
           })),
         }));
       setParticipants(newParticipants);
@@ -782,7 +786,8 @@ export default function Payment() {
           lastName: "",
           selectedOptions: eventOptions.map((option) => ({
             categoryName: option.categoryName,
-            choiceName: option.choices[0]?.name || "",
+            // Start unselected so the customer must explicitly choose.
+            choiceName: "",
           })),
         }));
       setParticipants(newParticipants);

--- a/lib/utils/optionHelpers.ts
+++ b/lib/utils/optionHelpers.ts
@@ -1,0 +1,60 @@
+// Helpers for event/reservation "options" (choice categories).
+//
+// Business rule: every option category must always include a FREE ($0) choice
+// so a customer is never forced to pay for an "optional" add-on. The free choice
+// is treated as the first choice in the category. Admins may rename it (defaults
+// to "None") but it always exists and is always free.
+
+export const DEFAULT_FREE_CHOICE_NAME = "None";
+
+export interface OptionChoiceLike {
+  name: string;
+  price?: number;
+}
+
+export interface OptionCategoryLike {
+  categoryName?: string;
+  categoryDescription?: string;
+  required?: boolean;
+  choices?: OptionChoiceLike[];
+}
+
+// A choice counts as "free" when it has no price or a price of 0.
+const isFreeChoice = (choice: OptionChoiceLike): boolean =>
+  !choice.price || choice.price <= 0;
+
+// Guarantees a single free choice exists and is positioned first.
+// - If no free choice exists, prepend one named DEFAULT_FREE_CHOICE_NAME.
+// - If a free choice exists but isn't first, move it to the front so the admin
+//   UI and customer dropdown render it consistently as the default option.
+export const ensureFreeOption = <T extends OptionCategoryLike>(category: T): T => {
+  const choices = category.choices ?? [];
+
+  const freeIndex = choices.findIndex(isFreeChoice);
+
+  if (freeIndex === -1) {
+    return {
+      ...category,
+      choices: [{ name: DEFAULT_FREE_CHOICE_NAME, price: 0 }, ...choices],
+    };
+  }
+
+  if (freeIndex > 0) {
+    const free = choices[freeIndex];
+    return {
+      ...category,
+      choices: [
+        free,
+        ...choices.slice(0, freeIndex),
+        ...choices.slice(freeIndex + 1),
+      ],
+    };
+  }
+
+  return category;
+};
+
+// Applies ensureFreeOption to every category in a list.
+export const ensureFreeOptions = <T extends OptionCategoryLike>(
+  categories: T[] | undefined | null
+): T[] => (categories ?? []).map((category) => ensureFreeOption(category));


### PR DESCRIPTION
## What

Brings the production options hotfix (PR #147 → `main`) into `develop` so the two branches stay in sync and a future `develop → main` merge has no conflict over this fix.

Same change as #147: every option category always includes a free ($0) choice (renameable, defaults to "None") and the customer must make an explicit selection at checkout. See #147 for full details.

## How it was applied (safe by construction)

- Cherry-picked the single hotfix commit onto a branch off `develop` — **not** a branch merge — so none of the 10 `main`-only merge commits leak into develop's history.
- `develop` was **not** touched directly; this PR is the only entry point.
- The only overlap with in-progress work is `components/payment/Payment.tsx` (store rework). Git auto-merged it cleanly; verified by hand that **both** the store work and all four hotfix edits are present:
  - `ensureFreeOptions` import + applied to fetched options
  - default selections start unselected (`choiceName: ""`, ×3)
  - `getRequiredOptionsError` requires all categories (no `required` filter)
- The other 5 files match the hotfix commit byte-for-byte.
- `tsc` and `eslint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)