### PR TITLE
style(shop): consistent blue background across all shop slides

### DIFF
--- a/components/store/variants/VariantB.tsx
+++ b/components/store/variants/VariantB.tsx
@@ -23,8 +23,9 @@ export default function VariantB(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen py-12 bg-white">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isLoading && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {Array.from({ length: 8 }).map((_, i) => (
@@ -117,6 +118,7 @@ export default function VariantB(): ReactElement {
             </AnimatePresence>
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantBReal.tsx
+++ b/components/store/variants/VariantBReal.tsx
@@ -26,6 +26,7 @@ export default function VariantBReal(): ReactElement {
   return (
     <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isLoading && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {Array.from({ length: 8 }).map((_, i) => (
@@ -119,6 +120,7 @@ export default function VariantBReal(): ReactElement {
             })}
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantC.tsx
+++ b/components/store/variants/VariantC.tsx
@@ -13,8 +13,9 @@ export default function VariantC(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen py-16 relative overflow-hidden bg-white">
+    <section className="min-h-screen py-16 relative overflow-hidden">
       <div className="relative mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {/* Section intro */}
         <div className="text-center mb-12">
           <p
@@ -132,6 +133,7 @@ export default function VariantC(): ReactElement {
             </AnimatePresence>
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantD.tsx
+++ b/components/store/variants/VariantD.tsx
@@ -13,8 +13,9 @@ export default function VariantD(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen py-12 bg-white">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="text-center text-[var(--color-error)] text-lg py-16">
             Unable to load products. Please try again later.
@@ -109,6 +110,7 @@ export default function VariantD(): ReactElement {
             </AnimatePresence>
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantE.tsx
+++ b/components/store/variants/VariantE.tsx
@@ -13,8 +13,9 @@ export default function VariantE(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen bg-white py-10">
+    <section className="min-h-screen py-10">
       <div className="mx-auto max-w-5xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="text-sm text-[var(--color-error)] py-10">
             Unable to load products. Please try again later.
@@ -119,6 +120,7 @@ export default function VariantE(): ReactElement {
             </AnimatePresence>
           </>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantF.tsx
+++ b/components/store/variants/VariantF.tsx
@@ -19,8 +19,9 @@ export default function VariantF(): ReactElement {
   const rest = filtered.filter((p) => p.squareItemId !== spotlight?.squareItemId);
 
   return (
-    <section className="min-h-screen py-12 bg-white">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="text-center text-[var(--color-error)] text-lg py-16">
             Unable to load products. Please try again later.
@@ -192,6 +193,7 @@ export default function VariantF(): ReactElement {
             )}
           </>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantG.tsx
+++ b/components/store/variants/VariantG.tsx
@@ -23,8 +23,9 @@ export default function VariantG(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen py-12 bg-white">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isLoading && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {Array.from({ length: 8 }).map((_, i) => (
@@ -128,6 +129,7 @@ export default function VariantG(): ReactElement {
             </AnimatePresence>
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantH.tsx
+++ b/components/store/variants/VariantH.tsx
@@ -19,8 +19,9 @@ export default function VariantH(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen bg-white py-12">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="py-16 text-center text-[var(--color-error)]">
             Unable to load products. Please try again later.
@@ -110,6 +111,7 @@ export default function VariantH(): ReactElement {
             })}
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantI.tsx
+++ b/components/store/variants/VariantI.tsx
@@ -33,8 +33,9 @@ export default function VariantI(): ReactElement {
   }, [products]);
 
   return (
-    <section className="min-h-screen bg-white py-12">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="py-16 text-center text-[var(--color-error)]">
             Unable to load products. Please try again later.
@@ -147,6 +148,7 @@ export default function VariantI(): ReactElement {
               </div>
             </div>
           ))}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantJ.tsx
+++ b/components/store/variants/VariantJ.tsx
@@ -19,8 +19,9 @@ export default function VariantJ(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen bg-white py-12">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="py-16 text-center text-[var(--color-error)]">
             Unable to load products. Please try again later.
@@ -109,6 +110,7 @@ export default function VariantJ(): ReactElement {
             })}
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantK.tsx
+++ b/components/store/variants/VariantK.tsx
@@ -20,8 +20,9 @@ export default function VariantK(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen bg-white py-12">
+    <section className="min-h-screen py-12">
       <div className="mx-auto max-w-7xl px-4">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="py-16 text-center text-[var(--color-error)]">
             Unable to load products. Please try again later.
@@ -112,6 +113,7 @@ export default function VariantK(): ReactElement {
             })}
           </div>
         )}
+        </div>
       </div>
     </section>
   );

--- a/components/store/variants/VariantL.tsx
+++ b/components/store/variants/VariantL.tsx
@@ -20,8 +20,9 @@ export default function VariantL(): ReactElement {
   const filtered = products ?? [];
 
   return (
-    <section className="min-h-screen bg-white py-16">
+    <section className="min-h-screen py-16">
       <div className="mx-auto max-w-6xl px-6">
+        <div className="rounded-[2rem] border border-white/65 bg-white/85 p-6 shadow-[0_14px_28px_rgba(12,74,110,0.1)] backdrop-blur-[2px] md:p-8">
         {isError && (
           <p className="py-16 text-center text-[var(--color-error)]">
             Unable to load products. Please try again later.
@@ -108,6 +109,7 @@ export default function VariantL(): ReactElement {
             })}
           </div>
         )}
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
Follow-up to #156. Every shop design slide (variants B–L + BReal) now drops its solid white background and sits in the shared white container over the ocean-depth blue page background — matching VariantA — so all slides look consistent.

`tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)