### PR TITLE
Gift shipping + payment/shipping/gift-card hardening, tests & CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+# Gate: these checks must pass before code reaches a deployable branch.
+# Enable branch protection on `develop` and `main` requiring the "verify" job.
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Non-secret placeholders so `next build` can evaluate modules that read env at
+# build time. Sanity project id + dataset are PUBLIC identifiers (the blog page
+# prerenders from a public dataset, no token needed). Real secrets never live here.
+env:
+  MONGODB_URI: "mongodb://localhost:27017/ci"
+  NEXTAUTH_URL: "http://localhost:3000"
+  NEXTAUTH_SECRET: "ci-placeholder-secret"
+  ADMIN_EMAILS: "admin@example.com"
+  GOOGLE_CLIENT_ID: "ci"
+  GOOGLE_CLIENT_SECRET: "ci"
+  SQUARE_ACCESS_TOKEN: "ci-placeholder"
+  SQUARE_APPLICATION_ID: "sandbox-sq0idb-ci"
+  SQUARE_LOCATION_ID: "CI"
+  SQUARE_ENVIRONMENT: "sandbox"
+  SANITY_PROJECT_ID: "vmqep02a"
+  SANITY_DATASET: "production"
+  NEXT_PUBLIC_SANITY_PROJECT_ID: "vmqep02a"
+  NEXT_PUBLIC_SANITY_DATASET: "production"
+  RESEND_API_KEY: "re_ci_placeholder"
+  SHIPPO_API_KEY: "shippo_test_ci"
+  SHIPPO_WEBHOOK_SECRET: "ci"
+  MERCHANT_SHIP_FROM_NAME: "CI"
+  MERCHANT_SHIP_FROM_STREET: "1 Main St"
+  MERCHANT_SHIP_FROM_CITY: "Ocean City"
+  MERCHANT_SHIP_FROM_STATE: "NJ"
+  MERCHANT_SHIP_FROM_ZIP: "08226"
+  MERCHANT_SHIP_FROM_COUNTRY: "US"
+  MERCHANT_SHIP_FROM_PHONE: "6095551234"
+  MERCHANT_SHIP_FROM_EMAIL: "ci@example.com"
+  STUDIO_EMAIL: "studio@example.com"
+  DEV_EMAIL: "dev@example.com"
+
+jobs:
+  # Required gate: static checks + unit/integration tests + production build.
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Unit & integration tests
+        run: pnpm test:run
+      - name: Production build
+        run: pnpm build
+
+  # Browser E2E (Playwright). Non-blocking for now — the full-page flows depend
+  # on live data/services; promote to a required check once pointed at a seeded
+  # stage environment.
+  e2e:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: pnpm test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -76,8 +74,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ next-env.d.ts
 
 # Local MCP server configs (contain secrets — never commit)
 spec/mcp/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/__tests__/account/scoping.test.ts
+++ b/__tests__/account/scoping.test.ts
@@ -22,8 +22,12 @@ import {
   getMyBookings,
 } from "@/lib/account/queries";
 
+// .sort() may be followed by .lean() (orders) or .populate().lean() (bookings).
 const sortable = (result: unknown) => ({
-  sort: () => ({ lean: () => Promise.resolve(result) }),
+  sort: () => ({
+    lean: () => Promise.resolve(result),
+    populate: () => ({ lean: () => Promise.resolve(result) }),
+  }),
 });
 const leanable = (result: unknown) => ({ lean: () => Promise.resolve(result) });
 

--- a/__tests__/checkout/reservationAvailability.test.ts
+++ b/__tests__/checkout/reservationAvailability.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateReservationAvailability,
+  buildReservationDecrementOps,
+  type ReservationDoc,
+} from "@/lib/checkout/reservationAvailability";
+
+// Noon UTC keeps the America/New_York calendar day stable regardless of runner TZ.
+const day = (d: string) => new Date(`${d}T12:00:00Z`);
+
+const dayReservation: ReservationDoc = {
+  _id: "res_1",
+  enableTimeSlots: false,
+  dailyAvailability: [
+    { date: day("2026-07-01"), maxParticipants: 10, currentBookings: 8 },
+    { date: day("2026-07-02"), maxParticipants: 10, currentBookings: 0 },
+  ],
+};
+
+const slotReservation: ReservationDoc = {
+  _id: "res_2",
+  enableTimeSlots: true,
+  dailyAvailability: [
+    {
+      date: day("2026-07-01"),
+      maxParticipants: 10,
+      currentBookings: 0,
+      timeSlots: [
+        { startTime: "10:00", endTime: "11:00", maxParticipants: 4, currentBookings: 3, isAvailable: true },
+      ],
+    },
+  ],
+};
+
+describe("validateReservationAvailability", () => {
+  it("returns null when every selected date has enough spots", () => {
+    expect(
+      validateReservationAvailability(dayReservation, [
+        { date: "2026-07-02", numberOfParticipants: 2 },
+      ])
+    ).toBeNull();
+  });
+
+  it("rejects a date that isn't in the availability calendar", () => {
+    expect(
+      validateReservationAvailability(dayReservation, [
+        { date: "2026-08-15", numberOfParticipants: 1 },
+      ])
+    ).toMatch(/not available/);
+  });
+
+  it("rejects when the day is over capacity", () => {
+    // 10 - 8 = 2 spots left; asking for 3.
+    expect(
+      validateReservationAvailability(dayReservation, [
+        { date: "2026-07-01", numberOfParticipants: 3 },
+      ])
+    ).toMatch(/Only 2 spots left/);
+  });
+
+  it("rejects a missing time slot when slots are enabled", () => {
+    expect(
+      validateReservationAvailability(slotReservation, [
+        { date: "2026-07-01", numberOfParticipants: 1, timeSlot: { startTime: "14:00", endTime: "15:00" } },
+      ])
+    ).toMatch(/Time slot .* is not available/);
+  });
+
+  it("rejects when the time slot is over capacity", () => {
+    // slot: 4 - 3 = 1 left; asking for 2.
+    expect(
+      validateReservationAvailability(slotReservation, [
+        { date: "2026-07-01", numberOfParticipants: 2, timeSlot: { startTime: "10:00", endTime: "11:00" } },
+      ])
+    ).toMatch(/Only 1 spots left/);
+  });
+});
+
+describe("buildReservationDecrementOps", () => {
+  it("emits a positional $inc op per day for a non-slot reservation", () => {
+    const ops = buildReservationDecrementOps(dayReservation, "res_1", [
+      { date: "2026-07-02", numberOfParticipants: 2 },
+    ]);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].updateOne.update.$inc).toEqual({
+      "dailyAvailability.$.currentBookings": 2,
+    });
+    expect(ops[0].updateOne.filter._id).toBe("res_1");
+  });
+
+  it("emits an indexed time-slot $inc op when slots are enabled", () => {
+    const ops = buildReservationDecrementOps(slotReservation, "res_2", [
+      { date: "2026-07-01", numberOfParticipants: 1, timeSlot: { startTime: "10:00", endTime: "11:00" } },
+    ]);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].updateOne.update.$inc).toEqual({
+      "dailyAvailability.0.timeSlots.0.currentBookings": 1,
+    });
+  });
+
+  it("skips dates that aren't in the calendar", () => {
+    const ops = buildReservationDecrementOps(dayReservation, "res_1", [
+      { date: "2026-12-25", numberOfParticipants: 1 },
+    ]);
+    expect(ops).toHaveLength(0);
+  });
+});

--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PriceIntegrityError } from "@/lib/checkout/errors";
+
+// --- Mock every dependency the store checkout route orchestrates ---
+const priceCartFromCatalog = vi.fn();
+const resolveShippingRate = vi.fn();
+vi.mock("@/lib/checkout/storePricing", () => ({
+  priceCartFromCatalog: (...a: unknown[]) => priceCartFromCatalog(...a),
+  resolveShippingRate: (...a: unknown[]) => resolveShippingRate(...a),
+  PriceIntegrityError,
+}));
+
+const paymentsCreate = vi.fn();
+vi.mock("@/lib/square/client", () => ({
+  getSquareClient: () => ({ payments: { create: (...a: unknown[]) => paymentsCreate(...a) } }),
+}));
+
+const findOrCreateCustomer = vi.fn();
+vi.mock("@/lib/square/customers", () => ({
+  squareCustomerService: { findOrCreateCustomer: (...a: unknown[]) => findOrCreateCustomer(...a) },
+}));
+
+const giftCardGetById = vi.fn();
+const giftCardRedeem = vi.fn();
+vi.mock("@/lib/square/gift-cards", () => ({
+  giftCardService: {
+    getById: (...a: unknown[]) => giftCardGetById(...a),
+    redeem: (...a: unknown[]) => giftCardRedeem(...a),
+  },
+}));
+
+const purchaseLabelForOrder = vi.fn();
+vi.mock("@/lib/shippo/labels", () => ({
+  purchaseLabelForOrder: (...a: unknown[]) => purchaseLabelForOrder(...a),
+}));
+
+const orderCreate = vi.fn();
+const orderFindByIdAndUpdate = vi.fn();
+vi.mock("@/lib/models/Order", () => ({
+  default: {
+    create: (...a: unknown[]) => orderCreate(...a),
+    findByIdAndUpdate: (...a: unknown[]) => orderFindByIdAndUpdate(...a),
+  },
+}));
+
+vi.mock("@/lib/mongoose", () => ({ connectMongo: vi.fn() }));
+vi.mock("@react-email/render", () => ({ render: vi.fn().mockResolvedValue("<html></html>") }));
+
+const emailSend = vi.fn();
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: (...a: unknown[]) => emailSend(...a) };
+  },
+}));
+
+import { POST } from "@/app/api/store/checkout/route";
+
+const BUYER = { firstName: "Pat", lastName: "Buyer", email: "buyer@example.com", phone: "(609) 555-1234" };
+const SELF_ADDRESS = {
+  name: "Pat Buyer",
+  addressLine1: "1 Main St",
+  city: "Ocean City",
+  stateProvince: "NJ",
+  postalCode: "08226",
+  country: "US",
+};
+const GIFT_ADDRESS = {
+  name: "Riley Recipient",
+  addressLine1: "20 W 34th St",
+  city: "New York",
+  stateProvince: "NY",
+  postalCode: "10001",
+  country: "US",
+};
+const RATE = { rateId: "rate_1", carrier: "USPS", service: "usps_ground_advantage", serviceName: "USPS Ground Advantage", rateCents: 570 };
+const ITEMS = [{ squareCatalogItemId: "item_1", squareVariationId: "var_1", quantity: 1 }];
+
+function req(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/store/checkout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function baseBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    paymentToken: "cnon:card-nonce-ok",
+    customer: BUYER,
+    shippingAddress: SELF_ADDRESS,
+    selectedRate: RATE,
+    items: ITEMS,
+    subtotalCents: 8800,
+    idempotencyKey: "idem-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  priceCartFromCatalog.mockResolvedValue({
+    items: [
+      { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
+    ],
+    subtotalCents: 8800,
+  });
+  resolveShippingRate.mockResolvedValue(RATE);
+  paymentsCreate.mockResolvedValue({ payment: { id: "pay_1", status: "COMPLETED" } });
+  findOrCreateCustomer.mockResolvedValue({ customerId: "sqcust_1" });
+  purchaseLabelForOrder.mockResolvedValue({ labelUrl: "https://label", trackingNumber: "TRK1" });
+  orderCreate.mockResolvedValue({ _id: { toString: () => "order_1" }, orderNumber: "CC-TEST-1" });
+  orderFindByIdAndUpdate.mockResolvedValue({});
+  emailSend.mockResolvedValue({});
+});
+
+describe("POST /api/store/checkout", () => {
+  it("charges the server total, creates the order, buys a label, returns the order number", async () => {
+    const res = await POST(req(baseBody()));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.orderNumber).toBe("CC-TEST-1");
+
+    // Charged subtotal + shipping (8800 + 570) as BigInt cents.
+    expect(paymentsCreate).toHaveBeenCalledTimes(1);
+    expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(9370));
+
+    expect(orderCreate).toHaveBeenCalledTimes(1);
+    const order = orderCreate.mock.calls[0][0];
+    expect(order.totalCents).toBe(9370);
+    expect(order.subtotalCents).toBe(8800);
+    expect(order.shippingCents).toBe(570);
+    expect(order.status).toBe("paid");
+    expect(purchaseLabelForOrder).toHaveBeenCalledWith("order_1");
+  });
+
+  it("ships to the RECIPIENT on a gift order while charging the BUYER (A1)", async () => {
+    const res = await POST(req(baseBody({ shippingAddress: GIFT_ADDRESS })));
+    expect(res.status).toBe(200);
+
+    // Square payment: payer is the buyer, ship-to name is the recipient (split).
+    const charge = paymentsCreate.mock.calls[0][0];
+    expect(charge.buyerEmailAddress).toBe("buyer@example.com");
+    expect(charge.shippingAddress.firstName).toBe("Riley");
+    expect(charge.shippingAddress.lastName).toBe("Recipient");
+    expect(charge.shippingAddress.postalCode).toBe("10001");
+
+    // Order: customer is the buyer; shippingAddress carries the recipient name.
+    const order = orderCreate.mock.calls[0][0];
+    expect(order.customer.email).toBe("buyer@example.com");
+    expect(order.shippingAddress.name).toBe("Riley Recipient");
+    expect(order.shippingAddress.postalCode).toBe("10001");
+  });
+
+  it("applies a gift card to the SUBTOTAL ONLY — shipping is always charged to the card", async () => {
+    // Card balance far exceeds the order; must still clamp to subtotal (8800).
+    giftCardGetById.mockResolvedValue({ state: "ACTIVE", balanceMoney: { amount: 100000 } });
+    giftCardRedeem.mockResolvedValue({});
+
+    const res = await POST(
+      req(baseBody({ giftCard: { giftCardId: "gc_1", amountCents: 100000 } }))
+    );
+    expect(res.status).toBe(200);
+
+    // Card charged only the shipping remainder (570), never $0.
+    expect(paymentsCreate).toHaveBeenCalledTimes(1);
+    expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(570));
+    // Redeemed exactly the subtotal.
+    expect(giftCardRedeem).toHaveBeenCalledWith("gc_1", 8800, "buyer@example.com");
+    const order = orderCreate.mock.calls[0][0];
+    expect(order.giftCard).toEqual({ giftCardId: "gc_1", amountCents: 8800 });
+  });
+
+  it("rejects (400) and never charges when the cart fails price integrity", async () => {
+    priceCartFromCatalog.mockRejectedValue(new PriceIntegrityError("Item unavailable"));
+    const res = await POST(req(baseBody()));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBe("Item unavailable");
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects (400) when the chosen shipping rate can no longer be quoted", async () => {
+    resolveShippingRate.mockRejectedValue(new PriceIntegrityError("Shipping rate unavailable"));
+    const res = await POST(req(baseBody()));
+    expect(res.status).toBe(400);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the order as paid when the Shippo label fails (non-fatal)", async () => {
+    purchaseLabelForOrder.mockRejectedValue(new Error("Shippo down"));
+    const res = await POST(req(baseBody()));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(orderCreate.mock.calls[0][0].status).toBe("paid");
+  });
+
+  it("returns 400 on missing required fields and never charges", async () => {
+    const res = await POST(req({ customer: BUYER, items: [] }));
+    expect(res.status).toBe(400);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and creates no order when Square reports payment not COMPLETED", async () => {
+    paymentsCreate.mockResolvedValue({ payment: { id: "pay_x", status: "FAILED" } });
+    const res = await POST(req(baseBody()));
+    expect(res.status).toBe(400);
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/email/recipients.test.ts
+++ b/__tests__/email/recipients.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  resolveEmailRecipients,
+  FALLBACK_STUDIO_EMAIL,
+} from "@/lib/email/recipients";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("resolveEmailRecipients", () => {
+  it("in production sends to the real customer + STUDIO_EMAIL", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("STUDIO_EMAIL", "studio@coastal.com");
+    expect(resolveEmailRecipients("buyer@example.com")).toEqual({
+      customer: "buyer@example.com",
+      admin: "studio@coastal.com",
+    });
+  });
+
+  it("in production falls back to the hardcoded studio email when STUDIO_EMAIL is unset", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("STUDIO_EMAIL", "");
+    expect(resolveEmailRecipients("buyer@example.com").admin).toBe(FALLBACK_STUDIO_EMAIL);
+  });
+
+  it("in dev/stage redirects everything to DEV_EMAIL", () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("DEV_EMAIL", "dev@coastal.com");
+    expect(resolveEmailRecipients("buyer@example.com")).toEqual({
+      customer: "dev@coastal.com",
+      admin: "dev@coastal.com",
+    });
+  });
+
+  it("in dev with no DEV_EMAIL falls back to the customer address", () => {
+    vi.stubEnv("VERCEL_ENV", "development");
+    vi.stubEnv("DEV_EMAIL", "");
+    expect(resolveEmailRecipients("buyer@example.com")).toEqual({
+      customer: "buyer@example.com",
+      admin: "buyer@example.com",
+    });
+  });
+});

