### PR TITLE
Automate store order status from Shippo tracking + checkout/admin polish

### DIFF
--- a/app/admin/dashboard/store/orders/[id]/page.tsx
+++ b/app/admin/dashboard/store/orders/[id]/page.tsx
@@ -1,9 +1,20 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { ReactElement } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
+
+// How often the page re-pulls the order so webhook-driven status changes
+// (shipped / delivered) appear without a manual refresh.
+const POLL_INTERVAL_MS = 15000;
+
+// Once an order reaches one of these, nothing more will change — stop polling.
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  "delivered",
+  "cancelled",
+  "refunded",
+]);
 
 type OrderStatus =
   | "pending" | "paid" | "label_created" | "shipped"
@@ -63,21 +74,53 @@ export default function OrderDetailPage(): ReactElement {
   const [updating, setUpdating] = useState(false);
   const [creatingLabel, setCreatingLabel] = useState(false);
 
+  // Track in-flight admin actions so a background poll can't clobber an
+  // optimistic update mid-request.
+  const busyRef = useRef(false);
   useEffect(() => {
-    async function fetchOrder() {
+    busyRef.current = updating || creatingLabel;
+  }, [updating, creatingLabel]);
+
+  // `silent` polls skip the loading spinner and swallow transient errors so a
+  // single failed background refresh doesn't blank out the page.
+  const fetchOrder = useCallback(
+    async (silent = false): Promise<void> => {
+      if (silent && busyRef.current) return;
       try {
         const res = await fetch(`/api/admin/store/orders/${id}`);
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || "Failed to load order");
         setOrder(data.order);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "An error occurred");
+        if (!silent) setError(err instanceof Error ? err.message : "An error occurred");
       } finally {
-        setLoading(false);
+        if (!silent) setLoading(false);
       }
-    }
+    },
+    [id]
+  );
+
+  // Initial load (runs once per order id).
+  useEffect(() => {
     fetchOrder();
-  }, [id]);
+  }, [fetchOrder]);
+
+  // Background polling — only while the order is still in motion AND the tab is
+  // visible. Switching back to the tab triggers an immediate refresh so you're
+  // never looking at a stale status after coming back.
+  const isTerminal = order ? TERMINAL_STATUSES.has(order.status) : false;
+  useEffect(() => {
+    if (isTerminal) return;
+    const tick = (): void => {
+      if (document.visibilityState === "visible") fetchOrder(true);
+    };
+    const interval = setInterval(tick, POLL_INTERVAL_MS);
+    document.addEventListener("visibilitychange", tick);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", tick);
+    };
+  }, [fetchOrder, isTerminal]);
 
   const updateStatus = async (status: OrderStatus) => {
     if (!order) return;

--- a/app/api/webhooks/shippo/route.ts
+++ b/app/api/webhooks/shippo/route.ts
@@ -1,14 +1,26 @@
 /**
  * Shippo Webhook Receiver
  *
- * Receives inbound events from Shippo and updates Order tracking state.
+ * Receives inbound carrier tracking events from Shippo and drives the order
+ * lifecycle automatically — no manual admin toggling required.
  *
  * Events handled:
- *   track_updated  — carrier tracking status changed → update status to shipped/delivered
+ *   track_updated — carrier tracking status changed. We act on:
+ *     TRANSIT             → first carrier scan: mark order "shipped", email
+ *                           the customer their tracking link + notify the admin.
+ *     DELIVERED           → mark order "delivered", email the customer.
+ *     FAILURE / RETURNED  → email the admin so they can intervene. No status
+ *                           change (the admin owns the resolution).
  *
- * Verification: Shippo sends the webhook secret in the `Shippo-Webhook-Secret` header.
- * Set SHIPPO_WEBHOOK_SECRET in your environment to match the secret configured in the
- * Shippo dashboard (Settings → Webhooks).
+ * Because labels are purchased through Shippo, Shippo auto-registers tracking
+ * and sends these events with no extra API calls on our side.
+ *
+ * Verification: Shippo does NOT sign webhooks or send a secret header, so we
+ * authenticate via a shared secret embedded in the registered webhook URL as a
+ * `?token=` query param. Set SHIPPO_WEBHOOK_SECRET in the environment and
+ * register the webhook URL as `<origin>/api/webhooks/shippo?token=<secret>`.
+ * (A `Shippo-Webhook-Secret` header carrying the same value is also accepted,
+ * for manual/testing convenience.)
  */
 import { NextResponse } from "next/server";
 import { Resend } from "resend";
@@ -16,12 +28,18 @@ import { render } from "@react-email/render";
 import * as React from "react";
 import { connectMongo } from "@/lib/mongoose";
 import Order from "@/lib/models/Order";
+import type { IOrder } from "@/lib/models/Order";
+import { ShippingConfirmationEmail } from "@/components/email-templates/ShippingConfirmationEmail";
 import { DeliveryConfirmationEmail } from "@/components/email-templates/DeliveryConfirmationEmail";
+import { ShipmentExceptionEmail } from "@/components/email-templates/ShipmentExceptionEmail";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
+const FROM = "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>";
+
 interface ShippoTrackingStatus {
-  status: string; // "DELIVERED" | "TRANSIT" | "FAILURE" | "RETURNED" | "UNKNOWN"
+  status: string; // "PRE_TRANSIT" | "TRANSIT" | "DELIVERED" | "RETURNED" | "FAILURE" | "UNKNOWN"
+  status_details?: string;
 }
 
 interface ShippoTrackUpdatedPayload {
@@ -41,8 +59,168 @@ function verifySecret(request: Request): boolean {
     console.warn("[WEBHOOKS-SHIPPO] SHIPPO_WEBHOOK_SECRET not set — skipping verification");
     return true;
   }
-  const incomingSecret = request.headers.get("Shippo-Webhook-Secret");
-  return incomingSecret === webhookSecret;
+  // Shippo can't send custom headers, so the secret rides in the URL (?token=).
+  // Accept the header form too, for manual curl/testing.
+  const urlToken = new URL(request.url).searchParams.get("token");
+  const headerToken = request.headers.get("Shippo-Webhook-Secret");
+  return urlToken === webhookSecret || headerToken === webhookSecret;
+}
+
+// In prod, real recipients. In dev/stage, redirect everything to DEV_EMAIL so we
+// never email real customers from a test environment.
+function resolveRecipients(order: IOrder): { customer: string; admin: string } {
+  const isProduction = process.env.VERCEL_ENV === "production";
+  if (isProduction) {
+    return {
+      customer: order.customer.email,
+      admin: process.env.STUDIO_EMAIL ?? "ashley@coastalcreationsstudio.com",
+    };
+  }
+  const devEmail = process.env.DEV_EMAIL ?? order.customer.email;
+  return { customer: devEmail, admin: devEmail };
+}
+
+// Mark the order shipped on the first carrier scan and notify customer + admin.
+// Idempotent: a second TRANSIT event (or any post-ship event) is a no-op.
+async function handleTransit(order: IOrder): Promise<void> {
+  if (
+    order.shippedAt ||
+    order.status === "shipped" ||
+    order.status === "delivered" ||
+    order.status === "cancelled" ||
+    order.status === "refunded"
+  ) {
+    return;
+  }
+
+  await Order.findByIdAndUpdate(order._id, {
+    status: "shipped",
+    shippedAt: new Date(),
+  });
+  console.log("[WEBHOOKS-SHIPPO] Order shipped (carrier scan):", order.orderNumber);
+
+  const { customer, admin } = resolveRecipients(order);
+
+  try {
+    const html = await render(
+      React.createElement(ShippingConfirmationEmail, {
+        customerFirstName: order.customer.firstName,
+        orderNumber: order.orderNumber,
+        carrier: order.shippo.carrier ?? "carrier",
+        trackingNumber: order.shippo.trackingNumber ?? "",
+        trackingUrlProvider: order.shippo.trackingUrlProvider,
+      })
+    );
+
+    await Promise.allSettled([
+      resend.emails.send({
+        from: FROM,
+        to: [customer],
+        subject: `Your order ${order.orderNumber} has shipped!`,
+        html,
+      }),
+      resend.emails.send({
+        from: FROM,
+        to: [admin],
+        subject: `Shipped: order ${order.orderNumber} is in transit`,
+        html,
+      }),
+    ]);
+  } catch (emailError) {
+    console.error(
+      "[WEBHOOKS-SHIPPO] Shipped email failed (order still marked shipped):",
+      emailError
+    );
+  }
+}
+
+// Mark the order delivered and email the customer. Idempotent on deliveredAt.
+async function handleDelivered(order: IOrder): Promise<void> {
+  if (order.status === "delivered" || order.deliveredAt) {
+    return;
+  }
+
+  // Backfill shippedAt if a package was delivered without us ever seeing a
+  // TRANSIT event (e.g. same-day scan) — keeps the shipped timestamp accurate
+  // without sending a redundant "shipped" email right before "delivered".
+  await Order.findByIdAndUpdate(order._id, {
+    status: "delivered",
+    deliveredAt: new Date(),
+    ...(order.shippedAt ? {} : { shippedAt: new Date() }),
+  });
+  console.log("[WEBHOOKS-SHIPPO] Order delivered:", order.orderNumber);
+
+  const { customer } = resolveRecipients(order);
+
+  try {
+    const html = await render(
+      React.createElement(DeliveryConfirmationEmail, {
+        customerFirstName: order.customer.firstName,
+        orderNumber: order.orderNumber,
+        carrier: order.shippo.carrier,
+        trackingNumber: order.shippo.trackingNumber,
+      })
+    );
+
+    await resend.emails.send({
+      from: FROM,
+      to: [customer],
+      subject: `Your order ${order.orderNumber} was delivered`,
+      html,
+    });
+  } catch (emailError) {
+    console.error(
+      "[WEBHOOKS-SHIPPO] Delivery email failed (order still marked delivered):",
+      emailError
+    );
+  }
+}
+
+// Carrier reported a problem (failed delivery / returned to sender). Alert the
+// admin only — they own the resolution, so we do NOT change order status.
+// NOTE: no persistent dedup, so a carrier that posts multiple exception updates
+// can trigger more than one alert. Acceptable for an internal heads-up; revisit
+// with an `exceptionNotifiedAt` field if it proves noisy.
+async function handleException(
+  order: IOrder,
+  carrierStatus: string,
+  statusDetails?: string
+): Promise<void> {
+  // Don't alert on terminal orders — a return on an already-refunded/cancelled
+  // order is expected and not actionable.
+  if (order.status === "cancelled" || order.status === "refunded") {
+    return;
+  }
+
+  console.warn(
+    `[WEBHOOKS-SHIPPO] Shipment exception (${carrierStatus}) for order:`,
+    order.orderNumber
+  );
+
+  const { admin } = resolveRecipients(order);
+
+  try {
+    const html = await render(
+      React.createElement(ShipmentExceptionEmail, {
+        orderNumber: order.orderNumber,
+        customerName: `${order.customer.firstName} ${order.customer.lastName}`,
+        carrier: order.shippo.carrier ?? "carrier",
+        trackingNumber: order.shippo.trackingNumber ?? "",
+        carrierStatus,
+        statusDetails,
+        trackingUrlProvider: order.shippo.trackingUrlProvider,
+      })
+    );
+
+    await resend.emails.send({
+      from: FROM,
+      to: [admin],
+      subject: `Action needed: shipping issue on order ${order.orderNumber}`,
+      html,
+    });
+  } catch (emailError) {
+    console.error("[WEBHOOKS-SHIPPO] Exception alert email failed:", emailError);
+  }
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -61,68 +239,43 @@ export async function POST(request: Request): Promise<Response> {
   const { event, data } = body;
   console.log("[WEBHOOKS-SHIPPO] Received event:", event);
 
-  if (event === "track_updated") {
-    const payload = data as ShippoTrackUpdatedPayload;
-    const { tracking_number, tracking_status } = payload;
+  if (event !== "track_updated") {
+    return NextResponse.json({ received: true });
+  }
 
-    if (!tracking_number) {
-      return NextResponse.json({ error: "Missing tracking_number" }, { status: 400 });
-    }
+  const payload = data as ShippoTrackUpdatedPayload;
+  const { tracking_number, tracking_status } = payload;
 
-    await connectMongo();
+  if (!tracking_number) {
+    return NextResponse.json({ error: "Missing tracking_number" }, { status: 400 });
+  }
 
-    const order = await Order.findOne({ "shippo.trackingNumber": tracking_number });
-    if (!order) {
-      // Shippo may send events for test shipments or labels not in our system — not an error.
-      console.log("[WEBHOOKS-SHIPPO] No order found for tracking number:", tracking_number);
-      return NextResponse.json({ received: true });
-    }
+  await connectMongo();
 
-    const carrierStatus = tracking_status?.status?.toUpperCase();
+  const order = await Order.findOne({ "shippo.trackingNumber": tracking_number });
+  if (!order) {
+    // Shippo may send events for test shipments or labels not in our system — not an error.
+    console.log("[WEBHOOKS-SHIPPO] No order found for tracking number:", tracking_number);
+    return NextResponse.json({ received: true });
+  }
 
-    // NOTE: we do NOT auto-advance to "shipped" on TRANSIT. "shipped" is the merchant's
-    // deliberate "Mark Shipped" action (which sends the customer tracking email). The
-    // webhook only owns the automatic DELIVERED transition + delivery email (step 8).
-    if (carrierStatus === "DELIVERED") {
-      // Idempotent: only act + email once per order.
-      if (order.status === "delivered" || order.deliveredAt) {
-        return NextResponse.json({ received: true });
-      }
+  const carrierStatus = tracking_status?.status?.toUpperCase();
+  const statusDetails = tracking_status?.status_details;
 
-      await Order.findByIdAndUpdate(order._id, {
-        status: "delivered",
-        deliveredAt: new Date(),
-      });
-      console.log("[WEBHOOKS-SHIPPO] Order delivered:", order.orderNumber);
-
-      const isProduction = process.env.VERCEL_ENV === "production";
-      const customerRecipient = isProduction
-        ? order.customer.email
-        : (process.env.DEV_EMAIL ?? order.customer.email);
-
-      try {
-        const emailHtml = await render(
-          React.createElement(DeliveryConfirmationEmail, {
-            customerFirstName: order.customer.firstName,
-            orderNumber: order.orderNumber,
-            carrier: order.shippo.carrier,
-            trackingNumber: order.shippo.trackingNumber,
-          })
-        );
-
-        await resend.emails.send({
-          from: "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>",
-          to: [customerRecipient],
-          subject: `Your order ${order.orderNumber} was delivered`,
-          html: emailHtml,
-        });
-      } catch (emailError) {
-        console.error(
-          "[WEBHOOKS-SHIPPO] Delivery email failed (order still marked delivered):",
-          emailError
-        );
-      }
-    }
+  switch (carrierStatus) {
+    case "TRANSIT":
+      await handleTransit(order);
+      break;
+    case "DELIVERED":
+      await handleDelivered(order);
+      break;
+    case "FAILURE":
+    case "RETURNED":
+      await handleException(order, carrierStatus, statusDetails);
+      break;
+    default:
+      // PRE_TRANSIT / UNKNOWN — nothing to do yet.
+      break;
   }
 
   return NextResponse.json({ received: true });

--- a/components/email-templates/ShipmentExceptionEmail.tsx
+++ b/components/email-templates/ShipmentExceptionEmail.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { Text, Button } from "@react-email/components";
+import { EmailShell, InfoCard, DetailRow, emailText } from "./shared";
+
+export interface ShipmentExceptionEmailProps {
+  orderNumber: string;
+  customerName: string;
+  carrier: string;
+  trackingNumber: string;
+  /** Carrier tracking status reported by Shippo, e.g. "FAILURE" or "RETURNED". */
+  carrierStatus: string;
+  /** Optional human-readable detail from the carrier (substatus text). */
+  statusDetails?: string;
+  trackingUrlProvider?: string;
+}
+
+export function ShipmentExceptionEmail({
+  orderNumber,
+  customerName,
+  carrier,
+  trackingNumber,
+  carrierStatus,
+  statusDetails,
+  trackingUrlProvider,
+}: ShipmentExceptionEmailProps): React.ReactElement {
+  return (
+    <EmailShell
+      preview={`Shipping issue on order ${orderNumber}`}
+      showDisclaimer={false}
+    >
+      <Text style={emailText.heroTitle}>Shipping issue needs attention</Text>
+      <Text style={emailText.paragraph}>
+        The carrier reported a problem with order <strong>{orderNumber}</strong>.
+        This was flagged automatically from carrier tracking — please review and
+        follow up with the customer if needed.
+      </Text>
+
+      <InfoCard title="Shipment Status">
+        <DetailRow label="Status">{carrierStatus}</DetailRow>
+        {statusDetails && <DetailRow label="Details">{statusDetails}</DetailRow>}
+        <DetailRow label="Carrier">{carrier}</DetailRow>
+        <DetailRow label="Tracking">{trackingNumber}</DetailRow>
+      </InfoCard>
+
+      <InfoCard title="Order">
+        <DetailRow label="Order">{orderNumber}</DetailRow>
+        <DetailRow label="Customer">{customerName}</DetailRow>
+      </InfoCard>
+
+      {trackingUrlProvider && (
+        <Button
+          href={trackingUrlProvider}
+          style={{
+            display: "inline-block",
+            backgroundColor: "#0c4a6e",
+            color: "#ffffff",
+            fontSize: "15px",
+            fontWeight: 700,
+            padding: "12px 28px",
+            borderRadius: "8px",
+            textDecoration: "none",
+            margin: "8px 0 20px",
+          }}
+        >
+          View Carrier Tracking →
+        </Button>
+      )}
+    </EmailShell>
+  );
+}
+
+export default ShipmentExceptionEmail;

--- a/components/store/ShippingRateStep.tsx
+++ b/components/store/ShippingRateStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactElement } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui";
 import { formatCents } from "@/lib/utils/moneyHelpers";
 import type { ShippingRate } from "@/lib/shippo/rates";
@@ -13,6 +14,41 @@ interface ShippingRateStepProps {
   onNext: () => void;
 }
 
+interface RateOptionProps {
+  rate: ShippingRate;
+  isSelected: boolean;
+  onSelect: (rate: ShippingRate) => void;
+}
+
+function RateOption({ rate, isSelected, onSelect }: RateOptionProps): ReactElement {
+  return (
+    <button
+      onClick={() => onSelect(rate)}
+      className={`w-full text-left px-4 py-3 rounded-[var(--radius-lg)] border-2 transition-colors ${
+        isSelected
+          ? "border-[var(--color-primary)] bg-[var(--color-light)]"
+          : "border-[var(--color-border-lighter)] hover:border-[var(--color-secondary)]"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="font-semibold text-[var(--color-text-primary)] text-sm">
+            {rate.serviceName}
+          </p>
+          {rate.estimatedDays != null && (
+            <p className="text-xs text-[var(--color-text-subtle)] mt-0.5">
+              Est. {rate.estimatedDays} business day{rate.estimatedDays !== 1 ? "s" : ""}
+            </p>
+          )}
+        </div>
+        <span className="font-bold text-[var(--color-primary)] ml-4">
+          {formatCents(rate.rateCents)}
+        </span>
+      </div>
+    </button>
+  );
+}
+
 export default function ShippingRateStep({
   rates,
   selectedRate,
@@ -20,6 +56,15 @@ export default function ShippingRateStep({
   onBack,
   onNext,
 }: ShippingRateStepProps): ReactElement {
+  // [SHIPPINGRATESTEP] Collapse the full rate list by default — show only the
+  // recommended (selected) option, let the user expand to choose another.
+  const [showAllOptions, setShowAllOptions] = useState(false);
+
+  const handleSelect = (rate: ShippingRate): void => {
+    onSelect(rate);
+    setShowAllOptions(false);
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <p className="text-sm text-[var(--color-text-subtle)]">
@@ -27,36 +72,34 @@ export default function ShippingRateStep({
       </p>
 
       <div className="flex flex-col gap-3">
-        {rates.map((rate) => {
-          const isSelected = selectedRate?.rateId === rate.rateId;
-          return (
-            <button
+        {showAllOptions ? (
+          rates.map((rate) => (
+            <RateOption
               key={rate.rateId}
-              onClick={() => onSelect(rate)}
-              className={`w-full text-left px-4 py-3 rounded-[var(--radius-lg)] border-2 transition-colors ${
-                isSelected
-                  ? "border-[var(--color-primary)] bg-[var(--color-light)]"
-                  : "border-[var(--color-border-lighter)] hover:border-[var(--color-secondary)]"
-              }`}
-            >
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="font-semibold text-[var(--color-text-primary)] text-sm">
-                    {rate.serviceName}
-                  </p>
-                  {rate.estimatedDays != null && (
-                    <p className="text-xs text-[var(--color-text-subtle)] mt-0.5">
-                      Est. {rate.estimatedDays} business day{rate.estimatedDays !== 1 ? "s" : ""}
-                    </p>
-                  )}
-                </div>
-                <span className="font-bold text-[var(--color-primary)] ml-4">
-                  {formatCents(rate.rateCents)}
-                </span>
-              </div>
-            </button>
-          );
-        })}
+              rate={rate}
+              isSelected={selectedRate?.rateId === rate.rateId}
+              onSelect={handleSelect}
+            />
+          ))
+        ) : (
+          selectedRate && (
+            <RateOption
+              rate={selectedRate}
+              isSelected
+              onSelect={handleSelect}
+            />
+          )
+        )}
+
+        {rates.length > 1 && (
+          <button
+            type="button"
+            onClick={() => setShowAllOptions((prev) => !prev)}
+            className="self-start text-sm font-medium text-[var(--color-secondary)] hover:text-[var(--color-primary)] underline transition-colors"
+          >
+            {showAllOptions ? "Hide other options" : "Choose a different shipping option"}
+          </button>
+        )}
       </div>
 
       <div className="flex gap-3 mt-2">


### PR DESCRIPTION
## Summary

Makes the store shipping flow hands-off: carrier tracking now drives the order lifecycle and customer/admin notifications automatically, so the admin no longer has to manually toggle order status. Also slims down the checkout shipping-method UI.

## Changes

### Shipping rate selection (`ShippingRateStep.tsx`)
- Collapse the rate list to the recommended (cheapest, auto-selected) option with a "Choose a different shipping option" toggle, instead of dumping all ~10 carrier rates on the customer.

### Shippo tracking webhooks (`api/webhooks/shippo/route.ts`)
- **TRANSIT** (first carrier scan) → mark order `shipped`, email the customer their tracking link + notify admin. Removes the manual "Mark Shipped" step.
- **DELIVERED** → mark `delivered`, email customer (backfills `shippedAt` if no prior TRANSIT event).
- **FAILURE / RETURNED** → admin-only exception alert; no status change (admin owns resolution).
- Each handler is idempotent on `shippedAt`/`deliveredAt` so repeated webhook deliveries don't double-email.
- **Auth fix:** Shippo doesn't sign requests or send a secret header, so verification now reads a shared secret from the URL (`?token=`) against `SHIPPO_WEBHOOK_SECRET` (header form still accepted for manual testing).
- New `ShipmentExceptionEmail` template for the admin transit-problem alert.

### Admin order detail auto-refresh (`admin/.../orders/[id]/page.tsx`)
- Polls the order every 15s so webhook status changes appear without a manual refresh.
- Bounded for cost: stops on terminal statuses (delivered/cancelled/refunded), pauses while the tab is hidden, refreshes immediately on refocus, and skips while an admin action is mid-flight.

## Testing
- Verified end-to-end against local endpoint (via DB orders in `coastal_stage`):
  - TRANSIT → `shipped` + emails ✓
  - DELIVERED → `delivered` + `shippedAt` backfill + email ✓
  - FAILURE → admin alert, status unchanged ✓
  - Invalid `?token=` → 401 ✓
- `pnpm run test:run`: 178/178 passing
- Lint clean on all changed files

## Deploy / setup notes (not code)
Requires a one-time setup per environment:
1. Set `SHIPPO_WEBHOOK_SECRET` in the environment.
2. Register the webhook in the Shippo dashboard (Event: Track Updated; Test mode for staging, Live for prod) pointing at `<origin>/api/webhooks/shippo?token=<secret>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)