### PR TITLE
chore(store): remove "Client review mode" label

### DIFF
--- a/components/store/Store.tsx
+++ b/components/store/Store.tsx
@@ -57,7 +57,10 @@ export default function Store(): ReactElement {
           in z-order (z-40 < the nav's z-50) so the nav always wins on overlap. */}
       <div
         className="sticky top-0 z-40 border-b border-gray-200 py-3 px-4"
-        style={{ background: "rgba(255,255,255,0.97)", backdropFilter: "blur(8px)" }}
+        style={{
+          background: "rgba(255,255,255,0.97)",
+          backdropFilter: "blur(8px)",
+        }}
       >
         <div className="mx-auto max-w-7xl flex items-center flex-wrap gap-2">
           <span className="text-xs font-semibold uppercase tracking-wider text-gray-400 mr-2">
@@ -85,9 +88,6 @@ export default function Store(): ReactElement {
               {v.label}
             </button>
           ))}
-          <span className="ml-auto text-xs italic text-gray-400 hidden sm:block">
-            Client review mode
-          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Removes the italic "Client review mode" indicator from the storefront variant-switcher bar — no longer needed now that the store is past client review. Also a minor inline-style formatting tidy (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)