--- a/__tests__/giftcards/giftCards.test.ts
+++ b/__tests__/giftcards/giftCards.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getBalance = vi.fn();
+const getById = vi.fn();
+const redeem = vi.fn();
+vi.mock("@/lib/square/gift-cards", () => ({
+  giftCardService: {
+    getBalance: (...a: unknown[]) => getBalance(...a),
+    getById: (...a: unknown[]) => getById(...a),
+    redeem: (...a: unknown[]) => redeem(...a),
+  },
+}));
+
+import { GET as balanceGET } from "@/app/api/gift-cards/balance/route";
+import { POST as redeemPOST } from "@/app/api/gift-cards/redeem/route";
+
+function balanceReq(gan?: string): Request {
+  const url = gan
+    ? `http://localhost/api/gift-cards/balance?gan=${encodeURIComponent(gan)}`
+    : "http://localhost/api/gift-cards/balance";
+  return new Request(url);
+}
+
+function redeemReq(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/gift-cards/redeem", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/gift-cards/balance", () => {
+  it("400s when no GAN is provided", async () => {
+    const res = await balanceGET(balanceReq());
+    expect(res.status).toBe(400);
+    expect(getBalance).not.toHaveBeenCalled();
+  });
+
+  it("400s on a malformed GAN (not 16 digits)", async () => {
+    const res = await balanceGET(balanceReq("1234"));
+    expect(res.status).toBe(400);
+    expect(getBalance).not.toHaveBeenCalled();
+  });
+
+  it("strips dashes and returns balance for a valid GAN", async () => {
+    getBalance.mockResolvedValue({ balance: 5000, status: "ACTIVE", giftCardId: "gc_1" });
+    const res = await balanceGET(balanceReq("1234-5678-9012-3456"));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(getBalance).toHaveBeenCalledWith("1234567890123456");
+    expect(data.balance).toBe(5000);
+    expect(data.formattedBalance).toBe("$50.00");
+  });
+
+  it("404s when the gift card is not found", async () => {
+    getBalance.mockResolvedValue(null);
+    const res = await balanceGET(balanceReq("1111222233334444"));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/gift-cards/redeem", () => {
+  it("400s without a gift card id", async () => {
+    const res = await redeemPOST(redeemReq({ amountCents: 100 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on a non-positive amount", async () => {
+    const res = await redeemPOST(redeemReq({ giftCardId: "gc_1", amountCents: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("404s when the card does not exist", async () => {
+    getById.mockResolvedValue(null);
+    const res = await redeemPOST(redeemReq({ giftCardId: "gc_x", amountCents: 100 }));
+    expect(res.status).toBe(404);
+  });
+
+  it("400s when the card is not ACTIVE", async () => {
+    getById.mockResolvedValue({ state: "DEACTIVATED", balanceMoney: { amount: 5000 } });
+    const res = await redeemPOST(redeemReq({ giftCardId: "gc_1", amountCents: 100 }));
+    expect(res.status).toBe(400);
+    expect(redeem).not.toHaveBeenCalled();
+  });
+
+  it("400s when the requested amount exceeds the balance", async () => {
+    getById.mockResolvedValue({ state: "ACTIVE", balanceMoney: { amount: 500 } });
+    const res = await redeemPOST(redeemReq({ giftCardId: "gc_1", amountCents: 1000 }));
+    expect(res.status).toBe(400);
+    expect(redeem).not.toHaveBeenCalled();
+  });
+
+  it("redeems and returns the new balance for a valid active card", async () => {
+    getById.mockResolvedValue({ state: "ACTIVE", balanceMoney: { amount: 5000 } });
+    redeem.mockResolvedValue({ newBalance: 4000 });
+    const res = await redeemPOST(redeemReq({ giftCardId: "gc_1", amountCents: 1000, referenceId: "order-1" }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(redeem).toHaveBeenCalledWith("gc_1", 1000, "order-1");
+    expect(data.newBalance).toBe(4000);
+    expect(data.formattedNewBalance).toBe("$40.00");
+  });
+});

--- a/__tests__/hooks/mutations/use-create-customer.test.ts
+++ b/__tests__/hooks/mutations/use-create-customer.test.ts
@@ -18,7 +18,12 @@ describe("useCreateCustomer", () => {
 
     await act(async () => {
       result.current.mutate({
-        event: "test-event-id-1",
+        event: {
+          _id: "test-event-id-1",
+          eventName: "Paint & Sip Night",
+          eventType: "class",
+          price: 45,
+        },
         eventType: "Event",
         quantity: 2,
         total: 90,
@@ -27,8 +32,13 @@ describe("useCreateCustomer", () => {
         billingInfo: {
           firstName: "John",
           lastName: "Doe",
-          email: "john@example.com",
-          phone: "555-1234",
+          addressLine1: "123 Main St",
+          city: "Ocean City",
+          stateProvince: "NJ",
+          postalCode: "08226",
+          country: "US",
+          emailAddress: "john@example.com",
+          phoneNumber: "555-1234",
         },
       });
     });
@@ -49,10 +59,23 @@ describe("useCreateCustomer", () => {
 
     await act(async () => {
       result.current.mutate({
-        event: "test-id",
+        event: {
+          _id: "test-id",
+          eventType: "class",
+          price: 45,
+        },
         eventType: "Event",
         quantity: 1,
-        billingInfo: { email: "test@test.com" },
+        billingInfo: {
+          firstName: "Test",
+          lastName: "User",
+          addressLine1: "123 Main St",
+          city: "Ocean City",
+          stateProvince: "NJ",
+          postalCode: "08226",
+          country: "US",
+          emailAddress: "test@test.com",
+        },
       });
     });
 
@@ -76,7 +99,11 @@ describe("useCreateCustomer", () => {
 
     await act(async () => {
       result.current.mutate({
-        event: "test-id",
+        event: {
+          _id: "test-id",
+          eventType: "class",
+          price: 45,
+        },
         eventType: "Event",
         quantity: 1,
       });
@@ -96,7 +123,11 @@ describe("useCreateCustomer", () => {
 
     await act(async () => {
       result.current.mutate({
-        event: "test-id",
+        event: {
+          _id: "test-id",
+          eventType: "class",
+          price: 45,
+        },
         eventType: "Event",
         quantity: 1,
       });

--- a/__tests__/hooks/mutations/use-create-reservation.test.ts
+++ b/__tests__/hooks/mutations/use-create-reservation.test.ts
@@ -19,11 +19,16 @@ describe("useCreateReservation", () => {
     await act(async () => {
       result.current.mutate({
         eventName: "Walk-In Session",
-        eventType: "reservation",
+        description: "Drop-in painting session",
         pricePerDayPerParticipant: 25,
+        maxParticipantsPerDay: 10,
         dates: {
           startDate: "2024-12-01",
           endDate: "2024-12-31",
+        },
+        time: {
+          startTime: "10:00 AM",
+          endTime: "6:00 PM",
         },
       });
     });
@@ -45,8 +50,11 @@ describe("useCreateReservation", () => {
     await act(async () => {
       result.current.mutate({
         eventName: "Test Reservation",
-        eventType: "reservation",
+        description: "Test reservation",
         pricePerDayPerParticipant: 30,
+        maxParticipantsPerDay: 5,
+        dates: { startDate: "2024-12-01" },
+        time: { startTime: "10:00 AM" },
       });
     });
 
@@ -71,7 +79,11 @@ describe("useCreateReservation", () => {
     await act(async () => {
       result.current.mutate({
         eventName: "",
-        eventType: "reservation",
+        description: "",
+        pricePerDayPerParticipant: 0,
+        maxParticipantsPerDay: 0,
+        dates: { startDate: "2024-12-01" },
+        time: { startTime: "10:00 AM" },
       });
     });
 

--- a/__tests__/hooks/queries/use-gallery.test.ts
+++ b/__tests__/hooks/queries/use-gallery.test.ts
@@ -28,7 +28,7 @@ describe("useGallery", () => {
 
   it("should fetch gallery with destination filter", async () => {
     const filteredItems = mockGalleryItems.filter(
-      i => i.destinations?.includes("adult-class")
+      i => i.destination?.includes("adult-class")
     );
     mockFetch({ success: true, data: filteredItems });
 

--- a/__tests__/hooks/queries/use-products.test.ts
+++ b/__tests__/hooks/queries/use-products.test.ts
@@ -13,6 +13,7 @@ const mockSummary: StoreProductSummary = {
   priceRange: { minCents: 2400, maxCents: 2400 },
   hasMultipleVariations: false,
   availability: "available",
+  availabilityLabel: null,
   displayOrder: 0,
 };
 

--- a/__tests__/refunds/refundsRoute.test.ts
+++ b/__tests__/refunds/refundsRoute.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getServerSessionMock } = vi.hoisted(() => ({ getServerSessionMock: vi.fn() }));
+vi.mock("next-auth", () => ({ getServerSession: getServerSessionMock }));
+vi.mock("@/auth", () => ({ authOptions: {} }));
+
+vi.mock("@/lib/mongoose", () => ({ connectMongo: vi.fn() }));
+// Side-effect model registrations the route imports.
+vi.mock("@/lib/models/Event", () => ({ default: {} }));
+vi.mock("@/lib/models/PrivateEvent", () => ({ default: {} }));
+vi.mock("@/lib/models/Reservations", () => ({ default: {} }));
+
+const customerFindById = vi.fn();
+vi.mock("@/lib/models/Customer", () => ({ default: { findById: (...a: unknown[]) => customerFindById(...a) } }));
+
+const refundPayment = vi.fn();
+vi.mock("@/lib/square/client", () => ({
+  getSquareClient: () => ({ refunds: { refundPayment: (...a: unknown[]) => refundPayment(...a) } }),
+}));
+
+const sendRefundConfirmation = vi.fn();
+vi.mock("@/lib/email/sendRefundConfirmation", () => ({
+  sendRefundConfirmation: (...a: unknown[]) => sendRefundConfirmation(...a),
+}));
+
+import { POST } from "@/app/api/refunds/route";
+
+function req(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/refunds", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function customerDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    squarePaymentId: "pay_real_1",
+    refundStatus: "none",
+    total: 100,
+    refundAmount: 0,
+    billingInfo: { emailAddress: "buyer@example.com", firstName: "Pat" },
+    event: { eventName: "Workshop" },
+    save: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+/** Customer.findById(id).populate("event") -> doc */
+function mockCustomer(doc: ReturnType<typeof customerDoc> | null) {
+  customerFindById.mockReturnValue({ populate: vi.fn().mockResolvedValue(doc) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getServerSessionMock.mockResolvedValue({ user: { isAdmin: true } });
+  refundPayment.mockResolvedValue({ refund: { id: "rf_1", status: "COMPLETED" } });
+});
+
+describe("POST /api/refunds — auth", () => {
+  it("401s when unauthenticated", async () => {
+    getServerSessionMock.mockResolvedValue(null);
+    const res = await POST(req({ customerId: "c1" }) as never);
+    expect(res.status).toBe(401);
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("401s a signed-in non-admin", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { isAdmin: false } });
+    const res = await POST(req({ customerId: "c1" }) as never);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/refunds — guards", () => {
+  it("400s without a customerId", async () => {
+    const res = await POST(req({}) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("404s when the customer is not found", async () => {
+    mockCustomer(null);
+    const res = await POST(req({ customerId: "missing" }) as never);
+    expect(res.status).toBe(404);
+  });
+
+  it("400s and never calls Square for a FREE-EVENT booking (synthetic id)", async () => {
+    mockCustomer(customerDoc({ squarePaymentId: "FREE-EVENT" }));
+    const res = await POST(req({ customerId: "c1" }) as never);
+    expect(res.status).toBe(400);
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("400s and never calls Square for a gift-card-only booking (GIFTCARD- id)", async () => {
+    mockCustomer(customerDoc({ squarePaymentId: "GIFTCARD-gc_1" }));
+    const res = await POST(req({ customerId: "c1" }) as never);
+    expect(res.status).toBe(400);
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("400s when there is no payment id at all", async () => {
+    mockCustomer(customerDoc({ squarePaymentId: undefined }));
+    const res = await POST(req({ customerId: "c1" }) as never);
+    expect(res.status).toBe(400);
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("400s when already fully refunded", async () => {
+    mockCustomer(customerDoc({ refundStatus: "full" }));
+    const res = await POST(req({ customerId: "c1" }) as never);
+    expect(res.status).toBe(400);
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/refunds — refund processing", () => {
+  it("issues a full refund as BigInt cents and marks the booking fully refunded", async () => {
+    const doc = customerDoc();
+    mockCustomer(doc);
+    const res = await POST(req({ customerId: "c1" }) as never);
+    expect(res.status).toBe(200);
+
+    expect(refundPayment).toHaveBeenCalledTimes(1);
+    const call = refundPayment.mock.calls[0][0];
+    expect(call.paymentId).toBe("pay_real_1");
+    expect(call.amountMoney.amount).toBe(BigInt(10000)); // $100 -> 10000 cents
+    expect(doc.refundStatus).toBe("full");
+    expect(doc.save).toHaveBeenCalled();
+  });
+
+  it("issues a partial refund and marks the booking partially refunded", async () => {
+    const doc = customerDoc();
+    mockCustomer(doc);
+    const res = await POST(req({ customerId: "c1", refundAmount: 30 }) as never);
+    expect(res.status).toBe(200);
+
+    expect(refundPayment.mock.calls[0][0].amountMoney.amount).toBe(BigInt(3000)); // $30
+    expect(doc.refundStatus).toBe("partial");
+    expect(doc.refundAmount).toBe(30);
+  });
+});

--- a/__tests__/store/CartProvider.test.tsx
+++ b/__tests__/store/CartProvider.test.tsx
@@ -36,6 +36,7 @@ const mockProduct: StoreProduct = {
   priceRange: { minCents: 2400, maxCents: 2400 },
   hasMultipleVariations: false,
   availability: "available",
+  availabilityLabel: null,
   displayOrder: 0,
   images: [],
   variations: [mockVariation],

--- a/__tests__/utils/mock-data.ts
+++ b/__tests__/utils/mock-data.ts
@@ -1,7 +1,16 @@
 import type { HoursOfOperation } from "@/types/hours";
-import type { PageContent } from "@/types/pageContent";
+import type { PageContent, PortableTextContent } from "@/types/pageContent";
 import type { ApiEvent, ICustomer, PictureGalleryItem } from "@/types/interfaces";
 import type { Reservation } from "@/lib/types/reservationTypes";
+
+// Minimal valid PortableText block helper for description fields.
+const portableText = (text: string): PortableTextContent => [
+  {
+    _type: "block",
+    _key: "block-0",
+    children: [{ _type: "span", _key: "span-0", text }],
+  },
+];
 
 // Hours mock data
 export const mockHoursData: HoursOfOperation = {
@@ -22,23 +31,24 @@ export const mockPageContent: PageContent = {
   _type: "pageContent",
   homepage: {
     hero: {
-      title: "Welcome to Coastal Creations",
-      subtitle: "Art Studio & Classes",
+      heading: "Welcome to Coastal Creations",
+      ctaButton1: "Book a Class",
+      ctaButton2: "View Gallery",
     },
     offerings: {
-      title: "Our Offerings",
-      description: "Explore our classes",
+      sectionTitle: "Our Offerings",
+      sectionSubtitle: portableText("Explore our classes"),
     },
   },
   eventPages: {
-    adultClasses: { title: "Adult Classes", description: "Classes for adults" },
-    kidClasses: { title: "Kid Classes", description: "Classes for kids" },
-    camps: { title: "Camps", description: "Summer camps" },
+    adultClasses: { title: "Adult Classes", description: portableText("Classes for adults") },
+    kidClasses: { title: "Kid Classes", description: portableText("Classes for kids") },
+    camps: { title: "Camps", description: portableText("Summer camps") },
   },
   otherPages: {
-    about: { title: "About Us", description: "Learn about us" },
-    gallery: { title: "Gallery", description: "View our gallery" },
-    reservations: { title: "Reservations", description: "Book a reservation" },
+    about: { title: "About Us", description: portableText("Learn about us") },
+    gallery: { title: "Gallery", description: portableText("View our gallery") },
+    reservations: { title: "Reservations", description: portableText("Book a reservation") },
   },
 };
 
@@ -57,13 +67,12 @@ export const mockEvent: ApiEvent = {
   dates: {
     startDate: "2024-12-20",
     endDate: "2024-12-20",
-    recurring: {
-      isRecurring: false,
-    },
+    isRecurring: false,
   },
   image: "https://example.com/image.jpg",
   options: [],
-  discount: { enabled: false },
+  createdAt: "2024-11-01T10:00:00Z",
+  updatedAt: "2024-11-01T10:00:00Z",
 };
 
 export const mockEvents: ApiEvent[] = [
@@ -87,19 +96,29 @@ export const mockEvents: ApiEvent[] = [
 // Customer mock data
 export const mockCustomer: ICustomer = {
   _id: "test-customer-id-1",
-  event: "test-event-id-1",
+  event: {
+    _id: "test-event-id-1",
+    eventName: "Paint & Sip Night",
+    eventType: "class",
+    price: 45,
+  },
   eventType: "Event",
   quantity: 2,
   total: 90,
   isSigningUpForSelf: true,
   participants: [
-    { firstName: "John", lastName: "Doe", age: 30 },
+    { firstName: "John", lastName: "Doe" },
   ],
   billingInfo: {
     firstName: "John",
     lastName: "Doe",
-    email: "john@example.com",
-    phone: "555-1234",
+    addressLine1: "123 Main St",
+    city: "Ocean City",
+    stateProvince: "NJ",
+    postalCode: "08226",
+    country: "US",
+    emailAddress: "john@example.com",
+    phoneNumber: "555-1234",
   },
   squarePaymentId: "sq-payment-123",
   refundStatus: "none",
@@ -113,7 +132,7 @@ export const mockCustomers: ICustomer[] = [
     billingInfo: {
       ...mockCustomer.billingInfo,
       firstName: "Jane",
-      email: "jane@example.com",
+      emailAddress: "jane@example.com",
     },
   },
 ];
@@ -126,8 +145,8 @@ export const mockReservation: Reservation = {
   description: "Drop-in painting session",
   pricePerDayPerParticipant: 25,
   dates: {
-    startDate: "2024-12-01",
-    endDate: "2024-12-31",
+    startDate: new Date("2024-12-01"),
+    endDate: new Date("2024-12-31"),
     excludeDates: [],
   },
   timeType: "same",
@@ -137,13 +156,15 @@ export const mockReservation: Reservation = {
   },
   dailyAvailability: [
     {
-      date: "2024-12-15",
+      date: new Date("2024-12-15"),
       maxParticipants: 10,
       currentBookings: 3,
+      isAvailable: true,
     },
   ],
   options: [],
-  discount: { enabled: false },
+  createdAt: new Date("2024-11-01T10:00:00Z"),
+  updatedAt: new Date("2024-11-01T10:00:00Z"),
 };
 
 export const mockReservations: Reservation[] = [
@@ -184,10 +205,20 @@ export const mockPrivateEvents = [
 // Gallery mock data
 export const mockGalleryItem: PictureGalleryItem = {
   _id: "test-gallery-id-1",
+  _type: "pictureGallery",
   title: "Summer Camp Art",
   description: "Art from summer camp 2024",
-  imageUrl: "https://example.com/gallery1.jpg",
-  destinations: ["camp", "kid-class"],
+  destination: ["camp", "kid-class"],
+  image: {
+    _type: "image",
+    asset: {
+      _type: "reference",
+      _ref: "image-gallery1",
+      url: "https://example.com/gallery1.jpg",
+    },
+  },
+  _createdAt: "2024-08-01T10:00:00Z",
+  _updatedAt: "2024-08-01T10:00:00Z",
 };
 
 export const mockGalleryItems: PictureGalleryItem[] = [
@@ -196,7 +227,7 @@ export const mockGalleryItems: PictureGalleryItem[] = [
     ...mockGalleryItem,
     _id: "test-gallery-id-2",
     title: "Adult Class Projects",
-    destinations: ["adult-class"],
+    destination: ["adult-class"],
   },
 ];
 

--- a/__tests__/utils/test-utils.tsx
+++ b/__tests__/utils/test-utils.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, type RenderOptions } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";

--- a/__tests__/utils/validation.test.ts
+++ b/__tests__/utils/validation.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { isValidEmail } from "@/lib/utils/validation";
+
+describe("isValidEmail", () => {
+  it("accepts well-formed addresses", () => {
+    for (const v of ["a@b.co", "first.last@example.com", "x+tag@sub.domain.org"]) {
+      expect(isValidEmail(v)).toBe(true);
+    }
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(isValidEmail("  a@b.co  ")).toBe(true);
+  });
+
+  it("rejects malformed addresses", () => {
+    for (const v of ["", "  ", "noatsign", "no@domain", "@no-local.com", "a b@c.com", "a@b .com"]) {
+      expect(isValidEmail(v)).toBe(false);
+    }
+  });
+
+  it("rejects null/undefined", () => {
+    expect(isValidEmail(null)).toBe(false);
+    expect(isValidEmail(undefined)).toBe(false);
+  });
+});

--- a/__tests__/webhooks/shippoWebhook.test.ts
+++ b/__tests__/webhooks/shippoWebhook.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const orderFindOne = vi.fn();
+const orderFindByIdAndUpdate = vi.fn();
+vi.mock("@/lib/models/Order", () => ({
+  default: {
+    findOne: (...a: unknown[]) => orderFindOne(...a),
+    findByIdAndUpdate: (...a: unknown[]) => orderFindByIdAndUpdate(...a),
+  },
+}));
+
+vi.mock("@/lib/mongoose", () => ({ connectMongo: vi.fn() }));
+vi.mock("@react-email/render", () => ({ render: vi.fn().mockResolvedValue("<html></html>") }));
+
+const emailSend = vi.fn();
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: (...a: unknown[]) => emailSend(...a) };
+  },
+}));
+
+import { POST } from "@/app/api/webhooks/shippo/route";
+
+const SECRET = "whsec_test";
+
+function makeOrder(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "order_1",
+    orderNumber: "CC-TEST-1",
+    status: "label_created",
+    shippedAt: undefined,
+    deliveredAt: undefined,
+    customer: { firstName: "Pat", lastName: "Buyer", email: "buyer@example.com" },
+    shippo: { carrier: "USPS", trackingNumber: "TRK1", trackingUrlProvider: "https://track" },
+    ...overrides,
+  };
+}
+
+function req(opts: { token?: string; header?: string; body: unknown }): Request {
+  const url = opts.token
+    ? `http://localhost/api/webhooks/shippo?token=${opts.token}`
+    : "http://localhost/api/webhooks/shippo";
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (opts.header) headers["Shippo-Webhook-Secret"] = opts.header;
+  return new Request(url, { method: "POST", headers, body: JSON.stringify(opts.body) });
+}
+
+const trackEvent = (status: string) => ({
+  event: "track_updated",
+  data: { tracking_number: "TRK1", carrier: "USPS", tracking_status: { status } },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("SHIPPO_WEBHOOK_SECRET", SECRET);
+  vi.stubEnv("VERCEL_ENV", "production");
+  vi.stubEnv("STUDIO_EMAIL", "studio@coastal.com");
+  orderFindByIdAndUpdate.mockResolvedValue({});
+  emailSend.mockResolvedValue({});
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("POST /api/webhooks/shippo — auth", () => {
+  it("rejects an invalid token (401)", async () => {
+    const res = await POST(req({ token: "wrong", body: trackEvent("TRANSIT") }));
+    expect(res.status).toBe(401);
+    expect(orderFindOne).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid token in the query string", async () => {
+    orderFindOne.mockResolvedValue(makeOrder());
+    const res = await POST(req({ token: SECRET, body: trackEvent("TRANSIT") }));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a valid token in the header", async () => {
+    orderFindOne.mockResolvedValue(makeOrder());
+    const res = await POST(req({ header: SECRET, body: trackEvent("TRANSIT") }));
+    expect(res.status).toBe(200);
+  });
+
+  it("fails closed (401) when SHIPPO_WEBHOOK_SECRET is not configured", async () => {
+    vi.stubEnv("SHIPPO_WEBHOOK_SECRET", "");
+    const res = await POST(req({ token: "anything", body: trackEvent("TRANSIT") }));
+    expect(res.status).toBe(401);
+    expect(orderFindOne).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/webhooks/shippo — payload handling", () => {
+  it("acknowledges non-track_updated events without touching orders", async () => {
+    const res = await POST(req({ token: SECRET, body: { event: "transaction_created", data: {} } }));
+    expect(res.status).toBe(200);
+    expect(orderFindOne).not.toHaveBeenCalled();
+  });
+
+  it("400s on a missing tracking number", async () => {
+    const res = await POST(
+      req({ token: SECRET, body: { event: "track_updated", data: { tracking_status: { status: "TRANSIT" } } } })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("acknowledges (200) when no order matches the tracking number", async () => {
+    orderFindOne.mockResolvedValue(null);
+    const res = await POST(req({ token: SECRET, body: trackEvent("TRANSIT") }));
+    expect(res.status).toBe(200);
+    expect(orderFindByIdAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/webhooks/shippo — status transitions + idempotency", () => {
+  it("marks shipped and emails customer + admin on first TRANSIT", async () => {
+    orderFindOne.mockResolvedValue(makeOrder());
+    await POST(req({ token: SECRET, body: trackEvent("TRANSIT") }));
+    expect(orderFindByIdAndUpdate).toHaveBeenCalledWith(
+      "order_1",
+      expect.objectContaining({ status: "shipped" })
+    );
+    expect(emailSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("is a no-op on a duplicate TRANSIT (already shipped)", async () => {
+    orderFindOne.mockResolvedValue(makeOrder({ status: "shipped", shippedAt: new Date() }));
+    await POST(req({ token: SECRET, body: trackEvent("TRANSIT") }));
+    expect(orderFindByIdAndUpdate).not.toHaveBeenCalled();
+    expect(emailSend).not.toHaveBeenCalled();
+  });
+
+  it("marks delivered and emails the customer on DELIVERED", async () => {
+    orderFindOne.mockResolvedValue(makeOrder({ status: "shipped", shippedAt: new Date() }));
+    await POST(req({ token: SECRET, body: trackEvent("DELIVERED") }));
+    expect(orderFindByIdAndUpdate).toHaveBeenCalledWith(
+      "order_1",
+      expect.objectContaining({ status: "delivered" })
+    );
+    expect(emailSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("backfills shippedAt when DELIVERED arrives without a prior TRANSIT", async () => {
+    orderFindOne.mockResolvedValue(makeOrder({ status: "label_created", shippedAt: undefined }));
+    await POST(req({ token: SECRET, body: trackEvent("DELIVERED") }));
+    const update = orderFindByIdAndUpdate.mock.calls[0][1];
+    expect(update.status).toBe("delivered");
+    expect(update.shippedAt).toBeInstanceOf(Date);
+    expect(update.deliveredAt).toBeInstanceOf(Date);
+  });
+
+  it("is a no-op on a duplicate DELIVERED", async () => {
+    orderFindOne.mockResolvedValue(makeOrder({ status: "delivered", deliveredAt: new Date() }));
+    await POST(req({ token: SECRET, body: trackEvent("DELIVERED") }));
+    expect(orderFindByIdAndUpdate).not.toHaveBeenCalled();
+    expect(emailSend).not.toHaveBeenCalled();
+  });
+
+  it("alerts admin only and does NOT change status on FAILURE", async () => {
+    orderFindOne.mockResolvedValue(makeOrder({ status: "shipped", shippedAt: new Date() }));
+    await POST(req({ token: SECRET, body: trackEvent("FAILURE") }));
+    expect(orderFindByIdAndUpdate).not.toHaveBeenCalled();
+    expect(emailSend).toHaveBeenCalledTimes(1);
+    expect(emailSend.mock.calls[0][0].to).toEqual(["studio@coastal.com"]);
+  });
+});
+
+describe("POST /api/webhooks/shippo — email routing", () => {
+  it("in production, emails the real customer + STUDIO_EMAIL", async () => {
+    orderFindOne.mockResolvedValue(makeOrder());
+    await POST(req({ token: SECRET, body: trackEvent("TRANSIT") }));
+    const recipients = emailSend.mock.calls.map((c) => c[0].to[0]);
+    expect(recipients).toContain("buyer@example.com");
+    expect(recipients).toContain("studio@coastal.com");
+  });
+
+  it("in dev/stage, redirects all mail to DEV_EMAIL", async () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("DEV_EMAIL", "dev@coastal.com");
+    orderFindOne.mockResolvedValue(makeOrder());
+    await POST(req({ token: SECRET, body: trackEvent("TRANSIT") }));
+    for (const call of emailSend.mock.calls) {
+      expect(call[0].to).toEqual(["dev@coastal.com"]);
+    }
+  });
+});

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -3,6 +3,7 @@ import { render } from "@react-email/render";
 import * as React from "react";
 import { CustomerContactTemplate } from "@/components/email-templates/CustomerContactTemplate";
 import { isValidEmail } from "@/lib/utils/validation";
+import { EMAIL_FROM } from "@/lib/email/recipients";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -94,7 +95,7 @@ export async function POST(request: Request) {
     }
 
     const { error } = await resend.emails.send({
-      from: "Coastal Creations <no-reply@resend.coastalcreationsstudio.com>",
+      from: EMAIL_FROM,
       to: [recipient],
       subject: `New Contact Message: ${subject.trim()}`,
       html: emailHtml,

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,6 +2,7 @@ import { Resend } from "resend";
 import { render } from "@react-email/render";
 import * as React from "react";
 import { CustomerContactTemplate } from "@/components/email-templates/CustomerContactTemplate";
+import { isValidEmail } from "@/lib/utils/validation";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -34,8 +35,7 @@ export async function POST(request: Request) {
       return Response.json({ error: "Message is required" }, { status: 400 });
     }
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    if (!isValidEmail(email)) {
       return Response.json({ error: "Invalid email format" }, { status: 400 });
     }
 

--- a/app/api/refunds/route.ts
+++ b/app/api/refunds/route.ts
@@ -40,9 +40,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    if (!customer.squarePaymentId) {
+    // Reject refunds for bookings with no real card payment: free events and
+    // gift-card-covered bookings carry a synthetic id ("FREE-EVENT" / "GIFTCARD-<id>"),
+    // which Square has no payment for. There is nothing to refund to a card.
+    if (
+      !customer.squarePaymentId ||
+      customer.squarePaymentId.startsWith("FREE-EVENT") ||
+      customer.squarePaymentId.startsWith("GIFTCARD-")
+    ) {
       return NextResponse.json(
-        { error: "No Square payment ID found for this customer" },
+        {
+          error:
+            "This booking has no card payment to refund (it was free or covered by a gift card).",
+        },
         { status: 400 }
       );
     }

--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -4,6 +4,7 @@ import { EmailTemplate } from "@/components/email-templates/EmailTemplate";
 import { Resend } from "resend";
 import { render } from "@react-email/render";
 import * as React from "react";
+import { EMAIL_FROM } from "@/lib/email/recipients";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -29,7 +30,7 @@ export async function POST() {
     }
 
     const { data, error } = await resend.emails.send({
-      from: "Coastal Creations <no-reply@resend.coastalcreationsstudio.com>",
+      from: EMAIL_FROM,
       to: [recipient],
       subject: "Welcome to Coastal Creations Studio",
       html: emailHtml,
@@ -67,7 +68,7 @@ export async function GET() {
     }
 
     const { data, error } = await resend.emails.send({
-      from: "Coastal Creations <no-reply@resend.coastalcreationsstudio.com>",
+      from: EMAIL_FROM,
       to: [recipient],
       subject: "Welcome to Coastal Creations Studio",
       html: emailHtml,

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -112,7 +112,9 @@ export async function POST(request: Request): Promise<Response> {
     console.log("[API-STORE-CHECKOUT-POST] Processing checkout for:", customer.email, "Server total:", totalCents);
 
     // Gift card: validate against Square's REAL balance and reduce the card charge.
-    // A tampered amountCents can never apply more than the actual balance / total.
+    // Gift cards apply to the PRODUCT SUBTOTAL ONLY — never to shipping — so the
+    // credit is clamped to subtotalCents (not the shipping-inclusive totalCents).
+    // A tampered amountCents can never apply more than the actual balance / subtotal.
     let giftCardAppliedCents = 0;
     if (body.giftCard && body.giftCard.amountCents > 0) {
       try {
@@ -120,7 +122,7 @@ export async function POST(request: Request): Promise<Response> {
         const available = card && card.state === "ACTIVE" ? card.balanceMoney.amount : 0;
         giftCardAppliedCents = Math.max(
           0,
-          Math.min(body.giftCard.amountCents, available, totalCents)
+          Math.min(body.giftCard.amountCents, available, subtotalCents)
         );
       } catch (giftCardError) {
         console.error(

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -35,11 +35,28 @@ import {
   PriceIntegrityError,
 } from "@/lib/checkout/storePricing";
 import { normalizeIdempotencyKey } from "@/lib/checkout/idempotency";
+import { resolveEmailRecipients, EMAIL_FROM } from "@/lib/email/recipients";
 import type { LabelResult } from "@/lib/shippo/labels";
 import type { CartItem } from "@/lib/types/cartTypes";
 import type { ShippingRate } from "@/lib/shippo/rates";
 
 const squareClient = getSquareClient();
+
+/**
+ * Split a full recipient name into first/last for Square's payment shippingAddress.
+ * First token = first name, the remainder = last name (handles single-token names).
+ * Falls back to the buyer's name when no recipient name is present.
+ */
+function splitName(
+  full: string | undefined,
+  fallback: { firstName: string; lastName: string }
+): { firstName: string; lastName: string } {
+  const trimmed = (full ?? "").trim();
+  if (!trimmed) return fallback;
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return { firstName: parts[0], lastName: "" };
+  return { firstName: parts[0], lastName: parts.slice(1).join(" ") };
+}
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -153,8 +170,12 @@ export async function POST(request: Request): Promise<Response> {
         shippingAddress: {
           addressLine1: shippingAddress.addressLine1,
           addressLine2: shippingAddress.addressLine2,
-          firstName: customer.firstName,
-          lastName: customer.lastName,
+          // Ship-to name is the RECIPIENT (gift orders ship to someone other than
+          // the buyer); derived from shippingAddress.name, not the payer.
+          ...splitName(shippingAddress.name, {
+            firstName: customer.firstName,
+            lastName: customer.lastName,
+          }),
           postalCode: shippingAddress.postalCode,
           country: (shippingAddress.country || "US") as "US",
         },
@@ -281,11 +302,8 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     // Step 4: Send emails (non-blocking — a failure here shouldn't fail the order)
-    const isProduction = process.env.VERCEL_ENV === "production";
-    const customerRecipient = isProduction ? customer.email : (process.env.DEV_EMAIL ?? customer.email);
-    const adminRecipient = isProduction
-      ? (process.env.STUDIO_EMAIL ?? "ashley@coastalcreationsstudio.com")
-      : (process.env.DEV_EMAIL ?? customer.email);
+    const { customer: customerRecipient, admin: adminRecipient } =
+      resolveEmailRecipients(customer.email);
 
     try {
       const emailHtml = await render(
@@ -341,13 +359,13 @@ export async function POST(request: Request): Promise<Response> {
 
       await Promise.allSettled([
         resend.emails.send({
-          from: "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>",
+          from: EMAIL_FROM,
           to: [customerRecipient],
           subject: `Order ${newOrder.orderNumber} confirmed — Coastal Creations Studio`,
           html: emailHtml,
         }),
         resend.emails.send({
-          from: "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>",
+          from: EMAIL_FROM,
           to: [adminRecipient],
           subject: `New Store Order: ${newOrder.orderNumber} — ${customer.firstName} ${customer.lastName}`,
           html: adminEmailHtml,

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -3,6 +3,7 @@ import { render } from "@react-email/render";
 import * as React from "react";
 import { NewsletterEmailTemplate } from "@/components/email-templates/NewsletterEmailTemplate";
 import { NewsletterWelcomeTemplate } from "@/components/email-templates/NewsletterWelcomeTemplate";
+import { isValidEmail } from "@/lib/utils/validation";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 const FROM = "Coastal Creations <no-reply@resend.coastalcreationsstudio.com>";
@@ -15,9 +16,7 @@ export async function POST(request: Request) {
       return Response.json({ error: "Email is required" }, { status: 400 });
     }
 
-    // Validate email format using regex
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    if (!isValidEmail(email)) {
       return Response.json({ error: "Invalid email format" }, { status: 400 });
     }
 

--- a/app/api/webhooks/shippo/route.ts
+++ b/app/api/webhooks/shippo/route.ts
@@ -32,10 +32,11 @@ import type { IOrder } from "@/lib/models/Order";
 import { ShippingConfirmationEmail } from "@/components/email-templates/ShippingConfirmationEmail";
 import { DeliveryConfirmationEmail } from "@/components/email-templates/DeliveryConfirmationEmail";
 import { ShipmentExceptionEmail } from "@/components/email-templates/ShipmentExceptionEmail";
+import { resolveEmailRecipients, EMAIL_FROM } from "@/lib/email/recipients";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const FROM = "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>";
+const FROM = EMAIL_FROM;
 
 interface ShippoTrackingStatus {
   status: string; // "PRE_TRANSIT" | "TRANSIT" | "DELIVERED" | "RETURNED" | "FAILURE" | "UNKNOWN"
@@ -56,8 +57,10 @@ interface ShippoWebhookEvent {
 function verifySecret(request: Request): boolean {
   const webhookSecret = process.env.SHIPPO_WEBHOOK_SECRET;
   if (!webhookSecret) {
-    console.warn("[WEBHOOKS-SHIPPO] SHIPPO_WEBHOOK_SECRET not set — skipping verification");
-    return true;
+    // Fail closed: with no configured secret we cannot authenticate the caller,
+    // so reject rather than accept unauthenticated webhook POSTs.
+    console.error("[WEBHOOKS-SHIPPO] SHIPPO_WEBHOOK_SECRET not set — rejecting request");
+    return false;
   }
   // Shippo can't send custom headers, so the secret rides in the URL (?token=).
   // Accept the header form too, for manual curl/testing.
@@ -66,18 +69,10 @@ function verifySecret(request: Request): boolean {
   return urlToken === webhookSecret || headerToken === webhookSecret;
 }
 
-// In prod, real recipients. In dev/stage, redirect everything to DEV_EMAIL so we
-// never email real customers from a test environment.
+// Recipient routing is centralized in lib/email/recipients.ts (prod → real +
+// STUDIO_EMAIL; dev/stage → DEV_EMAIL).
 function resolveRecipients(order: IOrder): { customer: string; admin: string } {
-  const isProduction = process.env.VERCEL_ENV === "production";
-  if (isProduction) {
-    return {
-      customer: order.customer.email,
-      admin: process.env.STUDIO_EMAIL ?? "ashley@coastalcreationsstudio.com",
-    };
-  }
-  const devEmail = process.env.DEV_EMAIL ?? order.customer.email;
-  return { customer: devEmail, admin: devEmail };
+  return resolveEmailRecipients(order.customer.email);
 }
 
 // Mark the order shipped on the first carrier scan and notify customer + admin.

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 export default function CalendarPage() {
   return (
-    <div className="min-h-screen bg-[var(--color-light)]">
+    <div className="min-h-screen">
       <PageHeader
         title="Events Calendar"
         subtitle="Browse our full schedule of classes, workshops, camps, and events. Find the perfect creative experience for you."

--- a/app/globals.css
+++ b/app/globals.css
@@ -339,6 +339,25 @@ html {
   animation: fade-in-up 0.4s ease-out both;
 }
 
+/* Continuous right-to-left marquee. The track holds TWO copies of the content,
+   so translating by -50% loops seamlessly. Duration is set inline per usage. */
+@keyframes marquee-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.animate-marquee {
+  animation: marquee-scroll linear infinite;
+  will-change: transform;
+}
+.animate-marquee:hover {
+  animation-play-state: paused;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-marquee {
+    animation: none;
+  }
+}
+
 @keyframes btn-shine {
   0%   { transform: translateX(-150%) skewX(-15deg); }
   100% { transform: translateX(200%) skewX(-15deg); }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Hero from "@/components/landing/Hero";
 import MainSection from "@/components/landing/MainSection";
 import Offerings from "@/components/landing/Offerings";
 import Calendar from "@/components/landing/Calendar";
+import ShopPreview from "@/components/landing/ShopPreview";
 import GiftCardBanner from "@/components/landing/GiftCardBanner";
 import SectionDivider from "@/components/landing/SectionDivider";
 import PhotoCorral from "@/components/gallery/PhotoCorral";
@@ -31,6 +32,8 @@ export default function Home() {
       <PhotoCorral destination="home-page" />
       <SectionDivider />
       <Offerings />
+      <SectionDivider />
+      <ShopPreview />
       <SectionDivider />
       <GiftCardBanner />
       <SectionDivider />

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react";
 import PageHeader from "@/components/classes/PageHeader";
 import Store from "@/components/store/Store";
 import StoreCartButton from "@/components/store/StoreCartButton";
+import ShopGiftCardCTA from "@/components/store/ShopGiftCardCTA";
 import { FaShoppingBag } from "react-icons/fa";
 import { GiPaintBrush } from "react-icons/gi";
 
@@ -21,6 +22,7 @@ export default function StorePage(): ReactElement {
         rightIcon={<GiPaintBrush />}
       />
       <Store />
+      <ShopGiftCardCTA />
       {/* Store-only: keep the cart reachable at all times while shopping. */}
       <StoreCartButton />
     </div>

--- a/components/about/About.tsx
+++ b/components/about/About.tsx
@@ -1,47 +1,120 @@
 "use client";
 
+import type { ReactElement, ReactNode } from "react";
 import Image from "next/image";
+import Link from "next/link";
+import { FaPalette, FaUsers, FaPaintRoller, FaStore } from "react-icons/fa";
 import { usePageContent } from "@/hooks/queries";
 import { DEFAULT_TEXT } from "@/lib/constants/defaultPageContent";
 import { portableTextToPlainText } from "@/lib/utils/portableTextHelpers";
+import { Button, Card } from "@/components/ui";
 
-export default function About() {
+const SERIF = { fontFamily: "var(--font-eb-garamond), serif" } as const;
+
+const FEATURES: { icon: ReactNode; title: string; body: string }[] = [
+  {
+    icon: <FaPalette />,
+    title: "Classes & Workshops",
+    body: "Guided sessions for every skill level — from mosaics to mixed media — led by artists who love to teach.",
+  },
+  {
+    icon: <FaPaintRoller />,
+    title: "Walk In & Create",
+    body: "No reservation needed. Drop by during studio hours, pick a project, and let your creativity flow.",
+  },
+  {
+    icon: <FaUsers />,
+    title: "All Ages Welcome",
+    body: "Kids, adults, families, and groups — our studio is a place for everyone to make something they're proud of.",
+  },
+  {
+    icon: <FaStore />,
+    title: "Shop & Gifts",
+    body: "Art kits, studio goods, and works of art from local artists — perfect for gifts or creating on your own time.",
+  },
+];
+
+export default function About(): ReactElement {
   const { content } = usePageContent();
 
-  // Get description as plain text
+  const title =
+    content?.otherPages?.about?.title || DEFAULT_TEXT.otherPages.about.title;
   const description = content?.otherPages?.about?.description
     ? portableTextToPlainText(content.otherPages.about.description)
     : DEFAULT_TEXT.otherPages.about.description;
 
   return (
-    <div className="container mx-auto px-6 md:px-12 py-16 md:py-24">
-      <div className="max-w-6xl mx-auto">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
-          <div className="relative w-full flex items-center justify-center">
+    <div className="container mx-auto px-6 md:px-12">
+      <div className="mx-auto max-w-6xl space-y-16 md:space-y-24">
+        {/* Intro: studio photo + story + CTAs */}
+        <div className="grid grid-cols-1 items-center gap-10 md:grid-cols-2 md:gap-14">
+          <div className="relative flex w-full items-center justify-center">
             <Image
               src="/assets/svg/ashley-rigid-bg.svg"
               alt="Ashley at Coastal Creations Studio"
               width={600}
               height={750}
-              className="w-full h-auto"
+              className="h-auto w-full max-w-md"
               priority
             />
           </div>
-          <div className="bg-white/80 p-8 rounded-2xl shadow-sm">
+          <Card
+            variant="featured"
+            className="p-8 shadow-[0_10px_30px_rgba(12,74,110,0.1)] backdrop-blur md:p-10"
+          >
             <h2
-              className="font-bold text-5xl md:text-6xl text-primary mb-8 leading-tight"
-              style={{ fontFamily: "Comic Neue", fontWeight: 700 }}
+              className="mb-6 text-4xl font-bold leading-tight text-[var(--color-primary)] md:text-5xl"
+              style={SERIF}
             >
-              {content?.otherPages?.about?.title || DEFAULT_TEXT.otherPages.about.title}
+              {title}
             </h2>
-            <div className="space-y-6">
-              <p
-                className="text-gray-700 text-lg md:text-xl leading-relaxed text-justify"
-                style={{ fontFamily: "Comic Neue", fontWeight: 700 }}
-              >
-                {description}
-              </p>
+            <p className="text-lg leading-relaxed text-slate-700">
+              {description}
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link href="/events/classes-workshops">
+                <Button variant="primary" size="lg">
+                  Explore Classes
+                </Button>
+              </Link>
+              <Link href="/walk-in">
+                <Button variant="secondary" size="lg">
+                  Walk In & Create
+                </Button>
+              </Link>
+              <Link href="/shop">
+                <Button variant="secondary" size="lg">
+                  Shop for Gifts
+                </Button>
+              </Link>
             </div>
+          </Card>
+        </div>
+
+        {/* What you'll find here */}
+        <div>
+          <h3
+            className="mb-10 text-center text-3xl font-bold text-[var(--color-primary)] md:text-4xl"
+            style={SERIF}
+          >
+            What you&apos;ll find here
+          </h3>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {FEATURES.map((feature) => (
+              <Card
+                key={feature.title}
+                variant="event"
+                className="h-full text-center transition-transform duration-300 hover:-translate-y-1"
+              >
+                <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--color-light)] text-2xl text-[var(--color-secondary)]">
+                  {feature.icon}
+                </div>
+                <h4 className="mb-2 text-xl font-bold text-[var(--color-primary)]">
+                  {feature.title}
+                </h4>
+                <p className="leading-relaxed text-slate-600">{feature.body}</p>
+              </Card>
+            ))}
           </div>
         </div>
       </div>

--- a/components/authentication/LoginForm.tsx
+++ b/components/authentication/LoginForm.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/shadcn/card";
 import { Button } from "@/components/ui/shadcn/button";
 import { Input } from "@/components/ui/shadcn/input";
+import { isValidEmail } from "@/lib/utils/validation";
 
 /**
  * Customer sign-in: Google OAuth + passwordless magic link (Resend).
@@ -26,6 +27,10 @@ export default function LoginForm(): ReactElement {
   const handleMagicLink = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
     if (!email) return;
+    if (!isValidEmail(email)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/components/calendar/NewCalendar.tsx
+++ b/components/calendar/NewCalendar.tsx
@@ -22,6 +22,10 @@ export default function NewCalendar() {
   // Use refs for tooltip tracking so event listeners always see current values
   const activeTooltipRef = useRef<HTMLElement | null>(null);
   const tooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Hover-intent delay: only show a preview once the pointer rests on an event,
+  // so sweeping across stacked events doesn't spawn/flicker tooltips.
+  const tooltipShowTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const TOOLTIP_SHOW_DELAY_MS = 220;
   const [selectedEvent, setSelectedEvent] = useState<{
     title: string;
     eventType: string;
@@ -418,6 +422,9 @@ export default function NewCalendar() {
       if (tooltipTimeoutRef.current) {
         clearTimeout(tooltipTimeoutRef.current);
       }
+      if (tooltipShowTimeoutRef.current) {
+        clearTimeout(tooltipShowTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -437,9 +444,8 @@ export default function NewCalendar() {
         }}
         initialView="dayGridMonth"
         nowIndicator={true}
-        editable={true}
-        selectable={true}
-        selectMirror={true}
+        editable={false}
+        selectable={false}
         events={events}
         schedulerLicenseKey="CC-Attribution-NonCommercial-NoDerivatives"
         resources={calendarView.includes("resource") ? resources : undefined}
@@ -470,6 +476,10 @@ export default function NewCalendar() {
             clearTimeout(tooltipTimeoutRef.current);
             tooltipTimeoutRef.current = null;
           }
+          if (tooltipShowTimeoutRef.current) {
+            clearTimeout(tooltipShowTimeoutRef.current);
+            tooltipShowTimeoutRef.current = null;
+          }
           const props = info.event.extendedProps;
           const eventId = props?._id || "";
           const currentSignups = eventId
@@ -489,6 +499,16 @@ export default function NewCalendar() {
           });
         }}
         eventMouseEnter={(info) => {
+          // Only show hover previews on devices with a true hover-capable
+          // pointer (mouse). Touch devices use tap -> detail sheet, so a
+          // synthetic hover must never leave a stuck tooltip behind.
+          if (
+            typeof window !== "undefined" &&
+            window.matchMedia("(hover: none)").matches
+          ) {
+            return;
+          }
+
           // Remove any existing tooltip DOM element
           if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
             document.body.removeChild(activeTooltipRef.current);
@@ -500,6 +520,18 @@ export default function NewCalendar() {
             clearTimeout(tooltipTimeoutRef.current);
             tooltipTimeoutRef.current = null;
           }
+
+          // Cancel a pending show from a previously-hovered event.
+          if (tooltipShowTimeoutRef.current) {
+            clearTimeout(tooltipShowTimeoutRef.current);
+            tooltipShowTimeoutRef.current = null;
+          }
+
+          // Hover-intent: only build + show the preview once the pointer has
+          // rested on this event for a beat. Quickly passing over neighbouring
+          // events is cancelled by eventMouseLeave before this fires.
+          tooltipShowTimeoutRef.current = setTimeout(() => {
+            tooltipShowTimeoutRef.current = null;
 
           // Create new tooltip
           const tooltip = document.createElement("div");
@@ -545,31 +577,15 @@ export default function NewCalendar() {
             tooltipContent += `<div class="tooltip-description">${info.event.extendedProps.description}</div>`;
           }
 
-          const isRecurring = info.event.extendedProps?.isRecurring;
-          const isFirstOccurrence = isRecurring
-            ? info.event.start &&
-              info.event.extendedProps?.originalStartDate &&
-              new Date(info.event.start).toDateString() ===
-                new Date(
-                  info.event.extendedProps.originalStartDate
-                ).toDateString()
-            : true;
-
-          // Don't show sign up button for artist events or if sold out
+          // The hover tooltip is a non-interactive PREVIEW only. The actual
+          // sign-up / sold-out CTA lives in the click-to-open detail sheet, so
+          // there is no fragile "move the mouse onto a hovering button" path.
           const maxParticipants = 20; // Default capacity
-          const isSoldOut = currentSignups >= maxParticipants;
-
-          if ((!isRecurring || isFirstOccurrence) && eventType !== "artist") {
-            if (isSoldOut) {
-              tooltipContent += `<div class="tooltip-soldout">
-                <div style="padding: 8px 16px; background: linear-gradient(135deg, #d32f2f, #f44336); color: white; border-radius: 4px; font-weight: bold; text-align: center; cursor: not-allowed;">Sold Out</div>
-              </div>`;
-            } else {
-              tooltipContent += `<div class="tooltip-signup">
-                <button id="signup-${info.event.extendedProps?._id || "event"}" type="button">Sign Up</button>
-              </div>`;
-            }
-          }
+          const isSoldOut =
+            eventType !== "artist" && currentSignups >= maxParticipants;
+          tooltipContent += `<div class="tooltip-hint">${
+            isSoldOut ? "Sold out" : "Click for details"
+          }</div>`;
 
           tooltip.innerHTML = tooltipContent;
 
@@ -632,80 +648,38 @@ export default function NewCalendar() {
             }
           }
 
-          // Apply positioning
+          // Apply positioning. pointer-events:none keeps the preview from ever
+          // intercepting the mouse, so moving toward / clicking the event below
+          // always works — no hover-bridge flicker.
           tooltip.style.position = "fixed";
           tooltip.style.left = left + "px";
           tooltip.style.top = top + "px";
           tooltip.style.transform = `translate(${transformX}, ${transformY})`;
           tooltip.style.zIndex = "99999";
           tooltip.style.display = "block";
+          tooltip.style.pointerEvents = "none";
 
           activeTooltipRef.current = tooltip;
-
-          // Add event listeners to the tooltip itself
-          tooltip.addEventListener("mouseenter", () => {
-            // If a hide timer was set by eventMouseLeave, cancel it because mouse is now over tooltip
-            if (tooltipTimeoutRef.current) {
-              clearTimeout(tooltipTimeoutRef.current);
-              tooltipTimeoutRef.current = null;
-            }
-          });
-
-          tooltip.addEventListener("mouseleave", () => {
-            // Mouse left the tooltip, so remove it
-            if (document.body.contains(tooltip)) {
-              document.body.removeChild(tooltip);
-            }
-            if (activeTooltipRef.current === tooltip) {
-              activeTooltipRef.current = null;
-            }
-            if (tooltipTimeoutRef.current) {
-              clearTimeout(tooltipTimeoutRef.current);
-              tooltipTimeoutRef.current = null;
-            }
-          });
-
-          // Add event listener for the signup button
-          setTimeout(() => {
-            const signupButton = document.getElementById(
-              `signup-${info.event.extendedProps?._id || "event"}`
-            );
-            if (signupButton) {
-              signupButton.addEventListener("click", (e) => {
-                e.stopPropagation();
-                navigateToPayment(
-                  info.event.extendedProps?._id || "unknown",
-                  info.event.title,
-                  info.event.extendedProps?.price,
-                  info.event.extendedProps?.isFree
-                );
-              });
-            }
-          }, 0);
+          }, TOOLTIP_SHOW_DELAY_MS);
         }}
-        eventMouseLeave={(leaveInfo) => {
-          const relatedTarget = leaveInfo.jsEvent.relatedTarget as Node | null;
-
+        eventMouseLeave={() => {
+          // Cancel a not-yet-shown preview (the pointer was just passing over).
+          if (tooltipShowTimeoutRef.current) {
+            clearTimeout(tooltipShowTimeoutRef.current);
+            tooltipShowTimeoutRef.current = null;
+          }
+          // Pure preview — remove it as soon as the pointer leaves the event.
+          if (tooltipTimeoutRef.current) {
+            clearTimeout(tooltipTimeoutRef.current);
+            tooltipTimeoutRef.current = null;
+          }
           if (
             activeTooltipRef.current &&
-            relatedTarget &&
-            (activeTooltipRef.current === relatedTarget ||
-              activeTooltipRef.current.contains(relatedTarget))
+            document.body.contains(activeTooltipRef.current)
           ) {
-            if (tooltipTimeoutRef.current) {
-              clearTimeout(tooltipTimeoutRef.current);
-              tooltipTimeoutRef.current = null;
-            }
-            return;
+            document.body.removeChild(activeTooltipRef.current);
           }
-
-          tooltipTimeoutRef.current = setTimeout(() => {
-            if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
-              document.body.removeChild(activeTooltipRef.current);
-              activeTooltipRef.current = null;
-            }
-            tooltipTimeoutRef.current = null;
-          }, 400);
+          activeTooltipRef.current = null;
         }}
         eventDidMount={(info) => {
           // Set event color based on event type

--- a/components/calendar/calendar.css
+++ b/components/calendar/calendar.css
@@ -263,7 +263,7 @@
   box-shadow: 0 8px 24px rgba(12, 74, 110, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
   font-size: 0.9em;
   z-index: 99999 !important;
-  pointer-events: auto;
+  pointer-events: none;
   white-space: normal;
   color: var(--color-text-primary, #111827);
   text-align: left;
@@ -363,6 +363,19 @@
 
 .tooltip-description::-webkit-scrollbar-thumb:hover {
   background: #94a3b8;
+}
+
+/* Hint footer -- nudges the user to click for the full detail sheet */
+.tooltip-hint {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #f1f5f9;
+  color: var(--color-text-subtle, #64748b);
+  font-weight: 600;
+  font-size: 0.82em;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 /* Sold out badge */

--- a/components/checkout/ContactForm.tsx
+++ b/components/checkout/ContactForm.tsx
@@ -93,6 +93,11 @@ export default function ContactForm({
             disabled={disabled}
             onChange={(e) => onChange("email", e.target.value)}
           />
+          {errors?.email && (
+            <p className="mt-1 text-sm text-[var(--color-error)]">
+              Enter a valid email address.
+            </p>
+          )}
         </div>
         <div>
           <Label htmlFor="contact-phone" required>

--- a/components/checkout/EventCheckout.tsx
+++ b/components/checkout/EventCheckout.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui";
 import EventPreview from "@/components/payment/EventPreview";
 import CheckoutLayout from "./CheckoutLayout";
 import ContactForm, { type ContactFormValues, isValidUsPhone } from "./ContactForm";
+import { isValidEmail } from "@/lib/utils/validation";
 import PaymentStep from "./PaymentStep";
 import EventSummary, { type SummaryLine } from "./EventSummary";
 import EventParticipantsFields from "./EventParticipantsFields";
@@ -208,7 +209,7 @@ export default function EventCheckout(): ReactElement {
   const formValid =
     contact.firstName.trim() !== "" &&
     contact.lastName.trim() !== "" &&
-    contact.email.trim() !== "" &&
+    isValidEmail(contact.email) &&
     isValidUsPhone(contact.phone) &&
     participants.every((p) => p.firstName.trim() !== "" && p.lastName.trim() !== "") &&
     (!isSigningUpForSelf || allOptionsChosen(selfSelectedOptions)) &&
@@ -388,7 +389,10 @@ export default function EventCheckout(): ReactElement {
             values={contact}
             onChange={updateContact}
             disabled={isProcessing}
-            errors={{ phone: contact.phone !== "" && !isValidUsPhone(contact.phone) }}
+            errors={{
+              email: contact.email !== "" && !isValidEmail(contact.email),
+              phone: contact.phone !== "" && !isValidUsPhone(contact.phone),
+            }}
           />
         </section>
 

--- a/components/checkout/GiftCardRedemption.tsx
+++ b/components/checkout/GiftCardRedemption.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, ReactElement } from "react";
+import { motion, AnimatePresence } from "motion/react";
 
 interface AppliedGiftCard {
   giftCardId: string;
@@ -127,12 +128,21 @@ export function GiftCardRedemption({
     );
   }
 
-  // Collapsed view - just a toggle button
-  if (!isExpanded) {
-    return (
+  // Toggle header + smoothly-revealed entry form (height/opacity animate so the
+  // open/close feels fluid instead of snapping between two states).
+  return (
+    <div className="border border-gray-200 rounded-lg mb-4 overflow-hidden">
       <button
-        onClick={() => setIsExpanded(true)}
-        className="w-full text-left border border-gray-200 rounded-lg p-4 mb-4 hover:bg-gray-50 transition-colors flex items-center justify-between"
+        type="button"
+        onClick={() => {
+          if (isExpanded) {
+            setGan("");
+            setError(null);
+          }
+          setIsExpanded((prev) => !prev);
+        }}
+        aria-expanded={isExpanded}
+        className="w-full text-left p-4 hover:bg-gray-50 transition-colors flex items-center justify-between"
       >
         <div className="flex items-center">
           <svg className="w-5 h-5 text-gray-400 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -140,67 +150,61 @@ export function GiftCardRedemption({
           </svg>
           <span className="text-gray-700 font-medium">Have a gift card?</span>
         </div>
-        <svg className="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <motion.svg
+          className="w-5 h-5 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          animate={{ rotate: isExpanded ? 90 : 0 }}
+          transition={{ duration: 0.25, ease: "easeInOut" }}
+        >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
+        </motion.svg>
       </button>
-    );
-  }
 
-  // Expanded view - input form
-  return (
-    <div className="border border-gray-200 rounded-lg p-4 mb-4">
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="font-medium text-gray-800 flex items-center">
-          <svg className="w-5 h-5 text-gray-400 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7" />
-          </svg>
-          Enter Gift Card Number
-        </h3>
-        <button
-          onClick={() => {
-            setIsExpanded(false);
-            setGan("");
-            setError(null);
-          }}
-          className="text-gray-400 hover:text-gray-600"
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
+      <AnimatePresence initial={false}>
+        {isExpanded && (
+          <motion.div
+            key="gift-card-entry"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-4 pt-1">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={gan}
+                  onChange={handleGanChange}
+                  placeholder="XXXX-XXXX-XXXX-XXXX"
+                  maxLength={19}
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-primary focus:border-transparent font-mono"
+                />
+                <button
+                  onClick={handleApply}
+                  disabled={gan.replace(/-/g, "").length !== 16 || loading}
+                  className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {loading ? (
+                    <span className="flex items-center">
+                      <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                    </span>
+                  ) : (
+                    "Apply"
+                  )}
+                </button>
+              </div>
 
-      <div className="flex gap-2">
-        <input
-          type="text"
-          value={gan}
-          onChange={handleGanChange}
-          placeholder="XXXX-XXXX-XXXX-XXXX"
-          maxLength={19}
-          className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-primary focus:border-transparent font-mono"
-        />
-        <button
-          onClick={handleApply}
-          disabled={gan.replace(/-/g, "").length !== 16 || loading}
-          className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {loading ? (
-            <span className="flex items-center">
-              <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
-            </span>
-          ) : (
-            "Apply"
-          )}
-        </button>
-      </div>
-
-      {error && (
-        <p className="text-red-600 text-sm mt-2">{error}</p>
-      )}
+              {error && <p className="text-red-600 text-sm mt-2">{error}</p>}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/components/contact/ContactForm.tsx
+++ b/components/contact/ContactForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Input, Textarea, Label, Button } from "@/components/ui";
+import { isValidEmail } from "@/lib/utils/validation";
 
 interface ContactFormData {
   name: string;
@@ -20,6 +21,7 @@ export default function ContactForm() {
     description: "",
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [emailError, setEmailError] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<
     "idle" | "success" | "error"
   >("idle");
@@ -32,10 +34,19 @@ export default function ContactForm() {
       ...prev,
       [name]: value,
     }));
+    if (name === "email" && emailError) setEmailError(false);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // Validate email format before sending (the API rejects bad emails too).
+    if (!isValidEmail(formData.email)) {
+      setEmailError(true);
+      return;
+    }
+    setEmailError(false);
+
     setIsSubmitting(true);
     setSubmitStatus("idle");
 
@@ -99,9 +110,16 @@ export default function ContactForm() {
             name="email"
             value={formData.email}
             onChange={handleChange}
+            error={emailError}
+            aria-invalid={emailError}
             required
             placeholder="your.email@example.com"
           />
+          {emailError && (
+            <p className="mt-1 text-sm text-[var(--color-error)]">
+              Enter a valid email address.
+            </p>
+          )}
         </div>
       </div>
 

--- a/components/gift-cards/GiftCardPurchase.tsx
+++ b/components/gift-cards/GiftCardPurchase.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactElement } from "react";
 import CheckoutLayout from "@/components/checkout/CheckoutLayout";
 import PaymentStep from "@/components/checkout/PaymentStep";
 import { formatCents } from "@/lib/utils/moneyHelpers";
+import { isValidEmail } from "@/lib/utils/validation";
 
 interface PaymentConfig {
   applicationId: string;
@@ -11,7 +12,6 @@ interface PaymentConfig {
 }
 
 const PRESET_AMOUNTS = [2000, 3500, 5000, 10000]; // In cents: $20, $35, $50, $100
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export function GiftCardPurchase(): ReactElement {
   const [amount, setAmount] = useState<number>(5000);
@@ -52,9 +52,9 @@ export function GiftCardPurchase(): ReactElement {
   const formValid =
     PRESET_AMOUNTS.includes(amount) &&
     recipientName.trim() !== "" &&
-    EMAIL_RE.test(recipientEmail) &&
+    isValidEmail(recipientEmail) &&
     senderName.trim() !== "" &&
-    (purchaserEmail.trim() === "" || EMAIL_RE.test(purchaserEmail));
+    (purchaserEmail.trim() === "" || isValidEmail(purchaserEmail));
 
   const handlePayment = async (token: string): Promise<void> => {
     setIsProcessing(true);

--- a/components/landing/GiftCardBanner.tsx
+++ b/components/landing/GiftCardBanner.tsx
@@ -2,30 +2,16 @@
 
 import type { ReactElement } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui";
-import { useProducts } from "@/hooks/queries/use-products";
-
-const PANEL =
-  "relative overflow-hidden rounded-[2rem] border border-white/65 bg-white/82 shadow-[0_18px_34px_rgba(12,74,110,0.14)] backdrop-blur-[2px]";
 
 const GiftCardBanner = (): ReactElement => {
   const router = useRouter();
-  const { data: products = [], isLoading } = useProducts();
-
-  // Marquee shows every in-stock item. The track renders the list TWICE so the
-  // -50% translate loops seamlessly; speed scales with the item count.
-  const marqueeItems = products.filter(
-    (item) => item.availability !== "sold_out"
-  );
-  const marqueeDurationSec = Math.max(24, marqueeItems.length * 5);
 
   return (
     <section id="gift-cards" className="bg-transparent py-10 md:py-16">
-      <div className="mx-auto flex w-full max-w-[var(--container-max)] flex-col gap-8 px-4 sm:px-6 lg:px-8">
-        {/* ── Gift cards ─────────────────────────────────────────── */}
-        <div className={`${PANEL} px-6 py-10 md:px-10 lg:px-14`}>
+      <div className="mx-auto w-full max-w-[var(--container-max)] px-4 sm:px-6 lg:px-8">
+        <div className="relative overflow-hidden rounded-[2rem] border border-white/65 bg-white/82 px-6 py-10 shadow-[0_18px_34px_rgba(12,74,110,0.14)] backdrop-blur-[2px] md:px-10 lg:px-14">
           <div className="grid items-center gap-10 lg:grid-cols-[1.1fr_0.9fr]">
             <div>
               <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
@@ -73,85 +59,6 @@ const GiftCardBanner = (): ReactElement => {
               </div>
             </div>
           </div>
-        </div>
-
-        {/* ── Shop preview ───────────────────────────────────────── */}
-        <div className={`${PANEL} px-6 py-10 md:px-10 lg:px-14`}>
-          {/* Header: copy left, CTA right (CTA drops below on mobile) */}
-          <div className="mb-8 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
-                Shop
-              </p>
-              <h2 className="mb-3 text-4xl font-bold leading-tight text-primary md:text-5xl">
-                Take home a little creativity.
-              </h2>
-              <p className="max-w-xl text-lg leading-relaxed text-slate-700">
-                Art kits, studio goods, and works of art from local artists —
-                shipped right to your door.
-              </p>
-            </div>
-            <Button
-              variant="secondary"
-              size="lg"
-              className="shrink-0 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md"
-              onClick={() => router.push("/shop")}
-            >
-              Visit the Shop
-            </Button>
-          </div>
-
-          {/* Product preview — a continuous right-to-left auto-scroll (no drag),
-              image + full name only. Bleeds to the panel edges; fades at sides. */}
-          {isLoading ? (
-            <div className="flex gap-5 overflow-hidden">
-              {[0, 1, 2, 3, 4].map((i) => (
-                <div
-                  key={i}
-                  className="aspect-square w-52 shrink-0 animate-pulse rounded-[var(--radius-lg)] bg-sky-100/70"
-                />
-              ))}
-            </div>
-          ) : marqueeItems.length > 0 ? (
-            <div className="relative -mx-6 overflow-hidden md:-mx-10 lg:-mx-14">
-              {/* edge fades */}
-              <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-gradient-to-r from-white/85 to-transparent md:w-16" />
-              <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-gradient-to-l from-white/85 to-transparent md:w-16" />
-              <div
-                className="animate-marquee flex w-max gap-5 px-6 md:px-10 lg:px-14"
-                style={{ animationDuration: `${marqueeDurationSec}s` }}
-              >
-                {[...marqueeItems, ...marqueeItems].map((item, index) => (
-                  <Link
-                    key={`${item.squareItemId}-${index}`}
-                    href={`/shop/${item.slug}`}
-                    aria-hidden={index >= marqueeItems.length}
-                    tabIndex={index >= marqueeItems.length ? -1 : undefined}
-                    className="group block w-52 shrink-0 overflow-hidden rounded-[var(--radius-lg)] border border-sky-100 bg-white shadow-[0_8px_20px_rgba(12,74,110,0.08)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_16px_28px_rgba(12,74,110,0.16)]"
-                  >
-                    <div className="relative aspect-square w-full overflow-hidden bg-[var(--color-light)]">
-                      {item.primaryImage ? (
-                        <Image
-                          src={item.primaryImage.url}
-                          alt={item.primaryImage.altText ?? item.name}
-                          fill
-                          sizes="208px"
-                          className="object-cover transition-transform duration-300 group-hover:scale-105"
-                        />
-                      ) : (
-                        <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-subtle)]">
-                          No image
-                        </div>
-                      )}
-                    </div>
-                    <p className="px-3 py-3 text-center text-sm font-semibold leading-snug text-primary">
-                      {item.name}
-                    </p>
-                  </Link>
-                ))}
-              </div>
-            </div>
-          ) : null}
         </div>
       </div>
     </section>

--- a/components/landing/GiftCardBanner.tsx
+++ b/components/landing/GiftCardBanner.tsx
@@ -2,21 +2,31 @@
 
 import type { ReactElement } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui";
+import { useProducts } from "@/hooks/queries/use-products";
+
+const PANEL =
+  "relative overflow-hidden rounded-[2rem] border border-white/65 bg-white/82 shadow-[0_18px_34px_rgba(12,74,110,0.14)] backdrop-blur-[2px]";
 
 const GiftCardBanner = (): ReactElement => {
   const router = useRouter();
+  const { data: products = [], isLoading } = useProducts();
+
+  // Marquee shows every in-stock item. The track renders the list TWICE so the
+  // -50% translate loops seamlessly; speed scales with the item count.
+  const marqueeItems = products.filter(
+    (item) => item.availability !== "sold_out"
+  );
+  const marqueeDurationSec = Math.max(24, marqueeItems.length * 5);
 
   return (
     <section id="gift-cards" className="bg-transparent py-10 md:py-16">
-      <div className="mx-auto w-full max-w-[var(--container-max)] px-4 sm:px-6 lg:px-8">
-        <div className="relative overflow-hidden rounded-[2rem] border border-white/65 bg-white/82 px-6 py-10 shadow-[0_18px_34px_rgba(12,74,110,0.14)] backdrop-blur-[2px] md:px-10 lg:px-14">
-          <div className="pointer-events-none absolute -left-6 top-8 hidden md:block">
-
-          </div>
-
-          <div className="grid items-center gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+      <div className="mx-auto flex w-full max-w-[var(--container-max)] flex-col gap-8 px-4 sm:px-6 lg:px-8">
+        {/* ── Gift cards ─────────────────────────────────────────── */}
+        <div className={`${PANEL} px-6 py-10 md:px-10 lg:px-14`}>
+          <div className="grid items-center gap-10 lg:grid-cols-[1.1fr_0.9fr]">
             <div>
               <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
                 Gift Cards
@@ -24,9 +34,9 @@ const GiftCardBanner = (): ReactElement => {
               <h2 className="mb-4 text-4xl font-bold leading-tight text-primary md:text-5xl">
                 Give the gift of creativity.
               </h2>
-              <p className="mb-7 max-w-xl text-lg leading-relaxed text-slate-700">
-                Send a digital gift card that can be used for classes, camps, workshops,
-                private events, and walk-in studio time.
+              <p className="mb-8 max-w-xl text-lg leading-relaxed text-slate-700">
+                Send a digital gift card that can be used for classes, camps,
+                workshops, private events, and walk-in studio time.
               </p>
               <Button
                 variant="primary"
@@ -34,10 +44,11 @@ const GiftCardBanner = (): ReactElement => {
                 className="transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg"
                 onClick={() => router.push("/gift-cards")}
               >
-                Buy Gift Card
+                Buy a Gift Card
               </Button>
             </div>
 
+            {/* Gift card visual */}
             <div className="flex justify-center lg:justify-end">
               <div className="w-full max-w-sm rounded-2xl border border-sky-100 bg-white p-3 shadow-[0_14px_24px_rgba(12,74,110,0.14)]">
                 <div className="rounded-xl border border-slate-200 bg-[linear-gradient(155deg,#ffffff_0%,#f3f9fd_70%,#e7f3fa_100%)] p-7">
@@ -54,14 +65,94 @@ const GiftCardBanner = (): ReactElement => {
                     <p className="text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
                       Digital Gift Card
                     </p>
-                    <p className="text-2xl font-bold text-primary">Coastal Creations Studio</p>
+                    <p className="text-2xl font-bold text-primary">
+                      Coastal Creations Studio
+                    </p>
                   </div>
-
                 </div>
               </div>
             </div>
           </div>
-        </div>  
+        </div>
+
+        {/* ── Shop preview ───────────────────────────────────────── */}
+        <div className={`${PANEL} px-6 py-10 md:px-10 lg:px-14`}>
+          {/* Header: copy left, CTA right (CTA drops below on mobile) */}
+          <div className="mb-8 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
+                Shop
+              </p>
+              <h2 className="mb-3 text-4xl font-bold leading-tight text-primary md:text-5xl">
+                Take home a little creativity.
+              </h2>
+              <p className="max-w-xl text-lg leading-relaxed text-slate-700">
+                Art kits, studio goods, and works of art from local artists —
+                shipped right to your door.
+              </p>
+            </div>
+            <Button
+              variant="secondary"
+              size="lg"
+              className="shrink-0 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md"
+              onClick={() => router.push("/shop")}
+            >
+              Visit the Shop
+            </Button>
+          </div>
+
+          {/* Product preview — a continuous right-to-left auto-scroll (no drag),
+              image + full name only. Bleeds to the panel edges; fades at sides. */}
+          {isLoading ? (
+            <div className="flex gap-5 overflow-hidden">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <div
+                  key={i}
+                  className="aspect-square w-52 shrink-0 animate-pulse rounded-[var(--radius-lg)] bg-sky-100/70"
+                />
+              ))}
+            </div>
+          ) : marqueeItems.length > 0 ? (
+            <div className="relative -mx-6 overflow-hidden md:-mx-10 lg:-mx-14">
+              {/* edge fades */}
+              <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-gradient-to-r from-white/85 to-transparent md:w-16" />
+              <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-gradient-to-l from-white/85 to-transparent md:w-16" />
+              <div
+                className="animate-marquee flex w-max gap-5 px-6 md:px-10 lg:px-14"
+                style={{ animationDuration: `${marqueeDurationSec}s` }}
+              >
+                {[...marqueeItems, ...marqueeItems].map((item, index) => (
+                  <Link
+                    key={`${item.squareItemId}-${index}`}
+                    href={`/shop/${item.slug}`}
+                    aria-hidden={index >= marqueeItems.length}
+                    tabIndex={index >= marqueeItems.length ? -1 : undefined}
+                    className="group block w-52 shrink-0 overflow-hidden rounded-[var(--radius-lg)] border border-sky-100 bg-white shadow-[0_8px_20px_rgba(12,74,110,0.08)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_16px_28px_rgba(12,74,110,0.16)]"
+                  >
+                    <div className="relative aspect-square w-full overflow-hidden bg-[var(--color-light)]">
+                      {item.primaryImage ? (
+                        <Image
+                          src={item.primaryImage.url}
+                          alt={item.primaryImage.altText ?? item.name}
+                          fill
+                          sizes="208px"
+                          className="object-cover transition-transform duration-300 group-hover:scale-105"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-subtle)]">
+                          No image
+                        </div>
+                      )}
+                    </div>
+                    <p className="px-3 py-3 text-center text-sm font-semibold leading-snug text-primary">
+                      {item.name}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
       </div>
     </section>
   );

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -210,7 +210,7 @@ const Hero = (): ReactElement => {
             />
           </div>
 
-          <div className="flex flex-wrap justify-center gap-4">
+          <div className="mx-auto flex max-w-2xl flex-wrap justify-center gap-4">
             {HERO_CTAS.map((cta) => (
               <Link
                 key={cta.href}

--- a/components/landing/MainSection.tsx
+++ b/components/landing/MainSection.tsx
@@ -174,9 +174,9 @@ const MainSection = (): ReactElement => {
                 variant="secondary"
                 size="lg"
                 className="w-full transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md"
-                onClick={() => router.push("/reservations")}
+                onClick={() => router.push("/events/classes-workshops")}
               >
-                Book Reservations
+                Explore Classes
               </Button>
             </div>
           </div>

--- a/components/landing/ShopPreview.tsx
+++ b/components/landing/ShopPreview.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { ReactElement } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui";
+import { useProducts } from "@/hooks/queries/use-products";
+
+const PANEL =
+  "relative overflow-hidden rounded-[2rem] border border-white/65 bg-white/82 shadow-[0_18px_34px_rgba(12,74,110,0.14)] backdrop-blur-[2px]";
+
+const ShopPreview = (): ReactElement => {
+  const router = useRouter();
+  const { data: products = [], isLoading } = useProducts();
+
+  // Marquee shows every in-stock item. The track renders the list TWICE so the
+  // -50% translate loops seamlessly; speed scales with the item count.
+  const marqueeItems = products.filter(
+    (item) => item.availability !== "sold_out"
+  );
+  const marqueeDurationSec = Math.max(24, marqueeItems.length * 5);
+
+  return (
+    <section id="shop-preview" className="bg-transparent py-10 md:py-16">
+      <div className="mx-auto w-full max-w-[var(--container-max)] px-4 sm:px-6 lg:px-8">
+        <div className={`${PANEL} px-6 py-10 md:px-10 lg:px-14`}>
+          {/* Header: copy left, CTA right (CTA drops below on mobile) */}
+          <div className="mb-8 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
+                Shop
+              </p>
+              <h2 className="mb-3 text-4xl font-bold leading-tight text-primary md:text-5xl">
+                Take home a little creativity.
+              </h2>
+              <p className="max-w-xl text-lg leading-relaxed text-slate-700">
+                Art kits, studio goods, and works of art from local artists —
+                shipped right to your door.
+              </p>
+            </div>
+            <Button
+              variant="secondary"
+              size="lg"
+              className="shrink-0 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md"
+              onClick={() => router.push("/shop")}
+            >
+              Visit the Shop
+            </Button>
+          </div>
+
+          {/* Product preview — a continuous right-to-left auto-scroll (no drag),
+              image + full name only. Bleeds to the panel edges; fades at sides. */}
+          {isLoading ? (
+            <div className="flex gap-5 overflow-hidden">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <div
+                  key={i}
+                  className="aspect-square w-52 shrink-0 animate-pulse rounded-[var(--radius-lg)] bg-sky-100/70"
+                />
+              ))}
+            </div>
+          ) : marqueeItems.length > 0 ? (
+            <div className="relative -mx-6 overflow-hidden md:-mx-10 lg:-mx-14">
+              {/* edge fades */}
+              <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-gradient-to-r from-white/85 to-transparent md:w-16" />
+              <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-gradient-to-l from-white/85 to-transparent md:w-16" />
+              <div
+                className="animate-marquee flex w-max gap-5 px-6 md:px-10 lg:px-14"
+                style={{ animationDuration: `${marqueeDurationSec}s` }}
+              >
+                {[...marqueeItems, ...marqueeItems].map((item, index) => (
+                  <Link
+                    key={`${item.squareItemId}-${index}`}
+                    href={`/shop/${item.slug}`}
+                    aria-hidden={index >= marqueeItems.length}
+                    tabIndex={index >= marqueeItems.length ? -1 : undefined}
+                    className="group block w-52 shrink-0 overflow-hidden rounded-[var(--radius-lg)] border border-sky-100 bg-white shadow-[0_8px_20px_rgba(12,74,110,0.08)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_16px_28px_rgba(12,74,110,0.16)]"
+                  >
+                    <div className="relative aspect-square w-full overflow-hidden bg-[var(--color-light)]">
+                      {item.primaryImage ? (
+                        <Image
+                          src={item.primaryImage.url}
+                          alt={item.primaryImage.altText ?? item.name}
+                          fill
+                          sizes="208px"
+                          className="object-cover transition-transform duration-300 group-hover:scale-105"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-subtle)]">
+                          No image
+                        </div>
+                      )}
+                    </div>
+                    <p className="px-3 py-3 text-center text-sm font-semibold leading-snug text-primary">
+                      {item.name}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ShopPreview;

--- a/components/layout/footer/Footer.tsx
+++ b/components/layout/footer/Footer.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState, FormEvent, useEffect } from "react";
 import { motion } from "motion/react";
+import { isValidEmail } from "@/lib/utils/validation";
 
 type DayHours = {
   isClosed?: boolean;
@@ -98,6 +99,13 @@ export default function Footer() {
   const handleSubscribe = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!email) return;
+
+    // Client-side format check (the API validates too) so we don't fire a
+    // request for an obviously-bad address.
+    if (!isValidEmail(email)) {
+      setMessage("Please enter a valid email address.");
+      return;
+    }
 
     setIsSubmitting(true);
     setMessage("");
@@ -263,7 +271,9 @@ export default function Footer() {
             {message && (
               <p
                 className={`mt-2 text-sm ${
-                  message.includes("error") || message.includes("wrong")
+                  message.includes("error") ||
+                  message.includes("wrong") ||
+                  message.includes("valid")
                     ? "text-[var(--color-error)]"
                     : "text-[var(--color-success-text)]"
                 }`}

--- a/components/layout/nav/NavBar.tsx
+++ b/components/layout/nav/NavBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { usePathname } from "next/navigation";
 import { isCheckoutRoute } from "@/lib/utils/isCheckoutRoute";
 import Link from "next/link";
@@ -8,13 +8,15 @@ import Image from "next/image";
 import { motion, AnimatePresence } from "motion/react";
 import CartIcon from "@/components/store/CartIcon";
 import AccountNavLink from "@/components/authentication/AccountNavLink";
+import { useReservations } from "@/hooks/queries";
+import { Reservation } from "@/lib/types/reservationTypes";
 
 interface OfferDropdownItem {
   href: string;
   label: string;
 }
 
-const OFFER_DROPDOWN_ITEMS: OfferDropdownItem[] = [
+const BASE_OFFER_DROPDOWN_ITEMS: OfferDropdownItem[] = [
   { href: "/walk-in", label: "Walk Ins" },
   { href: "/events/classes-workshops", label: "Classes" },
   { href: "/events/private-events", label: "Private Events" },
@@ -23,6 +25,26 @@ const OFFER_DROPDOWN_ITEMS: OfferDropdownItem[] = [
 
 export default function NavBar() {
   const pathname = usePathname();
+  // Hide the "Reservations" entry when there are no active reservations to book
+  // (same future-end-date rule the reservations page uses).
+  const { data: reservationsData = [] } = useReservations();
+  const hasActiveReservations = useMemo(() => {
+    const now = new Date();
+    return (reservationsData as Reservation[]).some((reservation) => {
+      const endDate = reservation.dates.endDate
+        ? new Date(reservation.dates.endDate)
+        : new Date(reservation.dates.startDate);
+      return endDate >= now;
+    });
+  }, [reservationsData]);
+
+  const offerDropdownItems = useMemo(
+    () =>
+      BASE_OFFER_DROPDOWN_ITEMS.filter(
+        (item) => item.href !== "/reservations" || hasActiveReservations
+      ),
+    [hasActiveReservations]
+  );
   // Checkout-style pages render the nav in-flow (relative) instead of fixed, so the
   // sticky order summary isn't overlapped by the nav (see isCheckoutRoute).
   const isCheckout = isCheckoutRoute(pathname);
@@ -266,7 +288,7 @@ export default function NavBar() {
               {/* Desktop Dropdown */}
               <div className="absolute top-full right-0 mt-2 w-56 bg-white/95 backdrop-blur-sm border border-gray-100 rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
                 <div className="py-2">
-                  {OFFER_DROPDOWN_ITEMS.map((item) => (
+                  {offerDropdownItems.map((item) => (
                     <Link
                       key={item.href}
                       href={item.href}
@@ -441,7 +463,7 @@ export default function NavBar() {
                         animate="visible"
                         exit="hidden"
                       >
-                        {OFFER_DROPDOWN_ITEMS.map((item) => (
+                        {offerDropdownItems.map((item) => (
                           <motion.div
                             key={item.href}
                             variants={itemVariants}

--- a/components/reservations/BillingFields.tsx
+++ b/components/reservations/BillingFields.tsx
@@ -2,6 +2,7 @@
 
 import { ReactElement, ChangeEvent } from "react";
 import { BillingInfo } from "./types";
+import { isValidEmail } from "@/lib/utils/validation";
 
 interface BillingFieldsProps {
   billingInfo: BillingInfo;
@@ -10,7 +11,6 @@ interface BillingFieldsProps {
   ) => void;
 }
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_REGEX = /^[\d\s\-\+\(\)]+$/;
 
 export default function BillingFields({
@@ -18,7 +18,7 @@ export default function BillingFields({
   onInputChange,
 }: BillingFieldsProps): ReactElement {
   const validateEmail = (email: string): boolean => {
-    return EMAIL_REGEX.test(email);
+    return isValidEmail(email);
   };
 
   const validatePhone = (phone: string): boolean => {

--- a/components/store/CheckoutField.tsx
+++ b/components/store/CheckoutField.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from "react";
+import { Label } from "@/components/ui";
+
+interface FieldWrapperProps {
+  id: string;
+  label: string;
+  required?: boolean;
+  touched: boolean;
+  error: string | null;
+  value?: string;
+  children: ReactElement;
+}
+
+/** Label + input shell with a valid ✓ and a touched-only error message. */
+export function FieldWrapper({
+  id,
+  label,
+  required,
+  touched,
+  error,
+  value,
+  children,
+}: FieldWrapperProps): ReactElement {
+  const isValid = !!value && !error;
+  return (
+    <div>
+      <Label htmlFor={id} required={required}>
+        {label}
+      </Label>
+      <div className="relative">
+        {children}
+        {isValid && (
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-green-500 text-sm pointer-events-none">
+            ✓
+          </span>
+        )}
+      </div>
+      {touched && error && (
+        <p className="text-[var(--color-error)] text-xs mt-1">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/components/store/CheckoutForm.tsx
+++ b/components/store/CheckoutForm.tsx
@@ -15,6 +15,7 @@ import type { AppliedGiftCard } from "@/components/checkout/eventCheckoutTypes";
 import CartSummary from "@/components/store/CartSummary";
 import { Button } from "@/components/ui";
 import { formatCents } from "@/lib/utils/moneyHelpers";
+import { isValidEmail } from "@/lib/utils/validation";
 import type { ShippingRate } from "@/lib/shippo/rates";
 
 const EMPTY_ADDRESS: AddressFormValues = {
@@ -48,10 +49,12 @@ export default function CheckoutForm(): ReactElement | null {
   const [idempotencyKey] = useState(() => crypto.randomUUID());
 
   // Order total (subtotal + shipping once known) and the card amount due after any
-  // applied gift card. The server re-validates + clamps; this only drives the UI.
+  // applied gift card. Gift cards apply to the PRODUCT SUBTOTAL ONLY — never to
+  // shipping — so the gift-card credit is clamped to the subtotal. The server
+  // re-validates + clamps the same way; this only drives the UI.
   const orderTotalCents = subtotalCents + (selectedRate?.rateCents ?? 0);
   const giftCardCents = appliedGiftCard
-    ? Math.min(appliedGiftCard.amountApplied, orderTotalCents)
+    ? Math.min(appliedGiftCard.amountApplied, subtotalCents)
     : 0;
   const amountDueCents = Math.max(0, orderTotalCents - giftCardCents);
 
@@ -154,7 +157,7 @@ export default function CheckoutForm(): ReactElement | null {
   const addressComplete = Boolean(
     address.firstName.trim() &&
       address.lastName.trim() &&
-      address.email.trim() &&
+      isValidEmail(address.email) &&
       isValidUsPhone(address.phone) &&
       address.addressLine1.trim() &&
       address.city.trim() &&
@@ -280,15 +283,19 @@ export default function CheckoutForm(): ReactElement | null {
               All transactions are secure and encrypted.
             </p>
           </div>
-          {/* Gift card — apply once shipping is known so the total is final. */}
-          {selectedRate && (
+          {/* Gift card — applies to the product subtotal only (never shipping), so it
+              can be entered up front without waiting for a shipping method. */}
+          <div className="flex flex-col gap-1">
             <GiftCardRedemption
-              totalAmount={orderTotalCents}
+              totalAmount={subtotalCents}
               appliedCard={appliedGiftCard}
               onApply={setAppliedGiftCard}
               onRemove={() => setAppliedGiftCard(null)}
             />
-          )}
+            <p className="text-xs text-[var(--color-text-subtle)]">
+              Gift cards apply to items only — shipping is paid at checkout.
+            </p>
+          </div>
 
           {amountDueCents <= 0 && appliedGiftCard && selectedRate ? (
             <>

--- a/components/store/CheckoutForm.tsx
+++ b/components/store/CheckoutForm.tsx
@@ -8,21 +8,29 @@ import { usePaymentConfig } from "@/hooks/queries/use-payment-config";
 import ShippingAddressStep, {
   type AddressFormValues,
 } from "@/components/store/ShippingAddressStep";
+import ContactFields, {
+  type ContactValues,
+} from "@/components/store/ContactFields";
 import PaymentStep from "@/components/checkout/PaymentStep";
 import GiftCardRedemption from "@/components/checkout/GiftCardRedemption";
 import { isValidUsPhone } from "@/components/checkout/ContactForm";
+import { isValidEmail } from "@/lib/utils/validation";
 import type { AppliedGiftCard } from "@/components/checkout/eventCheckoutTypes";
 import CartSummary from "@/components/store/CartSummary";
 import { Button } from "@/components/ui";
 import { formatCents } from "@/lib/utils/moneyHelpers";
-import { isValidEmail } from "@/lib/utils/validation";
 import type { ShippingRate } from "@/lib/shippo/rates";
 
-const EMPTY_ADDRESS: AddressFormValues = {
+const EMPTY_CONTACT: ContactValues = {
   firstName: "",
   lastName: "",
   email: "",
   phone: "",
+};
+
+const EMPTY_SHIPPING: AddressFormValues = {
+  firstName: "",
+  lastName: "",
   addressLine1: "",
   addressLine2: "",
   city: "",
@@ -35,7 +43,13 @@ export default function CheckoutForm(): ReactElement | null {
   const { items, subtotalCents, clearCart } = useCart();
   const { data: paymentConfig } = usePaymentConfig();
 
-  const [address, setAddress] = useState<AddressFormValues>(EMPTY_ADDRESS);
+  // Buyer (payer + receipt) is always `contact`. The shipment goes to `shipping`.
+  // When `isGift`, the buyer collects the recipient's name in the shipping block;
+  // otherwise the shipment is addressed to the buyer.
+  const [contact, setContact] = useState<ContactValues>(EMPTY_CONTACT);
+  const [isGift, setIsGift] = useState(false);
+  const [shipping, setShipping] = useState<AddressFormValues>(EMPTY_SHIPPING);
+
   const [rates, setRates] = useState<ShippingRate[]>([]);
   const [selectedRate, setSelectedRate] = useState<ShippingRate | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -48,22 +62,38 @@ export default function CheckoutForm(): ReactElement | null {
   // charge). A new mount (new cart attempt after clearCart) gets a fresh key.
   const [idempotencyKey] = useState(() => crypto.randomUUID());
 
-  // Order total (subtotal + shipping once known) and the card amount due after any
-  // applied gift card. Gift cards apply to the PRODUCT SUBTOTAL ONLY — never to
-  // shipping — so the gift-card credit is clamped to the subtotal. The server
-  // re-validates + clamps the same way; this only drives the UI.
+  // Recipient name: the buyer's when shipping to self, the entered name when gifting.
+  const recipientFirstName = isGift ? shipping.firstName : contact.firstName;
+  const recipientLastName = isGift ? shipping.lastName : contact.lastName;
+  const recipientName = `${recipientFirstName} ${recipientLastName}`.trim();
+
+  // Gift cards apply to the PRODUCT SUBTOTAL ONLY — never to shipping.
   const orderTotalCents = subtotalCents + (selectedRate?.rateCents ?? 0);
   const giftCardCents = appliedGiftCard
     ? Math.min(appliedGiftCard.amountApplied, subtotalCents)
     : 0;
   const amountDueCents = Math.max(0, orderTotalCents - giftCardCents);
 
-  const updateField = (field: keyof AddressFormValues, value: string): void => {
-    setAddress((prev) => ({ ...prev, [field]: value }));
+  const resetRates = (): void => {
     if (rates.length > 0) {
       setRates([]);
       setSelectedRate(null);
     }
+  };
+
+  const updateContact = (field: keyof ContactValues, value: string): void => {
+    setContact((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const updateShipping = (field: keyof AddressFormValues, value: string): void => {
+    setShipping((prev) => ({ ...prev, [field]: value }));
+    // Address (not name) changes invalidate the quoted rates.
+    if (field !== "firstName" && field !== "lastName") resetRates();
+  };
+
+  const toggleGift = (next: boolean): void => {
+    setIsGift(next);
+    resetRates();
   };
 
   const handleFetchRates = async (): Promise<void> => {
@@ -75,12 +105,12 @@ export default function CheckoutForm(): ReactElement | null {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           destination: {
-            name: `${address.firstName} ${address.lastName}`,
-            street1: address.addressLine1,
-            street2: address.addressLine2 || undefined,
-            city: address.city,
-            state: address.state,
-            zip: address.zip,
+            name: recipientName,
+            street1: shipping.addressLine1,
+            street2: shipping.addressLine2 || undefined,
+            city: shipping.city,
+            state: shipping.state,
+            zip: shipping.zip,
             country: "US",
           },
           cartItems: items.map((i) => ({
@@ -91,7 +121,7 @@ export default function CheckoutForm(): ReactElement | null {
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error ?? "Could not fetch shipping rates. Please check your address.");
+        setError(data.error ?? "Could not fetch shipping rates. Please check the address.");
         return;
       }
       setRates(data.rates);
@@ -114,18 +144,18 @@ export default function CheckoutForm(): ReactElement | null {
         body: JSON.stringify({
           paymentToken: token,
           customer: {
-            firstName: address.firstName,
-            lastName: address.lastName,
-            email: address.email,
-            phone: address.phone || undefined,
+            firstName: contact.firstName,
+            lastName: contact.lastName,
+            email: contact.email,
+            phone: contact.phone || undefined,
           },
           shippingAddress: {
-            name: `${address.firstName} ${address.lastName}`,
-            addressLine1: address.addressLine1,
-            addressLine2: address.addressLine2 || undefined,
-            city: address.city,
-            stateProvince: address.state,
-            postalCode: address.zip,
+            name: recipientName,
+            addressLine1: shipping.addressLine1,
+            addressLine2: shipping.addressLine2 || undefined,
+            city: shipping.city,
+            stateProvince: shipping.state,
+            postalCode: shipping.zip,
             country: "US",
           },
           selectedRate,
@@ -152,22 +182,28 @@ export default function CheckoutForm(): ReactElement | null {
     }
   };
 
-  // All required contact/shipping fields filled — gates rate-fetching AND payment.
-  // Phone is required and must be a valid 10-digit number.
-  const addressComplete = Boolean(
-    address.firstName.trim() &&
-      address.lastName.trim() &&
-      isValidEmail(address.email) &&
-      isValidUsPhone(address.phone) &&
-      address.addressLine1.trim() &&
-      address.city.trim() &&
-      address.state.trim() &&
-      address.zip.trim()
+  // Buyer contact must be valid to pay (and receive the receipt).
+  const contactComplete = Boolean(
+    contact.firstName.trim() &&
+      contact.lastName.trim() &&
+      isValidEmail(contact.email) &&
+      isValidUsPhone(contact.phone)
   );
 
-  // Auto-fetch rates when all required address fields are complete (600ms debounce)
+  // Destination address must be complete; gifting also requires a recipient name.
+  const shippingComplete = Boolean(
+    shipping.addressLine1.trim() &&
+      shipping.city.trim() &&
+      shipping.state.trim() &&
+      shipping.zip.trim() &&
+      (!isGift || (shipping.firstName.trim() && shipping.lastName.trim()))
+  );
+
+  const canPay = contactComplete && shippingComplete;
+
+  // Auto-fetch rates as soon as the destination address is complete (600ms debounce).
   useEffect(() => {
-    if (!addressComplete || rates.length > 0) return;
+    if (!shippingComplete || rates.length > 0) return;
 
     const timer = setTimeout(() => {
       void handleFetchRates();
@@ -176,8 +212,9 @@ export default function CheckoutForm(): ReactElement | null {
     return () => clearTimeout(timer);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    address.firstName, address.lastName, address.email, address.phone,
-    address.addressLine1, address.city, address.state, address.zip,
+    isGift,
+    shipping.addressLine1, shipping.city, shipping.state, shipping.zip,
+    shipping.firstName, shipping.lastName,
   ]);
 
   useEffect(() => {
@@ -194,14 +231,44 @@ export default function CheckoutForm(): ReactElement | null {
       {/* Left column: form (below the summary when stacked, left on desktop) */}
       <div className="order-2 lg:order-1 flex flex-col gap-8 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-white p-6 sm:p-8 shadow-[var(--shadow-card)]">
 
-        {/* Contact & Shipping */}
+        {/* Contact (buyer) */}
         <div className="flex flex-col gap-5">
           <h2 className="text-base font-semibold text-[var(--color-primary)]">
-            Contact &amp; Shipping
+            Your contact details
           </h2>
+          <ContactFields values={contact} onChange={updateContact} />
+        </div>
+
+        <hr className="border-0 border-t border-[var(--color-border)]" />
+
+        {/* Shipping + gift toggle */}
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-base font-semibold text-[var(--color-primary)]">
+              {isGift ? "Ship to recipient" : "Shipping address"}
+            </h2>
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+              <input
+                type="checkbox"
+                checked={isGift}
+                onChange={(e) => toggleGift(e.target.checked)}
+                className="h-4 w-4 cursor-pointer accent-[var(--color-primary)]"
+              />
+              This is a gift — ship to a different address
+            </label>
+          </div>
+
+          {isGift && (
+            <p className="rounded-[var(--radius-md)] bg-[var(--color-light)] px-3 py-2 text-xs text-[var(--color-text-subtle)]">
+              We&apos;ll ship to the recipient below. Your order confirmation and
+              receipt come to you.
+            </p>
+          )}
+
           <ShippingAddressStep
-            values={address}
-            onChange={updateField}
+            values={shipping}
+            onChange={updateShipping}
+            collectName={isGift}
             isLoading={isLoading}
             error={null}
           />
@@ -264,8 +331,8 @@ export default function CheckoutForm(): ReactElement | null {
           {!isLoading && rates.length === 0 && (
             <div className="rounded-[var(--radius-lg)] border-2 border-dashed border-[var(--color-border-lighter)] px-4 py-6 text-center text-sm text-[var(--color-text-subtle)]">
               {error
-                ? "We couldn't load shipping options — please check your address above."
-                : "Enter your address above to see shipping options."}
+                ? "We couldn't load shipping options — please check the address above."
+                : "Enter the shipping address above to see shipping options."}
             </div>
           )}
         </div>
@@ -306,7 +373,7 @@ export default function CheckoutForm(): ReactElement | null {
               )}
               <Button
                 variant="primary"
-                disabled={isProcessing}
+                disabled={isProcessing || !canPay}
                 onClick={() => void placeOrder()}
               >
                 {isProcessing ? "Placing order…" : "Place order with gift card"}
@@ -317,7 +384,7 @@ export default function CheckoutForm(): ReactElement | null {
               applicationId={paymentConfig.applicationId}
               locationId={paymentConfig.locationId}
               amountDollars={selectedRate ? (amountDueCents / 100).toFixed(2) : null}
-              ready={addressComplete && !!selectedRate}
+              ready={canPay && !!selectedRate}
               onToken={placeOrder}
               isProcessing={isProcessing}
               error={error}

--- a/components/store/ContactFields.tsx
+++ b/components/store/ContactFields.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Input } from "@/components/ui";
+import { FieldWrapper } from "./CheckoutField";
+import { formatUsPhone, isValidUsPhone } from "@/components/checkout/ContactForm";
+import { isValidEmail } from "@/lib/utils/validation";
+
+export interface ContactValues {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+}
+
+interface ContactFieldsProps {
+  values: ContactValues;
+  onChange: (field: keyof ContactValues, value: string) => void;
+}
+
+function contactError(field: keyof ContactValues, value: string): string | null {
+  if (!value.trim()) return "Required";
+  if (field === "email" && !isValidEmail(value)) return "Enter a valid email address";
+  if (field === "phone" && !isValidUsPhone(value)) return "Enter a 10-digit phone number";
+  return null;
+}
+
+/** Buyer contact details — the person paying and receiving the receipt. */
+export default function ContactFields({
+  values,
+  onChange,
+}: ContactFieldsProps): ReactElement {
+  const [touched, setTouched] = useState<
+    Partial<Record<keyof ContactValues, boolean>>
+  >({});
+
+  const touch = (field: keyof ContactValues): void =>
+    setTouched((prev) => ({ ...prev, [field]: true }));
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="grid grid-cols-2 gap-4">
+        <FieldWrapper
+          id="contact-email"
+          label="Email Address"
+          required
+          touched={!!touched.email}
+          error={contactError("email", values.email)}
+          value={values.email}
+        >
+          <Input
+            id="contact-email"
+            type="email"
+            autoComplete="email"
+            value={values.email}
+            onChange={(e) => onChange("email", e.target.value)}
+            onBlur={() => touch("email")}
+          />
+        </FieldWrapper>
+
+        <FieldWrapper
+          id="contact-phone"
+          label="Phone"
+          required
+          touched={!!touched.phone}
+          error={contactError("phone", values.phone)}
+          value={values.phone}
+        >
+          <Input
+            id="contact-phone"
+            type="tel"
+            inputMode="tel"
+            autoComplete="tel"
+            placeholder="(555) 555-5555"
+            maxLength={14}
+            value={values.phone}
+            onChange={(e) => onChange("phone", formatUsPhone(e.target.value))}
+            onBlur={() => touch("phone")}
+          />
+        </FieldWrapper>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <FieldWrapper
+          id="contact-firstName"
+          label="First Name"
+          required
+          touched={!!touched.firstName}
+          error={contactError("firstName", values.firstName)}
+          value={values.firstName}
+        >
+          <Input
+            id="contact-firstName"
+            autoComplete="given-name"
+            value={values.firstName}
+            onChange={(e) => onChange("firstName", e.target.value)}
+            onBlur={() => touch("firstName")}
+          />
+        </FieldWrapper>
+
+        <FieldWrapper
+          id="contact-lastName"
+          label="Last Name"
+          required
+          touched={!!touched.lastName}
+          error={contactError("lastName", values.lastName)}
+          value={values.lastName}
+        >
+          <Input
+            id="contact-lastName"
+            autoComplete="family-name"
+            value={values.lastName}
+            onChange={(e) => onChange("lastName", e.target.value)}
+            onBlur={() => touch("lastName")}
+          />
+        </FieldWrapper>
+      </div>
+    </div>
+  );
+}

--- a/components/store/ShippingAddressStep.tsx
+++ b/components/store/ShippingAddressStep.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from "react";
 import { useState } from "react";
 import { Input, Label } from "@/components/ui";
 import { formatUsPhone, isValidUsPhone } from "@/components/checkout/ContactForm";
+import { isValidEmail } from "@/lib/utils/validation";
 
 export interface AddressFormValues {
   firstName: string;
@@ -37,7 +38,7 @@ const REQUIRED_FIELDS: (keyof AddressFormValues)[] = [
 
 function validateField(field: keyof AddressFormValues, value: string): string | null {
   if (REQUIRED_FIELDS.includes(field) && !value.trim()) return "Required";
-  if (field === "email" && value.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
+  if (field === "email" && value.trim() && !isValidEmail(value))
     return "Enter a valid email address";
   if (field === "zip" && value.trim() && !/^\d{5}(-\d{4})?$/.test(value))
     return "Enter a valid ZIP code";

--- a/components/store/ShippingAddressStep.tsx
+++ b/components/store/ShippingAddressStep.tsx
@@ -3,14 +3,11 @@
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { Input, Label } from "@/components/ui";
-import { formatUsPhone, isValidUsPhone } from "@/components/checkout/ContactForm";
-import { isValidEmail } from "@/lib/utils/validation";
+import { FieldWrapper } from "./CheckoutField";
 
 export interface AddressFormValues {
   firstName: string;
   lastName: string;
-  email: string;
-  phone: string;
   addressLine1: string;
   addressLine2: string;
   city: string;
@@ -23,6 +20,10 @@ interface ShippingAddressStepProps {
   onChange: (field: keyof AddressFormValues, value: string) => void;
   isLoading: boolean;
   error: string | null;
+  /** When true, collect the recipient's name (gift / ship-to-someone-else). */
+  collectName?: boolean;
+  /** Label used for the recipient name fields. */
+  nameLabelPrefix?: string;
 }
 
 const US_STATES = [
@@ -32,49 +33,13 @@ const US_STATES = [
   "VA","WA","WV","WI","WY",
 ];
 
-const REQUIRED_FIELDS: (keyof AddressFormValues)[] = [
-  "firstName","lastName","email","phone","addressLine1","city","state","zip",
-];
-
 function validateField(field: keyof AddressFormValues, value: string): string | null {
-  if (REQUIRED_FIELDS.includes(field) && !value.trim()) return "Required";
-  if (field === "email" && value.trim() && !isValidEmail(value))
-    return "Enter a valid email address";
-  if (field === "zip" && value.trim() && !/^\d{5}(-\d{4})?$/.test(value))
+  // firstName/lastName/addressLine2 are validated/optional by the caller via collectName.
+  if (field === "addressLine2") return null;
+  if (!value.trim()) return "Required";
+  if (field === "zip" && !/^\d{5}(-\d{4})?$/.test(value))
     return "Enter a valid ZIP code";
-  if (field === "phone" && value.trim() && !isValidUsPhone(value))
-    return "Enter a 10-digit phone number";
   return null;
-}
-
-interface FieldWrapperProps {
-  id: string;
-  label: string;
-  required?: boolean;
-  touched: boolean;
-  error: string | null;
-  value?: string;
-  children: ReactElement;
-}
-
-function FieldWrapper({ id, label, required, touched, error, value, children }: FieldWrapperProps): ReactElement {
-  const isValid = !!value && !error;
-  return (
-    <div>
-      <Label htmlFor={id} required={required}>{label}</Label>
-      <div className="relative">
-        {children}
-        {isValid && (
-          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-green-500 text-sm pointer-events-none">
-            ✓
-          </span>
-        )}
-      </div>
-      {touched && error && (
-        <p className="text-[var(--color-error)] text-xs mt-1">{error}</p>
-      )}
-    </div>
-  );
 }
 
 export default function ShippingAddressStep({
@@ -82,6 +47,8 @@ export default function ShippingAddressStep({
   onChange,
   isLoading,
   error,
+  collectName = false,
+  nameLabelPrefix = "Recipient",
 }: ShippingAddressStepProps): ReactElement {
   const [touched, setTouched] = useState<Partial<Record<keyof AddressFormValues, boolean>>>({});
 
@@ -97,77 +64,31 @@ export default function ShippingAddressStep({
 
   return (
     <div className="flex flex-col gap-5">
-      {/* Email + Phone on top for a cleaner contact row */}
-      <div className="grid grid-cols-2 gap-4">
-        <FieldWrapper
-          id="email"
-          label="Email Address"
-          required
-          touched={!!touched.email}
-          error={validateField("email", values.email)}
-          value={values.email}
-        >
-          <Input
-            id="email"
-            type="email"
-            autoComplete="email"
-            {...fieldProps("email")}
-          />
-        </FieldWrapper>
+      {collectName && (
+        <div className="grid grid-cols-2 gap-4">
+          <FieldWrapper
+            id="ship-firstName"
+            label={`${nameLabelPrefix} First Name`}
+            required
+            touched={!!touched.firstName}
+            error={validateField("firstName", values.firstName)}
+            value={values.firstName}
+          >
+            <Input id="ship-firstName" autoComplete="off" {...fieldProps("firstName")} />
+          </FieldWrapper>
 
-        <FieldWrapper
-          id="phone"
-          label="Phone"
-          required
-          touched={!!touched.phone}
-          error={validateField("phone", values.phone)}
-          value={values.phone}
-        >
-          <Input
-            id="phone"
-            type="tel"
-            inputMode="tel"
-            autoComplete="tel"
-            placeholder="(555) 555-5555"
-            maxLength={14}
-            value={values.phone}
-            onChange={(e) => onChange("phone", formatUsPhone(e.target.value))}
-            onBlur={() => touch("phone")}
-          />
-        </FieldWrapper>
-      </div>
-
-      <div className="grid grid-cols-2 gap-4">
-        <FieldWrapper
-          id="firstName"
-          label="First Name"
-          required
-          touched={!!touched.firstName}
-          error={validateField("firstName", values.firstName)}
-          value={values.firstName}
-        >
-          <Input
-            id="firstName"
-            autoComplete="given-name"
-            {...fieldProps("firstName")}
-          />
-        </FieldWrapper>
-
-        <FieldWrapper
-          id="lastName"
-          label="Last Name"
-          required
-          touched={!!touched.lastName}
-          error={validateField("lastName", values.lastName)}
-          value={values.lastName}
-        >
-          <Input
-            id="lastName"
-            autoComplete="family-name"
-            {...fieldProps("lastName")}
-          />
-        </FieldWrapper>
-      </div>
+          <FieldWrapper
+            id="ship-lastName"
+            label={`${nameLabelPrefix} Last Name`}
+            required
+            touched={!!touched.lastName}
+            error={validateField("lastName", values.lastName)}
+            value={values.lastName}
+          >
+            <Input id="ship-lastName" autoComplete="off" {...fieldProps("lastName")} />
+          </FieldWrapper>
+        </div>
+      )}
 
       <FieldWrapper
         id="addressLine1"
@@ -177,11 +98,7 @@ export default function ShippingAddressStep({
         error={validateField("addressLine1", values.addressLine1)}
         value={values.addressLine1}
       >
-        <Input
-          id="addressLine1"
-          autoComplete="address-line1"
-          {...fieldProps("addressLine1")}
-        />
+        <Input id="addressLine1" autoComplete="address-line1" {...fieldProps("addressLine1")} />
       </FieldWrapper>
 
       <div>
@@ -203,11 +120,7 @@ export default function ShippingAddressStep({
           error={validateField("city", values.city)}
           value={values.city}
         >
-          <Input
-            id="city"
-            autoComplete="address-level2"
-            {...fieldProps("city")}
-          />
+          <Input id="city" autoComplete="address-level2" {...fieldProps("city")} />
         </FieldWrapper>
 
         <div>
@@ -247,12 +160,7 @@ export default function ShippingAddressStep({
           error={validateField("zip", values.zip)}
           value={values.zip}
         >
-          <Input
-            id="zip"
-            autoComplete="postal-code"
-            maxLength={10}
-            {...fieldProps("zip")}
-          />
+          <Input id="zip" autoComplete="postal-code" maxLength={10} {...fieldProps("zip")} />
         </FieldWrapper>
       </div>
 

--- a/components/store/ShopGiftCardCTA.tsx
+++ b/components/store/ShopGiftCardCTA.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+/**
+ * Gift-card nudge shown beneath the shop grid: for the shopper who can't decide
+ * on a specific item, point them at a gift card (usable in store + at events).
+ */
+export default function ShopGiftCardCTA(): ReactElement {
+  return (
+    <section className="bg-transparent py-10 md:py-14">
+      <div className="mx-auto w-full max-w-[var(--container-max)] px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col items-center gap-8 rounded-[2rem] border border-sky-100 bg-[var(--color-light)] px-6 py-10 text-center shadow-[0_10px_24px_rgba(12,74,110,0.08)] md:flex-row md:gap-12 md:px-12 md:text-left">
+          {/* Coastal Creations gift card visual */}
+          <div className="w-full max-w-[18rem] shrink-0 rounded-2xl border border-sky-100 bg-white p-3 shadow-[0_14px_24px_rgba(12,74,110,0.14)]">
+            <div className="rounded-xl border border-slate-200 bg-[linear-gradient(155deg,#ffffff_0%,#f3f9fd_70%,#e7f3fa_100%)] p-6">
+              <div className="mb-5 flex justify-center">
+                <Image
+                  src="/assets/logos/coastalLogoFull.png"
+                  alt="Coastal Creations Studio logo"
+                  width={160}
+                  height={62}
+                  className="h-auto w-auto object-contain"
+                />
+              </div>
+              <div className="space-y-1.5 text-center">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-secondary">
+                  Digital Gift Card
+                </p>
+                <p className="text-lg font-bold text-primary">
+                  Coastal Creations Studio
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Copy + CTA */}
+          <div className="flex flex-col items-center gap-4 md:items-start">
+            <h2 className="text-2xl font-bold text-[var(--color-primary)] md:text-3xl">
+              Tough to buy for? Let them choose.
+            </h2>
+            <p className="max-w-xl text-base leading-relaxed text-[var(--color-text-muted)] md:text-lg">
+              A Coastal Creations gift card is always the right fit — use it here
+              in the shop, or for classes, camps, workshops, and walk-in studio
+              time.
+            </p>
+            <Link
+              href="/gift-cards"
+              className="inline-flex h-12 items-center justify-center gap-2 rounded-[var(--radius-default)] bg-[var(--color-primary)] px-6 text-base font-medium text-white transition-all duration-300 hover:-translate-y-0.5 hover:bg-[var(--color-primary-dark)] hover:shadow-lg"
+            >
+              Buy a Gift Card
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/walk-in/WalkIn.tsx
+++ b/components/walk-in/WalkIn.tsx
@@ -1,34 +1,12 @@
 "use client";
 
 import type { ReactElement } from "react";
-import Link from "next/link";
-import { motion } from "motion/react";
-import { FaEnvelope } from "react-icons/fa";
-import { Button } from "@/components/ui";
 import WalkInCard from "./WalkInCard";
 import WalkInImageSlot from "./WalkInImageSlot";
 
 export default function WalkIn(): ReactElement {
-  const studioEmail =
-    process.env.NEXT_PUBLIC_STUDIO_EMAIL ||
-    "info@coastalcreationsstudio.com";
-
   return (
-    <section
-      className="relative overflow-hidden py-12 md:py-20"
-      style={{
-        background:
-          "linear-gradient(180deg, #f0f9ff 0%, #e0f2fe 55%, #f0f9ff 100%)",
-      }}
-    >
-      <div
-        className="pointer-events-none absolute inset-0 opacity-60"
-        style={{
-          background:
-            "radial-gradient(circle at 10% 0%, rgba(125,211,252,0.25), transparent 45%), radial-gradient(circle at 90% 100%, rgba(251,146,60,0.18), transparent 45%)",
-        }}
-      />
-
+    <section className="relative overflow-hidden py-12 md:py-20">
       <div className="container relative mx-auto px-4">
         <div className="mx-auto max-w-5xl space-y-8 md:space-y-12">
           <WalkInCard
@@ -111,43 +89,6 @@ export default function WalkIn(): ReactElement {
             }
           />
         </div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: "-80px" }}
-          transition={{ duration: 0.55, ease: "easeOut" }}
-          className="mx-auto mt-12 max-w-3xl rounded-3xl bg-white/80 p-8 text-center shadow-[0_10px_30px_rgba(12,74,110,0.1)] ring-1 ring-[var(--color-border-lighter)] backdrop-blur md:mt-16 md:p-10"
-        >
-          <div className="mb-3 flex items-center justify-center text-[var(--color-secondary)]">
-            <FaEnvelope className="text-2xl md:text-3xl" />
-          </div>
-          <h3
-            className="mb-3 text-xl font-bold text-[var(--color-primary)] md:text-2xl"
-            style={{ fontFamily: "var(--font-eb-garamond), serif" }}
-          >
-            Ready to drop in?
-          </h3>
-          <p
-            className="mx-auto mb-6 max-w-xl text-sm text-[var(--color-text-muted)] md:text-base"
-            style={{ fontFamily: "var(--font-montserrat), sans-serif" }}
-          >
-            Walk-ins are welcome during studio hours. Have a question first?
-            Reach out and we will be happy to help plan your visit.
-          </p>
-          <div className="flex flex-wrap items-center justify-center gap-3">
-            <Link href="/contact-us">
-              <Button variant="pill" size="md">
-                Contact the Studio
-              </Button>
-            </Link>
-            <a href={`mailto:${studioEmail}`}>
-              <Button variant="ghost" size="md">
-                {studioEmail}
-              </Button>
-            </a>
-          </div>
-        </motion.div>
       </div>
     </section>
   );

--- a/e2e/checkout-gift.spec.ts
+++ b/e2e/checkout-gift.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+
+// Seed a cart in localStorage (key cc_cart) before the app hydrates, then reach
+// checkout via the cart's "Proceed to Checkout" link (client nav keeps cart
+// state — a hard nav to /checkout can bounce to /cart before hydration).
+const CART_ITEM = {
+  squareCatalogItemId: "item_e2e",
+  squareVariationId: "var_e2e",
+  productName: "Test Art Kit",
+  variationName: "Regular",
+  priceCents: 5000,
+  imageUrl: "",
+  imageAlt: "Test Art Kit",
+  slug: "test-art-kit-item_e2e",
+  quantity: 1,
+  maxQuantity: 5,
+};
+
+test.describe("store checkout — gift shipping", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((item) => {
+      window.localStorage.setItem("cc_cart", JSON.stringify([item]));
+    }, CART_ITEM);
+  });
+
+  test("gift toggle reveals recipient fields and switches the heading", async ({ page }) => {
+    await page.goto("/cart");
+    await page.getByRole("button", { name: /proceed to checkout/i }).click();
+    await expect(page).toHaveURL(/\/checkout/);
+
+    await expect(page.getByRole("heading", { name: "Your contact details" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Shipping address" })).toBeVisible();
+    await expect(page.getByText("Recipient First Name")).toHaveCount(0);
+
+    await page.getByRole("checkbox", { name: /this is a gift/i }).check();
+
+    await expect(page.getByRole("heading", { name: "Ship to recipient" })).toBeVisible();
+    await expect(page.getByText("Recipient First Name")).toBeVisible();
+    await expect(page.getByText("Recipient Last Name")).toBeVisible();
+  });
+});

--- a/e2e/contact-validation.spec.ts
+++ b/e2e/contact-validation.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+// The contact form adds a stricter email check on top of the browser's native
+// type="email" validation. "a@b" passes native validation (has an @) but fails
+// our regex (no TLD), so it exercises the app's own inline error.
+test("contact form blocks a malformed email with an inline error", async ({ page }) => {
+  await page.goto("/contact-us");
+
+  await page.locator("#name").fill("Test Person");
+  await page.locator("#email").fill("a@b");
+  await page.locator("#subject").fill("Hello");
+  await page.locator("#description").fill("Just testing the form.");
+
+  await page.getByRole("button", { name: /send message/i }).click();
+
+  await expect(page.getByText("Enter a valid email address.")).toBeVisible();
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+// Smoke test: the key public pages render and the nav works.
+test("home page renders and key pages are reachable", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/Coastal Creations/i);
+
+  for (const path of ["/about", "/shop", "/gift-cards", "/calendar"]) {
+    const res = await page.goto(path);
+    expect(res?.status(), `${path} should respond OK`).toBeLessThan(400);
+    // Each page has a visible <h1>/<h2> heading once rendered.
+    await expect(page.locator("h1, h2").first()).toBeVisible();
+  }
+});

--- a/lib/email/recipients.ts
+++ b/lib/email/recipients.ts
@@ -1,0 +1,46 @@
+/**
+ * Centralized transactional-email recipient routing.
+ *
+ * In production, customer emails go to the customer and admin emails go to
+ * STUDIO_EMAIL (with a hard fallback). In dev/stage, EVERYTHING redirects to
+ * DEV_EMAIL so we never email real customers from a non-prod environment.
+ *
+ * This is the single source of truth — every send site should call it instead
+ * of re-deriving the prod/dev branch inline (which had drifted across routes).
+ */
+
+/** Hard fallback admin recipient if STUDIO_EMAIL is somehow unset in prod. */
+export const FALLBACK_STUDIO_EMAIL = "ashley@coastalcreationsstudio.com";
+
+/** Standard FROM header for all transactional email. */
+export const EMAIL_FROM =
+  "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>";
+
+export interface EmailRecipients {
+  customer: string;
+  admin: string;
+}
+
+/**
+ * Resolve the customer + admin recipients for a transactional email.
+ * @param customerEmail the real customer address (used in prod / as a last resort)
+ */
+export function resolveEmailRecipients(
+  customerEmail: string | null | undefined
+): EmailRecipients {
+  const isProduction = process.env.VERCEL_ENV === "production";
+  const customer = customerEmail ?? "";
+
+  // Use `||` so an empty-string env var (a misconfiguration) is treated as unset.
+  if (isProduction) {
+    return {
+      customer,
+      admin: process.env.STUDIO_EMAIL || FALLBACK_STUDIO_EMAIL,
+    };
+  }
+
+  // dev / stage: redirect both to DEV_EMAIL (falling back to the customer email
+  // only if DEV_EMAIL is not configured).
+  const devEmail = process.env.DEV_EMAIL || customer;
+  return { customer: devEmail, admin: devEmail };
+}

--- a/lib/email/sendBookingConfirmation.ts
+++ b/lib/email/sendBookingConfirmation.ts
@@ -19,9 +19,10 @@ import { CustomerDetailsTemplate } from "@/components/email-templates/CustomerDe
 import { connectMongo } from "@/lib/mongoose";
 import Customer from "@/lib/models/Customer";
 import Event from "@/lib/models/Event";
+import { resolveEmailRecipients, EMAIL_FROM } from "@/lib/email/recipients";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
-const FROM = "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>";
+const FROM = EMAIL_FROM;
 
 export async function sendBookingConfirmationEmails(
   customerId: string,
@@ -45,13 +46,8 @@ export async function sendBookingConfirmationEmails(
     const event = JSON.parse(JSON.stringify(eventDoc));
     const eventTitle = event.eventName || "your event";
 
-    const isProduction = process.env.VERCEL_ENV === "production";
-    const customerRecipient = isProduction
-      ? customerDoc.billingInfo.emailAddress
-      : process.env.DEV_EMAIL;
-    const adminRecipient = isProduction
-      ? process.env.STUDIO_EMAIL
-      : process.env.DEV_EMAIL;
+    const { customer: customerRecipient, admin: adminRecipient } =
+      resolveEmailRecipients(customerDoc.billingInfo.emailAddress);
 
     // Customer email only when they gave an address and we have a recipient.
     if (customerDoc.billingInfo.emailAddress && customerRecipient) {

--- a/lib/email/sendRefundConfirmation.ts
+++ b/lib/email/sendRefundConfirmation.ts
@@ -15,22 +15,18 @@ import {
   RefundConfirmationEmail,
   type RefundConfirmationData,
 } from "@/components/email-templates/RefundConfirmationEmail";
+import { resolveEmailRecipients, EMAIL_FROM } from "@/lib/email/recipients";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
-const FROM = "Coastal Creations Studio <no-reply@resend.coastalcreationsstudio.com>";
+const FROM = EMAIL_FROM;
 
 export async function sendRefundConfirmation(params: {
   customerEmail?: string | null;
   data: RefundConfirmationData;
 }): Promise<void> {
   try {
-    const isProduction = process.env.VERCEL_ENV === "production";
-    const customerRecipient = isProduction
-      ? params.customerEmail
-      : (process.env.DEV_EMAIL ?? params.customerEmail);
-    const adminRecipient = isProduction
-      ? (process.env.STUDIO_EMAIL ?? "ashley@coastalcreationsstudio.com")
-      : (process.env.DEV_EMAIL ?? params.customerEmail);
+    const { customer: customerRecipient, admin: adminRecipient } =
+      resolveEmailRecipients(params.customerEmail);
 
     const html = await render(
       React.createElement(RefundConfirmationEmail, { data: params.data })

--- a/lib/types/eventTypes.ts
+++ b/lib/types/eventTypes.ts
@@ -3,6 +3,8 @@
  * @module lib/types/eventTypes
  */
 
+import { isValidEmail } from "@/lib/utils/validation";
+
 /**
  * Event type enumeration.
  */
@@ -157,8 +159,7 @@ export const validators = {
 
   email: (value: string | undefined): string | null => {
     if (!value) return null;
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(value)) {
+    if (!isValidEmail(value)) {
       return "Invalid email address";
     }
     return null;

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared input validation helpers.
+ *
+ * The project has no validation library (no zod / react-hook-form / yup) — keep
+ * validation custom but CENTRALIZED here so every email entry across the app
+ * (forms + API routes) uses the exact same rule instead of duplicated regexes.
+ */
+
+/** Pragmatic email shape check: non-empty local part @ domain . tld, no spaces. */
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** True when `value` is a syntactically valid email address (trimmed). */
+export function isValidEmail(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return EMAIL_REGEX.test(value.trim());
+}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "coastal-creations-app",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.23.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config — follows the Next.js E2E guide
+ * (https://nextjs.org/docs/app/guides/testing/playwright).
+ *
+ * Runs the specs against a PRODUCTION build (`next build && next start`) via the
+ * webServer block, which is what the guide recommends to mirror real behavior.
+ * Locally it reuses an already-running dev server if you have one.
+ */
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "list" : "html",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm build && pnpm start",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,7 +9,8 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
     include: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
-    exclude: ["node_modules", ".next", "dist"],
+    // Playwright specs live in e2e/ (.spec.ts) and must NOT be collected by Vitest.
+    exclude: ["node_modules", ".next", "dist", "e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary
Targets **stage** (`develop`). Bundles this session's work: the new gift-shipping checkout, a round of payment/shipping/gift-card correctness fixes, a comprehensive Vitest suite, Playwright E2E, and a GitHub Actions CI gate. Also includes the prior landing/about/shop/calendar UI polish on this branch.

## Gift shipping (buyer pays, ships to a recipient)
- Store checkout split into a buyer **Contact** section + a **Shipping address** with a "this is a gift — ship to a different address" toggle that reveals recipient name fields.
- Square payment's ship-to name is now the **recipient** (not the buyer); the payer/receipt stays the buyer. Verified end-to-end against the Square **sandbox**.

## Correctness fixes
- **Refunds**: reject synthetic/missing payment ids (`FREE-EVENT` / `GIFTCARD-…` / none) before calling Square.
- **Shippo webhook**: fail closed when `SHIPPO_WEBHOOK_SECRET` is unset.
- **Email routing**: centralized prod/dev recipient + FROM into `lib/email/recipients.ts`, adopted across store checkout, the webhook, and booking/refund emails.

## Tests
- Vitest route-handler + unit suites (per the Next.js Vitest guide): store checkout, shippo webhook, gift cards, refunds, reservation availability, email recipients, email validation. Fixed pre-existing stale fixture type errors. **318 tests passing**, `tsc --noEmit` clean.
- Playwright E2E (per the Next.js Playwright guide): navigation, gift-toggle checkout, contact validation — run against a production build.

## CI
- `.github/workflows/ci.yml`: required **verify** job (lint → typecheck → test → build) on PRs/pushes to `develop`/`main`, plus a **non-blocking** Playwright job. Build runs with non-secret placeholder env (real secrets stay in Vercel).

## After merge / before prod
- Protect `develop` requiring the **`verify`** check (add the same on `main` when prod is ready).
- A3 (webhook fail-closed) requires `SHIPPO_WEBHOOK_SECRET` present in each environment — already set on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)