### PR TITLE
Customer accounts: Square Cards on File, receipts on every checkout, and email upgrades

### DIFF
--- a/__tests__/account/scoping.test.ts
+++ b/__tests__/account/scoping.test.ts
@@ -20,6 +20,7 @@ import {
   getMyOrders,
   getMyOrderByNumber,
   getMyBookings,
+  getLatestOrderForPrefill,
 } from "@/lib/account/queries";
 
 // .sort() may be followed by .lean() (orders) or .populate().lean() (bookings).
@@ -66,5 +67,32 @@ describe("account queries are scoped to the session email", () => {
     findOneMock.mockReturnValue(leanable(null)); // DB finds nothing for this email+number
     const result = await getMyOrderByNumber("notmine@x.com", "CC-SOMEONE-ELSE");
     expect(result).toBeNull();
+  });
+
+  it("getMyOrders matches the stamped userId OR the email when a userId is given", async () => {
+    findMock.mockReturnValue(sortable([]));
+    await getMyOrders("USER@Example.com", "u123");
+    const filter = findMock.mock.calls[0][0];
+    // Owns the order via either the durable userId stamp or a legacy/guest email match.
+    expect(filter.$or).toHaveLength(2);
+    expect(filter.$or[0]).toEqual({ userId: "u123" });
+    expect(filter.$or[1]["customer.email"].$regex).toBe("^user@example\\.com$");
+  });
+
+  it("getMyOrderByNumber scopes by orderNumber AND (userId OR email)", async () => {
+    findOneMock.mockReturnValue(leanable(null));
+    await getMyOrderByNumber("owner@x.com", "CC-ABC-123", "u9");
+    const filter = findOneMock.mock.calls[0][0];
+    expect(filter.orderNumber).toBe("CC-ABC-123");
+    expect(filter.$or[0]).toEqual({ userId: "u9" });
+    expect(filter.$or[1]["customer.email"].$regex).toBe("^owner@x\\.com$");
+  });
+
+  it("getLatestOrderForPrefill matches userId OR email, scoped to the caller", async () => {
+    findOneMock.mockReturnValue(sortable(null));
+    await getLatestOrderForPrefill("p@x.com", "u1");
+    const filter = findOneMock.mock.calls[0][0];
+    expect(filter.$or[0]).toEqual({ userId: "u1" });
+    expect(filter.$or[1]["customer.email"].$regex).toBe("^p@x\\.com$");
   });
 });

--- a/__tests__/cards/cardsRoutes.test.ts
+++ b/__tests__/cards/cardsRoutes.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+// --- Mock auth + Square dependencies ---
+const requireUser = vi.fn();
+vi.mock("@/lib/auth/guards", () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+const listCards = vi.fn();
+const createCard = vi.fn();
+const getCard = vi.fn();
+const disableCard = vi.fn();
+vi.mock("@/lib/square/cards", () => ({
+  squareCardService: {
+    listCards: (...a: unknown[]) => listCards(...a),
+    createCard: (...a: unknown[]) => createCard(...a),
+    getCard: (...a: unknown[]) => getCard(...a),
+    disableCard: (...a: unknown[]) => disableCard(...a),
+  },
+}));
+
+const resolveUserSquareCustomerId = vi.fn();
+vi.mock("@/lib/square/userCustomer", () => ({
+  resolveUserSquareCustomerId: (...a: unknown[]) =>
+    resolveUserSquareCustomerId(...a),
+}));
+
+import { GET, POST } from "@/app/api/account/cards/route";
+import { DELETE } from "@/app/api/account/cards/[cardId]/route";
+
+const USER = { id: "user_1", email: "u@example.com", isAdmin: false, role: "customer" };
+const UNAUTH = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+function postReq(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/account/cards", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUser.mockResolvedValue(USER);
+});
+
+describe("GET /api/account/cards", () => {
+  it("401s when not signed in", async () => {
+    requireUser.mockResolvedValue(UNAUTH);
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(listCards).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when the user has no Square customer yet", async () => {
+    resolveUserSquareCustomerId.mockResolvedValue(null);
+    const res = await GET();
+    const data = await res.json();
+    expect(data.cards).toEqual([]);
+    expect(listCards).not.toHaveBeenCalled();
+  });
+
+  it("lists the user's saved cards", async () => {
+    resolveUserSquareCustomerId.mockResolvedValue("sqcust_1");
+    listCards.mockResolvedValue([{ id: "ccof:1", brand: "VISA", last4: "1111" }]);
+    const res = await GET();
+    const data = await res.json();
+    expect(listCards).toHaveBeenCalledWith("sqcust_1");
+    expect(data.cards).toHaveLength(1);
+  });
+});
+
+describe("POST /api/account/cards", () => {
+  it("401s when not signed in", async () => {
+    requireUser.mockResolvedValue(UNAUTH);
+    const res = await POST(postReq({ sourceId: "cnon:x" }));
+    expect(res.status).toBe(401);
+    expect(createCard).not.toHaveBeenCalled();
+  });
+
+  it("400s when the card token is missing", async () => {
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+    expect(createCard).not.toHaveBeenCalled();
+  });
+
+  it("saves the card under the user's (created-if-missing) customer and passes the user id as reference", async () => {
+    resolveUserSquareCustomerId.mockResolvedValue("sqcust_1");
+    createCard.mockResolvedValue({ id: "ccof:1", brand: "VISA", last4: "1111" });
+
+    const res = await POST(
+      postReq({ sourceId: "cnon:x", verificationToken: "v1", cardholderName: "Pat" })
+    );
+    expect(res.status).toBe(201);
+    expect(resolveUserSquareCustomerId).toHaveBeenCalledWith(USER, {
+      createIfMissing: true,
+    });
+    const arg = createCard.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      sourceId: "cnon:x",
+      customerId: "sqcust_1",
+      verificationToken: "v1",
+      cardholderName: "Pat",
+      referenceId: "user_1",
+    });
+  });
+});
+
+describe("DELETE /api/account/cards/[cardId]", () => {
+  const ctx = (cardId: string) => ({ params: Promise.resolve({ cardId }) });
+
+  it("401s when not signed in", async () => {
+    requireUser.mockResolvedValue(UNAUTH);
+    const res = await DELETE(new Request("http://localhost"), ctx("ccof:1"));
+    expect(res.status).toBe(401);
+    expect(disableCard).not.toHaveBeenCalled();
+  });
+
+  it("404s and does NOT disable a card owned by a different customer", async () => {
+    resolveUserSquareCustomerId.mockResolvedValue("sqcust_1");
+    getCard.mockResolvedValue({ id: "ccof:1", customerId: "sqcust_OTHER" });
+
+    const res = await DELETE(new Request("http://localhost"), ctx("ccof:1"));
+    expect(res.status).toBe(404);
+    expect(disableCard).not.toHaveBeenCalled();
+  });
+
+  it("disables a card the user owns", async () => {
+    resolveUserSquareCustomerId.mockResolvedValue("sqcust_1");
+    getCard.mockResolvedValue({ id: "ccof:1", customerId: "sqcust_1" });
+    disableCard.mockResolvedValue(true);
+
+    const res = await DELETE(new Request("http://localhost"), ctx("ccof:1"));
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(disableCard).toHaveBeenCalledWith("ccof:1");
+  });
+});

--- a/__tests__/cards/cardsService.test.ts
+++ b/__tests__/cards/cardsService.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the Square v44 client's cards API. The service instantiates the client at
+// import time, so the mock must be in place before importing the service.
+const cardsCreate = vi.fn();
+const cardsList = vi.fn();
+const cardsGet = vi.fn();
+const cardsDisable = vi.fn();
+
+vi.mock("@/lib/square/client", () => ({
+  getSquareClient: () => ({
+    cards: {
+      create: (...a: unknown[]) => cardsCreate(...a),
+      list: (...a: unknown[]) => cardsList(...a),
+      get: (...a: unknown[]) => cardsGet(...a),
+      disable: (...a: unknown[]) => cardsDisable(...a),
+    },
+  }),
+}));
+
+import { squareCardService } from "@/lib/square/cards";
+
+// An async-iterable page like the SDK returns from cards.list().
+function asyncPage<T>(items: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) yield item;
+    },
+  };
+}
+
+const SQUARE_CARD = {
+  id: "ccof:abc123",
+  cardBrand: "VISA",
+  last4: "1111",
+  expMonth: BigInt(4),
+  expYear: BigInt(2027),
+  cardholderName: "Pat Buyer",
+  customerId: "sqcust_1",
+  enabled: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("squareCardService.createCard", () => {
+  it("saves the card under the customer and returns display-safe metadata", async () => {
+    cardsCreate.mockResolvedValue({ card: SQUARE_CARD });
+
+    const card = await squareCardService.createCard({
+      sourceId: "cnon:nonce",
+      customerId: "sqcust_1",
+      cardholderName: "Pat Buyer",
+      verificationToken: "verif_1",
+      referenceId: "user_1",
+    });
+
+    const req = cardsCreate.mock.calls[0][0];
+    expect(req.sourceId).toBe("cnon:nonce");
+    expect(req.verificationToken).toBe("verif_1");
+    expect(req.card.customerId).toBe("sqcust_1");
+    expect(req.card.referenceId).toBe("user_1");
+    expect(req.idempotencyKey).toBeTruthy();
+
+    // bigint expiry mapped to number; no PAN exposed.
+    expect(card).toEqual({
+      id: "ccof:abc123",
+      brand: "VISA",
+      last4: "1111",
+      expMonth: 4,
+      expYear: 2027,
+      cardholderName: "Pat Buyer",
+    });
+  });
+
+  it("throws when Square returns no card", async () => {
+    cardsCreate.mockResolvedValue({ card: undefined });
+    await expect(
+      squareCardService.createCard({ sourceId: "x", customerId: "sqcust_1" })
+    ).rejects.toThrow(/failed to save card/i);
+  });
+});
+
+describe("squareCardService.listCards", () => {
+  it("returns enabled cards for the customer and skips disabled ones", async () => {
+    cardsList.mockResolvedValue(
+      asyncPage([
+        SQUARE_CARD,
+        { ...SQUARE_CARD, id: "ccof:disabled", enabled: false },
+        { ...SQUARE_CARD, id: "ccof:second", last4: "4242" },
+      ])
+    );
+
+    const cards = await squareCardService.listCards("sqcust_1");
+
+    expect(cardsList.mock.calls[0][0]).toMatchObject({
+      customerId: "sqcust_1",
+      includeDisabled: false,
+    });
+    expect(cards.map((c) => c.id)).toEqual(["ccof:abc123", "ccof:second"]);
+  });
+
+  it("returns an empty list (never throws) when Square errors", async () => {
+    cardsList.mockRejectedValue(new Error("Square down"));
+    const cards = await squareCardService.listCards("sqcust_1");
+    expect(cards).toEqual([]);
+  });
+});
+
+describe("squareCardService.getCard", () => {
+  it("includes the owning customerId for ownership checks", async () => {
+    cardsGet.mockResolvedValue({ card: SQUARE_CARD });
+    const card = await squareCardService.getCard("ccof:abc123");
+    expect(card?.customerId).toBe("sqcust_1");
+    expect(card?.last4).toBe("1111");
+  });
+
+  it("returns null when the card does not exist", async () => {
+    cardsGet.mockRejectedValue(new Error("not found"));
+    expect(await squareCardService.getCard("ccof:nope")).toBeNull();
+  });
+});
+
+describe("squareCardService.disableCard", () => {
+  it("returns true on success and false on failure", async () => {
+    cardsDisable.mockResolvedValue({ card: { ...SQUARE_CARD, enabled: false } });
+    expect(await squareCardService.disableCard("ccof:abc123")).toBe(true);
+
+    cardsDisable.mockRejectedValue(new Error("boom"));
+    expect(await squareCardService.disableCard("ccof:abc123")).toBe(false);
+  });
+});

--- a/__tests__/checkout/bookingRoute.test.ts
+++ b/__tests__/checkout/bookingRoute.test.ts
@@ -73,7 +73,9 @@ function req(body: unknown): Request {
 beforeEach(() => {
   vi.clearAllMocks();
   resolveBookingCharge.mockResolvedValue({ totalCents: 5000, giftCardAppliedCents: 0, chargeCents: 5000 });
-  paymentsCreate.mockResolvedValue({ payment: { id: "pay_123", status: "COMPLETED" } });
+  paymentsCreate.mockResolvedValue({
+    payment: { id: "pay_123", status: "COMPLETED", receiptUrl: "https://squareup.com/receipt/pay_123" },
+  });
   findOrCreateCustomer.mockResolvedValue({ customerId: "sqcust_1", isNew: true });
   customerCreate.mockResolvedValue({ _id: { toString: () => "cust_123" } });
   getSessionUser.mockResolvedValue(null);
@@ -113,6 +115,9 @@ describe("POST /api/checkout/booking", () => {
     expect(saved.squarePaymentId).toBe("pay_123");
     expect(saved.squareCustomerId).toBe("sqcust_1");
     expect(sendBookingConfirmationEmails).toHaveBeenCalledWith("cust_123", "ev1");
+
+    // Square receipt returned for the confirmation page.
+    expect(data.receiptUrl).toBe("https://squareup.com/receipt/pay_123");
   });
 
   it("returns 400 on a price-integrity rejection without charging", async () => {

--- a/__tests__/checkout/bookingRoute.test.ts
+++ b/__tests__/checkout/bookingRoute.test.ts
@@ -34,6 +34,23 @@ vi.mock("@/lib/models/Reservations", () => ({
   },
 }));
 
+const cardGetCard = vi.fn();
+const cardCreateCard = vi.fn();
+vi.mock("@/lib/square/cards", () => ({
+  squareCardService: {
+    getCard: (...a: unknown[]) => cardGetCard(...a),
+    createCard: (...a: unknown[]) => cardCreateCard(...a),
+  },
+}));
+
+const resolveUserSquareCustomerId = vi.fn();
+vi.mock("@/lib/square/userCustomer", () => ({
+  resolveUserSquareCustomerId: (...a: unknown[]) => resolveUserSquareCustomerId(...a),
+}));
+
+const getSessionUser = vi.fn();
+vi.mock("@/lib/auth/guards", () => ({ getSessionUser: (...a: unknown[]) => getSessionUser(...a) }));
+
 vi.mock("@/lib/mongoose", () => ({ connectMongo: vi.fn() }));
 const sendBookingConfirmationEmails = vi.fn();
 vi.mock("@/lib/email/sendBookingConfirmation", () => ({
@@ -59,7 +76,13 @@ beforeEach(() => {
   paymentsCreate.mockResolvedValue({ payment: { id: "pay_123", status: "COMPLETED" } });
   findOrCreateCustomer.mockResolvedValue({ customerId: "sqcust_1", isNew: true });
   customerCreate.mockResolvedValue({ _id: { toString: () => "cust_123" } });
+  getSessionUser.mockResolvedValue(null);
+  resolveUserSquareCustomerId.mockResolvedValue("acct_cust_1");
+  cardGetCard.mockResolvedValue({ id: "ccof:1", customerId: "acct_cust_1" });
+  cardCreateCard.mockResolvedValue({ id: "ccof:new" });
 });
+
+const SIGNED_IN = { id: "user_1", email: "u@example.com", isAdmin: false, role: "customer" };
 
 describe("POST /api/checkout/booking", () => {
   it("rejects when contact fields are missing (no charge)", async () => {
@@ -136,5 +159,47 @@ describe("POST /api/checkout/booking", () => {
     const res = await POST(req({ booking: BOOKING, contact: CONTACT }));
     expect(res.status).toBe(400);
     expect(paymentsCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/checkout/booking — saved cards", () => {
+  it("charges a saved card by id under the signed-in user's customer", async () => {
+    getSessionUser.mockResolvedValue(SIGNED_IN);
+    const res = await POST(req({ booking: BOOKING, contact: CONTACT, savedCardId: "ccof:1" }));
+    expect(res.status).toBe(200);
+    const charge = paymentsCreate.mock.calls[0][0];
+    expect(charge.sourceId).toBe("ccof:1");
+    expect(charge.customerId).toBe("acct_cust_1");
+    expect(cardGetCard).toHaveBeenCalledWith("ccof:1");
+  });
+
+  it("rejects (404) and never charges a saved card the user does not own", async () => {
+    getSessionUser.mockResolvedValue(SIGNED_IN);
+    cardGetCard.mockResolvedValue({ id: "ccof:1", customerId: "someone_else" });
+    const res = await POST(req({ booking: BOOKING, contact: CONTACT, savedCardId: "ccof:1" }));
+    expect(res.status).toBe(404);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("requires sign-in to use a saved card (401)", async () => {
+    const res = await POST(req({ booking: BOOKING, contact: CONTACT, savedCardId: "ccof:1" }));
+    expect(res.status).toBe(401);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("saves the new card on file after charge when saveCard is set and signed in", async () => {
+    getSessionUser.mockResolvedValue(SIGNED_IN);
+    const res = await POST(req({ paymentToken: "cnon:tok", booking: BOOKING, contact: CONTACT, saveCard: true }));
+    expect(res.status).toBe(200);
+    expect(resolveUserSquareCustomerId).toHaveBeenCalledWith(SIGNED_IN, { createIfMissing: true });
+    const arg = cardCreateCard.mock.calls[0][0];
+    expect(arg.sourceId).toBe("pay_123");
+    expect(arg.customerId).toBe("acct_cust_1");
+  });
+
+  it("forwards the SCA verificationToken to the charge", async () => {
+    const res = await POST(req({ paymentToken: "cnon:tok", booking: BOOKING, contact: CONTACT, verificationToken: "verif_1" }));
+    expect(res.status).toBe(200);
+    expect(paymentsCreate.mock.calls[0][0].verificationToken).toBe("verif_1");
   });
 });

--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -20,6 +20,21 @@ vi.mock("@/lib/square/customers", () => ({
   squareCustomerService: { findOrCreateCustomer: (...a: unknown[]) => findOrCreateCustomer(...a) },
 }));
 
+const cardGetCard = vi.fn();
+const cardCreateCard = vi.fn();
+vi.mock("@/lib/square/cards", () => ({
+  squareCardService: {
+    getCard: (...a: unknown[]) => cardGetCard(...a),
+    createCard: (...a: unknown[]) => cardCreateCard(...a),
+  },
+}));
+
+const resolveUserSquareCustomerId = vi.fn();
+vi.mock("@/lib/square/userCustomer", () => ({
+  resolveUserSquareCustomerId: (...a: unknown[]) =>
+    resolveUserSquareCustomerId(...a),
+}));
+
 const giftCardGetById = vi.fn();
 const giftCardRedeem = vi.fn();
 vi.mock("@/lib/square/gift-cards", () => ({
@@ -138,7 +153,12 @@ beforeEach(() => {
   emailSend.mockResolvedValue({});
   getSessionUser.mockResolvedValue(null); // default: guest checkout
   usersUpdateOne.mockResolvedValue({});
+  resolveUserSquareCustomerId.mockResolvedValue("acct_cust_1");
+  cardGetCard.mockResolvedValue({ id: "ccof:1", customerId: "acct_cust_1" });
+  cardCreateCard.mockResolvedValue({ id: "ccof:new" });
 });
+
+const SIGNED_IN = { id: "user_1", email: "u@example.com", isAdmin: false, role: "customer" };
 
 describe("POST /api/store/checkout", () => {
   it("charges the server total, creates the order, buys a label, returns the order number", async () => {
@@ -282,5 +302,58 @@ describe("POST /api/store/checkout", () => {
     // Identity link uses the session; the charge + receipt stay with the typed buyer.
     expect(paymentsCreate.mock.calls[0][0].buyerEmailAddress).toBe("buyer@example.com");
     expect(orderCreate.mock.calls[0][0].customer.email).toBe("buyer@example.com");
+  });
+
+  it("charges a saved card by id under the signed-in user's customer", async () => {
+    getSessionUser.mockResolvedValue(SIGNED_IN);
+    const res = await POST(
+      req(baseBody({ paymentToken: undefined, savedCardId: "ccof:1" }))
+    );
+    expect(res.status).toBe(200);
+
+    const charge = paymentsCreate.mock.calls[0][0];
+    expect(charge.sourceId).toBe("ccof:1");
+    expect(charge.customerId).toBe("acct_cust_1");
+    // Ownership was verified against the user's customer.
+    expect(cardGetCard).toHaveBeenCalledWith("ccof:1");
+  });
+
+  it("rejects (404) and never charges a saved card the user does not own", async () => {
+    getSessionUser.mockResolvedValue(SIGNED_IN);
+    cardGetCard.mockResolvedValue({ id: "ccof:1", customerId: "someone_else" });
+    const res = await POST(
+      req(baseBody({ paymentToken: undefined, savedCardId: "ccof:1" }))
+    );
+    expect(res.status).toBe(404);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("requires sign-in to use a saved card (401)", async () => {
+    getSessionUser.mockResolvedValue(null);
+    const res = await POST(
+      req(baseBody({ paymentToken: undefined, savedCardId: "ccof:1" }))
+    );
+    expect(res.status).toBe(401);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("saves the new card on file after charge when saveCard is set and signed in", async () => {
+    getSessionUser.mockResolvedValue(SIGNED_IN);
+    const res = await POST(req(baseBody({ saveCard: true })));
+    expect(res.status).toBe(200);
+
+    expect(resolveUserSquareCustomerId).toHaveBeenCalledWith(SIGNED_IN, {
+      createIfMissing: true,
+    });
+    // Card filed from the PAYMENT id (the one-time nonce is already spent).
+    const arg = cardCreateCard.mock.calls[0][0];
+    expect(arg.sourceId).toBe("pay_1");
+    expect(arg.customerId).toBe("acct_cust_1");
+  });
+
+  it("forwards the SCA verificationToken to the charge", async () => {
+    const res = await POST(req(baseBody({ verificationToken: "verif_1" })));
+    expect(res.status).toBe(200);
+    expect(paymentsCreate.mock.calls[0][0].verificationToken).toBe("verif_1");
   });
 });

--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -145,7 +145,9 @@ beforeEach(() => {
     subtotalCents: 8800,
   });
   resolveShippingRate.mockResolvedValue(RATE);
-  paymentsCreate.mockResolvedValue({ payment: { id: "pay_1", status: "COMPLETED" } });
+  paymentsCreate.mockResolvedValue({
+    payment: { id: "pay_1", status: "COMPLETED", receiptUrl: "https://squareup.com/receipt/pay_1" },
+  });
   findOrCreateCustomer.mockResolvedValue({ customerId: "sqcust_1" });
   purchaseLabelForOrder.mockResolvedValue({ labelUrl: "https://label", trackingNumber: "TRK1" });
   orderCreate.mockResolvedValue({ _id: { toString: () => "order_1" }, orderNumber: "CC-TEST-1" });
@@ -180,6 +182,10 @@ describe("POST /api/store/checkout", () => {
     expect(order.shippingCents).toBe(570);
     expect(order.status).toBe("paid");
     expect(purchaseLabelForOrder).toHaveBeenCalledWith("order_1");
+
+    // Square receipt captured on the order + returned for the confirmation page.
+    expect(order.square.receiptUrl).toBe("https://squareup.com/receipt/pay_1");
+    expect(data.receiptUrl).toBe("https://squareup.com/receipt/pay_1");
   });
 
   it("ships to the RECIPIENT on a gift order while charging the BUYER (A1)", async () => {

--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -53,6 +53,31 @@ vi.mock("resend", () => ({
   },
 }));
 
+// Authenticated-user identity (null = guest). Drives the durable userId stamp.
+const getSessionUser = vi.fn();
+vi.mock("@/lib/auth/guards", () => ({
+  getSessionUser: (...a: unknown[]) => getSessionUser(...a),
+}));
+
+// The route uses mongoose.Types.ObjectId + a direct driver update on `users`.
+const usersUpdateOne = vi.fn();
+vi.mock("mongoose", () => {
+  class ObjectId {
+    constructor(public value: string) {}
+    toString(): string {
+      return this.value;
+    }
+  }
+  return {
+    default: {
+      Types: { ObjectId },
+      connection: {
+        collection: () => ({ updateOne: (...a: unknown[]) => usersUpdateOne(...a) }),
+      },
+    },
+  };
+});
+
 import { POST } from "@/app/api/store/checkout/route";
 
 const BUYER = { firstName: "Pat", lastName: "Buyer", email: "buyer@example.com", phone: "(609) 555-1234" };
@@ -111,6 +136,8 @@ beforeEach(() => {
   orderCreate.mockResolvedValue({ _id: { toString: () => "order_1" }, orderNumber: "CC-TEST-1" });
   orderFindByIdAndUpdate.mockResolvedValue({});
   emailSend.mockResolvedValue({});
+  getSessionUser.mockResolvedValue(null); // default: guest checkout
+  usersUpdateOne.mockResolvedValue({});
 });
 
 describe("POST /api/store/checkout", () => {
@@ -213,5 +240,47 @@ describe("POST /api/store/checkout", () => {
     const res = await POST(req(baseBody()));
     expect(res.status).toBe(400);
     expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("stamps userId and links the Square customer to the user when signed in", async () => {
+    getSessionUser.mockResolvedValue({
+      id: "6650f0000000000000000abc",
+      email: "account@example.com",
+    });
+    const res = await POST(req(baseBody()));
+    expect(res.status).toBe(200);
+
+    // Durable user link stamped on the order.
+    const order = orderCreate.mock.calls[0][0];
+    expect(order.userId.toString()).toBe("6650f0000000000000000abc");
+
+    // Square customer associated to the user record exactly once, only when unset.
+    expect(usersUpdateOne).toHaveBeenCalledTimes(1);
+    const [filter, update] = usersUpdateOne.mock.calls[0];
+    expect(filter.squareCustomerId).toEqual({ $exists: false });
+    expect(update.$set.squareCustomerId).toBe("sqcust_1");
+  });
+
+  it("leaves userId unset and writes no user link for a guest checkout", async () => {
+    // getSessionUser default is null (guest)
+    const res = await POST(req(baseBody()));
+    expect(res.status).toBe(200);
+
+    const order = orderCreate.mock.calls[0][0];
+    expect(order.userId).toBeUndefined();
+    expect(usersUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("charges the BUYER's submitted email, never the signed-in account email", async () => {
+    getSessionUser.mockResolvedValue({
+      id: "6650f0000000000000000abc",
+      email: "account@example.com",
+    });
+    const res = await POST(req(baseBody()));
+    expect(res.status).toBe(200);
+
+    // Identity link uses the session; the charge + receipt stay with the typed buyer.
+    expect(paymentsCreate.mock.calls[0][0].buyerEmailAddress).toBe("buyer@example.com");
+    expect(orderCreate.mock.calls[0][0].customer.email).toBe("buyer@example.com");
   });
 });

--- a/__tests__/email/recipients.test.ts
+++ b/__tests__/email/recipients.test.ts
@@ -22,16 +22,16 @@ describe("resolveEmailRecipients", () => {
     expect(resolveEmailRecipients("buyer@example.com").admin).toBe(FALLBACK_STUDIO_EMAIL);
   });
 
-  it("in dev/stage redirects everything to DEV_EMAIL", () => {
+  it("in dev/stage sends the customer copy to the real address, only the admin copy to DEV_EMAIL", () => {
     vi.stubEnv("VERCEL_ENV", "preview");
     vi.stubEnv("DEV_EMAIL", "dev@coastal.com");
     expect(resolveEmailRecipients("buyer@example.com")).toEqual({
-      customer: "dev@coastal.com",
+      customer: "buyer@example.com",
       admin: "dev@coastal.com",
     });
   });
 
-  it("in dev with no DEV_EMAIL falls back to the customer address", () => {
+  it("in dev with no DEV_EMAIL falls back to the customer address for admin too", () => {
     vi.stubEnv("VERCEL_ENV", "development");
     vi.stubEnv("DEV_EMAIL", "");
     expect(resolveEmailRecipients("buyer@example.com")).toEqual({

--- a/__tests__/webhooks/shippoWebhook.test.ts
+++ b/__tests__/webhooks/shippoWebhook.test.ts
@@ -172,13 +172,15 @@ describe("POST /api/webhooks/shippo — email routing", () => {
     expect(recipients).toContain("studio@coastal.com");
   });
 
-  it("in dev/stage, redirects all mail to DEV_EMAIL", async () => {
+  it("in dev/stage, emails the real customer but redirects only the admin copy to DEV_EMAIL", async () => {
     vi.stubEnv("VERCEL_ENV", "preview");
     vi.stubEnv("DEV_EMAIL", "dev@coastal.com");
     orderFindOne.mockResolvedValue(makeOrder());
     await POST(req({ token: SECRET, body: trackEvent("TRANSIT") }));
-    for (const call of emailSend.mock.calls) {
-      expect(call[0].to).toEqual(["dev@coastal.com"]);
-    }
+    const recipients = emailSend.mock.calls.map((c) => c[0].to[0]);
+    // Customer copy goes to the real buyer; the admin copy is redirected.
+    expect(recipients).toContain("buyer@example.com");
+    expect(recipients).toContain("dev@coastal.com");
+    expect(recipients).not.toContain("studio@coastal.com");
   });
 });

--- a/app/account/orders/[orderNumber]/page.tsx
+++ b/app/account/orders/[orderNumber]/page.tsx
@@ -102,6 +102,18 @@ export default async function OrderDetailPage({
               <span>{formatCents(order.totalCents)}</span>
             </div>
           </div>
+          {order.square?.receiptUrl && (
+            <div className="ml-auto mt-3 max-w-xs">
+              <a
+                href={order.square.receiptUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block w-full text-center px-4 py-2 border border-sky-200 text-sky-700 font-medium rounded-lg text-sm hover:bg-sky-50 transition-colors"
+              >
+                View Square Receipt
+              </a>
+            </div>
+          )}
         </div>
       </div>
 

--- a/app/account/orders/[orderNumber]/page.tsx
+++ b/app/account/orders/[orderNumber]/page.tsx
@@ -14,7 +14,7 @@ export default async function OrderDetailPage({
 }): Promise<ReactElement> {
   const user = await requireUserPage();
   const { orderNumber } = await params;
-  const order = await getMyOrderByNumber(user.email, orderNumber);
+  const order = await getMyOrderByNumber(user.email, orderNumber, user.id);
   if (!order) notFound();
 
   const address = order.shippingAddress;

--- a/app/account/orders/page.tsx
+++ b/app/account/orders/page.tsx
@@ -9,7 +9,7 @@ import OrdersAccordion, {
 export default async function MyOrdersPage(): Promise<ReactElement> {
   const user = await requireUserPage();
   const [orders, refundRequests] = await Promise.all([
-    getMyOrders(user.email),
+    getMyOrders(user.email, user.id),
     getMyRefundRequests(user.email),
   ]);
   const pendingRefundIds = refundRequests

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -9,7 +9,7 @@ import OrderStatusBadge from "@/components/account/OrderStatusBadge";
 export default async function AccountOverviewPage(): Promise<ReactElement> {
   const user = await requireUserPage();
   const [orders, bookings] = await Promise.all([
-    getMyOrders(user.email),
+    getMyOrders(user.email, user.id),
     getMyBookings(user.email),
   ]);
 

--- a/app/account/payment-methods/page.tsx
+++ b/app/account/payment-methods/page.tsx
@@ -1,0 +1,29 @@
+import type { ReactElement } from "react";
+import { requireUserPage } from "@/lib/auth/guards";
+import { resolveUserSquareCustomerId } from "@/lib/square/userCustomer";
+import { squareCardService, type SavedCard } from "@/lib/square/cards";
+import PaymentMethodsManager from "@/components/account/PaymentMethodsManager";
+
+export default async function PaymentMethodsPage(): Promise<ReactElement> {
+  const user = await requireUserPage();
+
+  // Read-only resolve: list cards if the user already has a Square customer; a new
+  // customer is created lazily only when they actually save a card (POST route).
+  const customerId = await resolveUserSquareCustomerId(user);
+  const cards: SavedCard[] = customerId
+    ? await squareCardService.listCards(customerId)
+    : [];
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold text-gray-800">Payment methods</h1>
+      <PaymentMethodsManager
+        initialCards={cards}
+        applicationId={process.env.SQUARE_APPLICATION_ID ?? ""}
+        locationId={process.env.SQUARE_LOCATION_ID ?? ""}
+        email={user.email}
+        name={user.name}
+      />
+    </div>
+  );
+}

--- a/app/api/account/cards/[cardId]/route.ts
+++ b/app/api/account/cards/[cardId]/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Remove a saved card (DELETE, requireUser).
+ *
+ * Ownership is enforced: the card must belong to the signed-in user's Square
+ * customer, otherwise we 404 (never reveal another customer's card). Disable is
+ * idempotent in Square.
+ */
+import { NextResponse } from "next/server";
+import { requireUser } from "@/lib/auth/guards";
+import { squareCardService } from "@/lib/square/cards";
+import { resolveUserSquareCustomerId } from "@/lib/square/userCustomer";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ cardId: string }> }
+): Promise<NextResponse> {
+  const user = await requireUser();
+  if (user instanceof NextResponse) return user;
+
+  const { cardId } = await params;
+  const customerId = await resolveUserSquareCustomerId(user);
+  if (!customerId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const card = await squareCardService.getCard(cardId);
+  if (!card || card.customerId !== customerId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const ok = await squareCardService.disableCard(cardId);
+  if (!ok) {
+    return NextResponse.json(
+      { error: "Could not remove card" },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/api/account/cards/route.ts
+++ b/app/api/account/cards/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Account Cards on File API (customer-facing, requireUser).
+ *   GET  — list the signed-in user's saved cards (display metadata only).
+ *   POST — save a new card on file from a Web Payments SDK token (intent STORE).
+ *
+ * Card data never reaches us: the client tokenizes with Square, we exchange the
+ * one-time token for a durable card id filed under the user's Square customer.
+ */
+import { NextResponse } from "next/server";
+import { requireUser } from "@/lib/auth/guards";
+import { squareCardService } from "@/lib/square/cards";
+import { resolveUserSquareCustomerId } from "@/lib/square/userCustomer";
+
+export async function GET(): Promise<NextResponse> {
+  const user = await requireUser();
+  if (user instanceof NextResponse) return user;
+
+  // Read-only: don't create a Square customer just to list (none → no cards yet).
+  const customerId = await resolveUserSquareCustomerId(user);
+  if (!customerId) return NextResponse.json({ cards: [] });
+
+  const cards = await squareCardService.listCards(customerId);
+  return NextResponse.json({ cards });
+}
+
+interface SaveCardBody {
+  sourceId?: string;
+  verificationToken?: string;
+  cardholderName?: string;
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const user = await requireUser();
+  if (user instanceof NextResponse) return user;
+
+  const body = (await request.json()) as SaveCardBody;
+  if (!body.sourceId) {
+    return NextResponse.json({ error: "Missing card token" }, { status: 400 });
+  }
+
+  // Saving requires a customer to file under — create one from the account identity
+  // if this user has never transacted.
+  const customerId = await resolveUserSquareCustomerId(user, {
+    createIfMissing: true,
+  });
+  if (!customerId) {
+    return NextResponse.json(
+      { error: "Could not resolve a customer profile" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const card = await squareCardService.createCard({
+      sourceId: body.sourceId,
+      customerId,
+      cardholderName: body.cardholderName,
+      verificationToken: body.verificationToken,
+      referenceId: user.id,
+    });
+    return NextResponse.json({ card }, { status: 201 });
+  } catch (error) {
+    console.error("[API-ACCOUNT-CARDS-POST] Save card failed:", error);
+    return NextResponse.json({ error: "Could not save card" }, { status: 400 });
+  }
+}

--- a/app/api/checkout/booking/route.ts
+++ b/app/api/checkout/booking/route.ts
@@ -173,6 +173,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     // 4. Charge the card portion (skipped when free or fully gift-card-covered).
     let squarePaymentId: string;
+    let squareReceiptUrl: string | undefined;
     if (chargeCents > 0) {
       const usingSavedCard = Boolean(body.savedCardId);
       if (!usingSavedCard && !paymentToken) {
@@ -211,6 +212,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         );
       }
       squarePaymentId = payment.id ?? "";
+      squareReceiptUrl = payment.receiptUrl ?? undefined;
 
       // Save the new card on file after a successful charge (opt-in, signed-in).
       // The PAYMENT id is a valid card source — the one-time nonce is already spent.
@@ -303,6 +305,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       success: true,
       customerId: customer._id.toString(),
       squarePaymentId,
+      receiptUrl: squareReceiptUrl,
       total: totalCents / 100,
       status: "COMPLETED",
     });

--- a/app/api/checkout/booking/route.ts
+++ b/app/api/checkout/booking/route.ts
@@ -25,6 +25,9 @@ import Customer from "@/lib/models/Customer";
 import Reservation from "@/lib/models/Reservations";
 import { getSquareClient } from "@/lib/square/client";
 import { squareCustomerService } from "@/lib/square/customers";
+import { squareCardService } from "@/lib/square/cards";
+import { resolveUserSquareCustomerId } from "@/lib/square/userCustomer";
+import { getSessionUser } from "@/lib/auth/guards";
 import { giftCardService } from "@/lib/square/gift-cards";
 import { resolveBookingCharge } from "@/lib/checkout/resolveBookingCharge";
 import { PriceIntegrityError } from "@/lib/checkout/errors";
@@ -45,6 +48,12 @@ interface SelectedOption {
 interface BookingCheckoutRequest {
   paymentToken?: string;
   idempotencyKey?: string;
+  /** SCA verification token from tokenize (new-card path). */
+  verificationToken?: string;
+  /** Charge a saved card on file instead of a new nonce (signed-in users only). */
+  savedCardId?: string;
+  /** Save the new card on file after charging (signed-in users only). */
+  saveCard?: boolean;
   contact: {
     firstName: string;
     lastName: string;
@@ -87,6 +96,9 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     await connectMongo();
     const eventType = booking.eventType ?? "Event";
+
+    // Signed-in user (null for guests) — needed for saved cards / save-on-file.
+    const sessionUser = await getSessionUser();
 
     // 1. PRICE INTEGRITY — authoritative charge recomputed from the DB.
     const { totalCents, giftCardAppliedCents, chargeCents } =
@@ -136,22 +148,54 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
+    // Cards on file live on the signed-in user's Square customer. Resolve it when a
+    // saved card is being used or a new card is being saved.
+    let accountCustomerId: string | null = null;
+    if (sessionUser && (body.savedCardId || body.saveCard)) {
+      accountCustomerId = await resolveUserSquareCustomerId(sessionUser, {
+        createIfMissing: Boolean(body.saveCard),
+      });
+    }
+
+    // A saved card must belong to THIS user's customer — otherwise reject.
+    if (body.savedCardId) {
+      if (!sessionUser || !accountCustomerId) {
+        return NextResponse.json(
+          { error: "Sign in to use a saved card" },
+          { status: 401 }
+        );
+      }
+      const owned = await squareCardService.getCard(body.savedCardId);
+      if (!owned || owned.customerId !== accountCustomerId) {
+        return NextResponse.json({ error: "Saved card not found" }, { status: 404 });
+      }
+    }
+
     // 4. Charge the card portion (skipped when free or fully gift-card-covered).
     let squarePaymentId: string;
     if (chargeCents > 0) {
-      if (!paymentToken) {
+      const usingSavedCard = Boolean(body.savedCardId);
+      if (!usingSavedCard && !paymentToken) {
         return NextResponse.json(
           { error: "Payment information is required" },
           { status: 400 }
         );
       }
       const client = getSquareClient();
+      // Saved card charges under its owning (account) customer; a new card uses the
+      // booking's email-resolved customer.
+      const chargeCustomerId = usingSavedCard
+        ? accountCustomerId ?? undefined
+        : squareCustomerId;
       const paymentResult = await client.payments.create({
         idempotencyKey: normalizeIdempotencyKey(body.idempotencyKey),
-        sourceId: paymentToken,
+        sourceId: body.savedCardId ?? (paymentToken as string),
+        ...(body.verificationToken
+          ? { verificationToken: body.verificationToken }
+          : {}),
         amountMoney: { amount: BigInt(chargeCents), currency: "USD" },
         referenceId: booking.eventId,
-        customerId: squareCustomerId,
+        customerId: chargeCustomerId,
         buyerEmailAddress: contact.email,
         note: "Coastal Creations Studio — booking",
       });
@@ -167,6 +211,24 @@ export async function POST(request: Request): Promise<NextResponse> {
         );
       }
       squarePaymentId = payment.id ?? "";
+
+      // Save the new card on file after a successful charge (opt-in, signed-in).
+      // The PAYMENT id is a valid card source — the one-time nonce is already spent.
+      if (body.saveCard && !usingSavedCard && accountCustomerId && payment.id) {
+        try {
+          await squareCardService.createCard({
+            sourceId: payment.id,
+            customerId: accountCustomerId,
+            cardholderName: `${contact.firstName} ${contact.lastName}`.trim(),
+            referenceId: sessionUser?.id,
+          });
+        } catch (saveError) {
+          console.error(
+            "[API-CHECKOUT-BOOKING-POST] Save card on file failed (non-fatal):",
+            saveError
+          );
+        }
+      }
     } else {
       squarePaymentId =
         giftCardAppliedCents > 0

--- a/app/api/checkout/booking/route.ts
+++ b/app/api/checkout/booking/route.ts
@@ -281,6 +281,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       },
       squarePaymentId,
       squareCustomerId,
+      squareReceiptUrl,
       refundStatus: "none",
     });
 

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -414,6 +414,7 @@ export async function POST(request: Request): Promise<Response> {
               postalCode: shippingAddress.postalCode,
             },
             shippingMethod: serverRate.serviceName,
+            receiptUrl: squareReceiptUrl,
           },
         })
       );

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -192,6 +192,7 @@ export async function POST(request: Request): Promise<Response> {
 
     // Step 1: Charge the card portion (skipped when a gift card covers the full total).
     let squarePaymentId: string | undefined;
+    let squareReceiptUrl: string | undefined;
     if (chargeCents > 0) {
       const usingSavedCard = Boolean(body.savedCardId);
       if (!usingSavedCard && !paymentToken) {
@@ -238,6 +239,7 @@ export async function POST(request: Request): Promise<Response> {
       }
       console.log("[API-STORE-CHECKOUT-POST] Square payment completed:", payment.id);
       squarePaymentId = payment.id ?? undefined;
+      squareReceiptUrl = payment.receiptUrl ?? undefined;
 
       // Save the new card on file after a successful charge (opt-in, signed-in).
       // The PAYMENT id is a valid card source — the one-time nonce is already spent.
@@ -308,6 +310,7 @@ export async function POST(request: Request): Promise<Response> {
       shippingAddress,
       square: {
         paymentId: squarePaymentId,
+        receiptUrl: squareReceiptUrl,
       },
       giftCard:
         giftCardAppliedCents > 0 && body.giftCard
@@ -460,6 +463,8 @@ export async function POST(request: Request): Promise<Response> {
       success: true,
       orderId: newOrder._id.toString(),
       orderNumber: newOrder.orderNumber,
+      receiptUrl: squareReceiptUrl,
+      totalCents,
     });
   } catch (error) {
     // Price/shipping reconciliation failures are the customer's to resolve (stale

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -30,6 +30,8 @@ import { OrderConfirmationEmail } from "@/components/email-templates/OrderConfir
 import { StoreOrderAdminEmail } from "@/components/email-templates/StoreOrderAdminEmail";
 import { purchaseLabelForOrder } from "@/lib/shippo/labels";
 import { squareCustomerService } from "@/lib/square/customers";
+import { squareCardService } from "@/lib/square/cards";
+import { resolveUserSquareCustomerId } from "@/lib/square/userCustomer";
 import { giftCardService } from "@/lib/square/gift-cards";
 import {
   priceCartFromCatalog,
@@ -87,6 +89,12 @@ interface CheckoutRequest {
   idempotencyKey?: string;
   /** Optional gift card the customer applied — validated against Square below. */
   giftCard?: { giftCardId: string; amountCents: number };
+  /** SCA verification token from tokenize (new-card path). */
+  verificationToken?: string;
+  /** Charge a saved card on file instead of a new nonce (signed-in users only). */
+  savedCardId?: string;
+  /** Save the new card on file after charging (signed-in users only). */
+  saveCard?: boolean;
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -158,10 +166,35 @@ export async function POST(request: Request): Promise<Response> {
     }
     const chargeCents = totalCents - giftCardAppliedCents;
 
+    // Cards on file live on the signed-in user's Square customer. Resolve it when a
+    // saved card is being used or a new card is being saved.
+    let accountCustomerId: string | null = null;
+    if (sessionUser && (body.savedCardId || body.saveCard)) {
+      accountCustomerId = await resolveUserSquareCustomerId(sessionUser, {
+        createIfMissing: Boolean(body.saveCard),
+      });
+    }
+
+    // A saved card must belong to THIS user's customer — otherwise reject (never
+    // charge another customer's card).
+    if (body.savedCardId) {
+      if (!sessionUser || !accountCustomerId) {
+        return NextResponse.json(
+          { error: "Sign in to use a saved card" },
+          { status: 401 }
+        );
+      }
+      const owned = await squareCardService.getCard(body.savedCardId);
+      if (!owned || owned.customerId !== accountCustomerId) {
+        return NextResponse.json({ error: "Saved card not found" }, { status: 404 });
+      }
+    }
+
     // Step 1: Charge the card portion (skipped when a gift card covers the full total).
     let squarePaymentId: string | undefined;
     if (chargeCents > 0) {
-      if (!paymentToken) {
+      const usingSavedCard = Boolean(body.savedCardId);
+      if (!usingSavedCard && !paymentToken) {
         return NextResponse.json(
           { error: "Payment information is required" },
           { status: 400 }
@@ -169,7 +202,12 @@ export async function POST(request: Request): Promise<Response> {
       }
       const paymentResult = await squareClient.payments.create({
         idempotencyKey: normalizeIdempotencyKey(body.idempotencyKey),
-        sourceId: paymentToken,
+        // A saved card charges by its card id; a new card by the one-time nonce.
+        sourceId: body.savedCardId ?? (paymentToken as string),
+        ...(accountCustomerId ? { customerId: accountCustomerId } : {}),
+        ...(body.verificationToken
+          ? { verificationToken: body.verificationToken }
+          : {}),
         amountMoney: {
           amount: BigInt(chargeCents),
           currency: "USD",
@@ -200,6 +238,24 @@ export async function POST(request: Request): Promise<Response> {
       }
       console.log("[API-STORE-CHECKOUT-POST] Square payment completed:", payment.id);
       squarePaymentId = payment.id ?? undefined;
+
+      // Save the new card on file after a successful charge (opt-in, signed-in).
+      // The PAYMENT id is a valid card source — the one-time nonce is already spent.
+      if (body.saveCard && !usingSavedCard && accountCustomerId && payment.id) {
+        try {
+          await squareCardService.createCard({
+            sourceId: payment.id,
+            customerId: accountCustomerId,
+            cardholderName: `${customer.firstName} ${customer.lastName}`.trim(),
+            referenceId: sessionUser?.id,
+          });
+        } catch (saveError) {
+          console.error(
+            "[API-STORE-CHECKOUT-POST] Save card on file failed (non-fatal):",
+            saveError
+          );
+        }
+      }
     }
 
     // Redeem the gift card. Gift-card-only order → fatal on failure (no order is

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -18,7 +18,9 @@
  *   subtotalCents  — number (ignored; recomputed server-side)
  */
 import { NextResponse } from "next/server";
+import mongoose from "mongoose";
 import { getSquareClient } from "@/lib/square/client";
+import { getSessionUser } from "@/lib/auth/guards";
 import { Resend } from "resend";
 import { render } from "@react-email/render";
 import * as React from "react";
@@ -99,6 +101,12 @@ export async function POST(request: Request): Promise<Response> {
 
     // Mongo is needed to read parcel presets for the shipping re-quote.
     await connectMongo();
+
+    // Durable buyer identity: link this order to the authenticated user when one is
+    // signed in. NON-FATAL and identity-only — a guest (null) still checks out, and
+    // the buyer email/charge always comes from the submitted form (so gifting and
+    // buying-for-someone keep working). See lib/account/queries.ts for read-side use.
+    const sessionUser = await getSessionUser();
 
     // PRICE INTEGRITY: never trust client money. Recompute the subtotal from the
     // Square catalog and the shipping from a fresh Shippo re-quote. A tampered
@@ -227,6 +235,9 @@ export async function POST(request: Request): Promise<Response> {
     }));
 
     const newOrder = await Order.create({
+      userId: sessionUser
+        ? new mongoose.Types.ObjectId(sessionUser.id)
+        : undefined,
       items: orderItems,
       subtotalCents,
       shippingCents: serverRate.rateCents,
@@ -280,6 +291,20 @@ export async function POST(request: Request): Promise<Response> {
       await Order.findByIdAndUpdate(newOrder._id, {
         "square.customerId": squareResult.customerId,
       });
+      // Associate the Square customer profile with the authenticated user (once),
+      // so their account can resolve saved payment methods (Cards on File) later.
+      // Adapter-managed `users` collection — direct driver update, only if unset.
+      if (sessionUser) {
+        await mongoose.connection
+          .collection("users")
+          .updateOne(
+            {
+              _id: new mongoose.Types.ObjectId(sessionUser.id),
+              squareCustomerId: { $exists: false },
+            },
+            { $set: { squareCustomerId: squareResult.customerId } }
+          );
+      }
     } catch (squareError) {
       console.error(
         "[API-STORE-CHECKOUT-POST] Square customer link failed (non-fatal):",

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,20 +1,84 @@
 import type { Metadata } from "next";
 import type { ReactElement } from "react";
 import CheckoutForm from "@/components/store/CheckoutForm";
+import type { ContactValues } from "@/components/store/ContactFields";
+import type { AddressFormValues } from "@/components/store/ShippingAddressStep";
+import { getSessionUser } from "@/lib/auth/guards";
+import { getLatestOrderForPrefill } from "@/lib/account/queries";
+import { squareCustomerService } from "@/lib/square/customers";
 
 export const metadata: Metadata = {
   title: "Checkout | Coastal Creations Studio",
   description: "Complete your purchase.",
 };
 
-export default function CheckoutPage(): ReactElement {
+/**
+ * Resolve prefill values for a signed-in customer. Prefer their most recent order
+ * (richest source: name, phone, full shipping address); fall back to their Square
+ * customer profile. Guests (no session) get nothing → the form starts empty.
+ * Phone is prefilled only from a prior order (already a valid, user-typed value);
+ * the Square profile stores phone as E.164, which the form's validation rejects.
+ */
+async function resolvePrefill(): Promise<{
+  contact?: Partial<ContactValues>;
+  shipping?: Partial<AddressFormValues>;
+}> {
+  const user = await getSessionUser();
+  if (!user) return {};
+
+  const lastOrder = await getLatestOrderForPrefill(user.email, user.id);
+  if (lastOrder) {
+    return {
+      contact: {
+        firstName: lastOrder.customer.firstName,
+        lastName: lastOrder.customer.lastName,
+        email: lastOrder.customer.email,
+        phone: lastOrder.customer.phone ?? "",
+      },
+      shipping: {
+        addressLine1: lastOrder.shippingAddress.addressLine1,
+        addressLine2: lastOrder.shippingAddress.addressLine2 ?? "",
+        city: lastOrder.shippingAddress.city,
+        state: lastOrder.shippingAddress.stateProvince,
+        zip: lastOrder.shippingAddress.postalCode,
+      },
+    };
+  }
+
+  const sq = await squareCustomerService.searchByEmail(user.email);
+  if (sq) {
+    return {
+      contact: {
+        firstName: sq.givenName ?? "",
+        lastName: sq.familyName ?? "",
+        email: sq.emailAddress ?? user.email,
+      },
+      shipping: sq.address
+        ? {
+            addressLine1: sq.address.addressLine1 ?? "",
+            addressLine2: sq.address.addressLine2 ?? "",
+            city: sq.address.locality ?? "",
+            state: sq.address.administrativeDistrictLevel1 ?? "",
+            zip: sq.address.postalCode ?? "",
+          }
+        : undefined,
+    };
+  }
+
+  // Signed in but no order/profile yet — at least seed their account email.
+  return { contact: { email: user.email } };
+}
+
+export default async function CheckoutPage(): Promise<ReactElement> {
+  const { contact, shipping } = await resolvePrefill();
+
   return (
     <div className="min-h-screen">
       <div className="container mx-auto px-4 pt-12 pb-10 max-w-5xl">
         <h1 className="text-3xl font-bold text-[var(--color-primary)] mb-8">
           Checkout
         </h1>
-        <CheckoutForm />
+        <CheckoutForm initialContact={contact} initialShipping={shipping} />
       </div>
     </div>
   );

--- a/app/order-confirmation/page.tsx
+++ b/app/order-confirmation/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactElement } from "react";
 import Link from "next/link";
-import { FaCheckCircle } from "react-icons/fa";
-import { Button } from "@/components/ui";
+import { FaCheck, FaRegEnvelope } from "react-icons/fa";
 
 export const metadata: Metadata = {
   title: "Order Confirmed | Coastal Creations Studio",
@@ -10,43 +9,110 @@ export const metadata: Metadata = {
 };
 
 interface OrderConfirmationPageProps {
-  searchParams: Promise<{ orderNumber?: string }>;
+  searchParams: Promise<{
+    orderNumber?: string;
+    receiptUrl?: string;
+    total?: string;
+    firstName?: string;
+    email?: string;
+  }>;
 }
 
 export default async function OrderConfirmationPage({
   searchParams,
 }: OrderConfirmationPageProps): Promise<ReactElement> {
-  const { orderNumber } = await searchParams;
+  const { orderNumber, receiptUrl, total, firstName, email } =
+    await searchParams;
 
   return (
-    <div className="container mx-auto px-4 py-20 max-w-lg text-center flex flex-col items-center gap-6">
-      <FaCheckCircle
-        size={64}
-        className="text-[var(--color-success)]"
-      />
+    <div className="min-h-[70vh] bg-gradient-to-b from-[#e0f2fe] via-[#f0f9ff] to-white py-12 px-4">
+      <div className="max-w-xl mx-auto">
+        {/* Success header */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-green-100 ring-8 ring-green-50 mb-5">
+            <span className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-green-500 shadow-lg shadow-green-500/30">
+              <FaCheck className="text-white text-2xl" />
+            </span>
+          </div>
+          <h1 className="text-3xl font-bold text-[var(--color-primary)] mb-2">
+            {firstName ? `Thank you, ${firstName}!` : "Order Confirmed!"}
+          </h1>
+          <p className="text-gray-600 max-w-md mx-auto">
+            Your order is confirmed and will be packed and shipped soon.
+            {email ? (
+              <>
+                {" "}
+                A confirmation email is on its way to{" "}
+                <span className="font-medium text-gray-800">{email}</span>.
+              </>
+            ) : null}
+          </p>
+        </div>
 
-      <h1 className="text-3xl font-bold text-[var(--color-primary)]">
-        Order Confirmed!
-      </h1>
+        {/* Summary card */}
+        <div className="bg-white rounded-2xl shadow-[var(--shadow-card)] border border-sky-100 overflow-hidden">
+          <div className="bg-gradient-to-r from-[var(--color-primary)] to-[var(--color-secondary)] px-6 py-5">
+            <p className="text-sky-100 text-xs font-semibold uppercase tracking-wider mb-1">
+              Order Confirmed
+            </p>
+            <h2 className="text-white text-xl font-bold leading-tight">
+              {orderNumber ?? "Your order"}
+            </h2>
+          </div>
 
-      {orderNumber && (
-        <p className="text-[var(--color-text-subtle)] text-sm">
-          Order number: <strong className="text-[var(--color-text-primary)]">{orderNumber}</strong>
+          <div className="px-6 py-5">
+            <dl className="divide-y divide-gray-100">
+              {total && (
+                <div className="flex items-center justify-between py-2.5">
+                  <dt className="text-sm text-gray-500">Amount paid</dt>
+                  <dd className="text-base font-bold text-gray-900">${total}</dd>
+                </div>
+              )}
+              {orderNumber && (
+                <div className="flex items-center justify-between gap-4 py-2.5">
+                  <dt className="text-sm text-gray-500">Order number</dt>
+                  <dd className="text-sm font-mono text-gray-700 truncate">
+                    {orderNumber}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          {receiptUrl && (
+            <div className="px-6 pb-5">
+              <a
+                href={receiptUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block w-full text-center px-5 py-2.5 border border-sky-200 text-[var(--color-secondary)] font-semibold rounded-lg hover:bg-sky-50 transition-colors"
+              >
+                View Square Receipt
+              </a>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="mt-6 flex flex-col sm:flex-row gap-3">
+          <Link
+            href="/shop"
+            className="flex-1 text-center px-6 py-3 bg-[var(--color-primary)] text-white font-semibold rounded-lg hover:bg-[var(--color-primary-dark)] transition-colors"
+          >
+            Continue Shopping
+          </Link>
+          <Link
+            href="/account/orders"
+            className="flex-1 text-center px-6 py-3 bg-white border border-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            View My Orders
+          </Link>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-gray-400 flex items-center justify-center gap-1.5">
+          <FaRegEnvelope className="text-gray-300" />
+          Questions? Reply to your confirmation email and we&apos;ll help.
         </p>
-      )}
-
-      <p className="text-[var(--color-text-secondary)] max-w-sm leading-relaxed">
-        Thank you for your purchase! We&apos;ll send a confirmation email shortly. Your order will
-        be packed and shipped as soon as possible.
-      </p>
-
-      <div className="flex gap-3">
-        <Link href="/shop">
-          <Button variant="primary">Continue Shopping</Button>
-        </Link>
-        <Link href="/">
-          <Button variant="ghost">Home</Button>
-        </Link>
       </div>
     </div>
   );

--- a/app/reservations/confirmation/page.tsx
+++ b/app/reservations/confirmation/page.tsx
@@ -2,14 +2,19 @@ import { ReactElement } from "react";
 import Link from "next/link";
 
 interface Props {
-  searchParams: Promise<{ bookingId?: string; total?: string; name?: string }>;
+  searchParams: Promise<{
+    bookingId?: string;
+    total?: string;
+    name?: string;
+    receiptUrl?: string;
+  }>;
 }
 
 export default async function ConfirmationPage({
   searchParams,
 }: Props): Promise<ReactElement> {
   const params = await searchParams;
-  const { bookingId, total, name } = params;
+  const { bookingId, total, name, receiptUrl } = params;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-blue-50 to-white px-4 py-12">
@@ -71,6 +76,17 @@ export default async function ConfirmationPage({
                 ${parseFloat(total).toFixed(2)}
               </p>
             </div>
+          )}
+
+          {receiptUrl && (
+            <a
+              href={receiptUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block w-full text-center px-5 py-2.5 border border-sky-200 text-[var(--color-secondary)] font-semibold rounded-lg hover:bg-sky-50 transition-colors"
+            >
+              View Square Receipt
+            </a>
           )}
 
           <div className="mt-6 pt-6 border-t border-gray-200">

--- a/components/account/AccountNav.tsx
+++ b/components/account/AccountNav.tsx
@@ -13,6 +13,8 @@ import {
   RiCalendarEventFill,
   RiUser3Line,
   RiUser3Fill,
+  RiBankCardLine,
+  RiBankCardFill,
 } from "react-icons/ri";
 import LogoutButton from "@/components/authentication/LogoutButton";
 
@@ -41,6 +43,12 @@ const NAV_ITEMS: NavItem[] = [
     label: "Bookings",
     icon: <RiCalendarEventLine className="w-5 h-5" />,
     activeIcon: <RiCalendarEventFill className="w-5 h-5" />,
+  },
+  {
+    href: "/account/payment-methods",
+    label: "Payment methods",
+    icon: <RiBankCardLine className="w-5 h-5" />,
+    activeIcon: <RiBankCardFill className="w-5 h-5" />,
   },
   {
     href: "/account/profile",

--- a/components/account/AddCardForm.tsx
+++ b/components/account/AddCardForm.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { useState } from "react";
+import PaymentStep from "@/components/checkout/PaymentStep";
+import type { SavedCard } from "@/lib/square/cards";
+
+interface AddCardFormProps {
+  applicationId: string;
+  locationId: string;
+  /** Account identity used as SCA billingContact + cardholder name (no new fields). */
+  email: string;
+  name?: string | null;
+  onSaved: (card: SavedCard) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Save a new card on file. Reuses the shared Square card widget with intent STORE
+ * (tokenize handles SCA), then exchanges the token for a stored card via
+ * POST /api/account/cards. Card data never touches our server.
+ */
+export default function AddCardForm({
+  applicationId,
+  locationId,
+  email,
+  name,
+  onSaved,
+  onCancel,
+}: AddCardFormProps): ReactElement {
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [givenName, ...rest] = (name ?? "").trim().split(/\s+/);
+  const familyName = rest.join(" ");
+
+  const handleToken = async (
+    token: string,
+    verificationToken?: string
+  ): Promise<void> => {
+    setIsProcessing(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/account/cards", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceId: token,
+          verificationToken,
+          cardholderName: name ?? undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Could not save card. Please try again.");
+        setIsProcessing(false);
+        return;
+      }
+      onSaved(data.card as SavedCard);
+    } catch {
+      setError("Network error. Please try again.");
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <PaymentStep
+        applicationId={applicationId}
+        locationId={locationId}
+        amountDollars={null}
+        ready={true}
+        onToken={handleToken}
+        isProcessing={isProcessing}
+        error={error}
+        processingLabel="Saving card…"
+        submitLabel="Save card"
+        verification={{
+          intent: "STORE",
+          billingContact: { givenName, familyName, email },
+        }}
+      />
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={isProcessing}
+        className="text-sm text-gray-500 hover:text-gray-800 disabled:opacity-50"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/components/account/PaymentMethodsManager.tsx
+++ b/components/account/PaymentMethodsManager.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { RiBankCardLine, RiAddLine } from "react-icons/ri";
+import type { SavedCard } from "@/lib/square/cards";
+import AddCardForm from "@/components/account/AddCardForm";
+
+interface PaymentMethodsManagerProps {
+  initialCards: SavedCard[];
+  applicationId: string;
+  locationId: string;
+  email: string;
+  name?: string | null;
+}
+
+// Square card brands ("VISA", "AMERICAN_EXPRESS", ...) → friendly display labels.
+function brandLabel(brand: string): string {
+  return brand
+    .split("_")
+    .map((w) => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function formatExpiry(month: number, year: number): string {
+  if (!month || !year) return "";
+  return `${String(month).padStart(2, "0")}/${String(year).slice(-2)}`;
+}
+
+export default function PaymentMethodsManager({
+  initialCards,
+  applicationId,
+  locationId,
+  email,
+  name,
+}: PaymentMethodsManagerProps): ReactElement {
+  const [cards, setCards] = useState<SavedCard[]>(initialCards);
+  const [showAdd, setShowAdd] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRemove = async (cardId: string): Promise<void> => {
+    setRemovingId(cardId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/account/cards/${cardId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? "Could not remove card. Please try again.");
+        return;
+      }
+      setCards((prev) => prev.filter((c) => c.id !== cardId));
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  const handleSaved = (card: SavedCard): void => {
+    setCards((prev) => [card, ...prev.filter((c) => c.id !== card.id)]);
+    setShowAdd(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-500">
+        Save a card for faster checkout. Your card details are stored securely by
+        Square — we never see or store your full card number.
+      </p>
+
+      {error && (
+        <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      {cards.length === 0 && !showAdd && (
+        <div className="rounded-lg border border-gray-200 bg-white py-10 text-center text-sm text-gray-500">
+          You don&apos;t have any saved cards yet.
+        </div>
+      )}
+
+      {cards.length > 0 && (
+        <ul className="space-y-2">
+          {cards.map((card) => (
+            <li
+              key={card.id}
+              className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white px-4 py-3"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <RiBankCardLine className="h-5 w-5 shrink-0 text-gray-400" />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-800">
+                    {brandLabel(card.brand)} •••• {card.last4}
+                  </p>
+                  {formatExpiry(card.expMonth, card.expYear) && (
+                    <p className="text-xs text-gray-500">
+                      Expires {formatExpiry(card.expMonth, card.expYear)}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRemove(card.id)}
+                disabled={removingId === card.id}
+                className="shrink-0 text-sm font-medium text-red-600 hover:text-red-700 disabled:opacity-50"
+              >
+                {removingId === card.id ? "Removing…" : "Remove"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showAdd ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <AddCardForm
+            applicationId={applicationId}
+            locationId={locationId}
+            email={email}
+            name={name}
+            onSaved={handleSaved}
+            onCancel={() => setShowAdd(false)}
+          />
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setShowAdd(true)}
+          className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          <RiAddLine className="h-4 w-4" /> Add a card
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/checkout/EventCheckout.tsx
+++ b/components/checkout/EventCheckout.tsx
@@ -302,6 +302,7 @@ export default function EventCheckout(): ReactElement {
         router.push(
           buildSuccessUrl({
             paymentId: data.squarePaymentId,
+            receiptUrl: data.receiptUrl,
             firstName: contact.firstName,
             lastName: contact.lastName,
             eventTitle: eventDetails?.eventName || eventTitle,

--- a/components/checkout/EventCheckout.tsx
+++ b/components/checkout/EventCheckout.tsx
@@ -12,6 +12,8 @@ import CheckoutLayout from "./CheckoutLayout";
 import ContactForm, { type ContactFormValues, isValidUsPhone } from "./ContactForm";
 import { isValidEmail } from "@/lib/utils/validation";
 import PaymentStep from "./PaymentStep";
+import SavedCardPicker from "./SavedCardPicker";
+import { useSavedCards } from "@/hooks/queries/use-saved-cards";
 import EventSummary, { type SummaryLine } from "./EventSummary";
 import EventParticipantsFields from "./EventParticipantsFields";
 import GiftCardRedemption from "./GiftCardRedemption";
@@ -86,6 +88,12 @@ export default function EventCheckout(): ReactElement {
   const [discountInfo, setDiscountInfo] = useState<DiscountInfo>({ isDiscountAvailable: false });
 
   const [appliedGiftCard, setAppliedGiftCard] = useState<AppliedGiftCard | null>(null);
+  // Cards on file (signed-in users). null selection = pay with a new card.
+  const { data: savedCardsData } = useSavedCards();
+  const savedCards = savedCardsData?.cards ?? [];
+  const isAuthenticated = savedCardsData?.authenticated ?? false;
+  const [selectedSavedCardId, setSelectedSavedCardId] = useState<string | null>(null);
+  const [saveNewCard, setSaveNewCard] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // One stable idempotency key per mount — reused across retries of THIS attempt.
@@ -251,7 +259,7 @@ export default function EventCheckout(): ReactElement {
 
   // --- Submit ---
   const submitBooking = useCallback(
-    async (paymentToken?: string): Promise<void> => {
+    async (paymentToken?: string, verificationToken?: string): Promise<void> => {
       setIsProcessing(true);
       setError(null);
       try {
@@ -260,6 +268,12 @@ export default function EventCheckout(): ReactElement {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             paymentToken,
+            verificationToken,
+            savedCardId: selectedSavedCardId ?? undefined,
+            saveCard:
+              saveNewCard && !selectedSavedCardId && isAuthenticated
+                ? true
+                : undefined,
             idempotencyKey,
             contact,
             booking: {
@@ -293,7 +307,7 @@ export default function EventCheckout(): ReactElement {
             eventTitle: eventDetails?.eventName || eventTitle,
             eventId,
             amount: (totalCents / 100).toFixed(2),
-            paymentMethod: paymentToken ? "card" : "free",
+            paymentMethod: paymentToken || selectedSavedCardId ? "card" : "free",
             email: contact.email,
             phone: contact.phone,
             numberOfPeople: quantity,
@@ -310,6 +324,7 @@ export default function EventCheckout(): ReactElement {
       idempotencyKey, contact, eventId, isPrivateEvent, quantity, isSigningUpForSelf,
       selfSelectedOptions, participants, router, eventDetails, eventTitle, totalCents,
       appliedGiftCard, giftCardCents,
+      selectedSavedCardId, saveNewCard, isAuthenticated,
     ]
   );
 
@@ -430,6 +445,18 @@ export default function EventCheckout(): ReactElement {
                 onRemove={() => setAppliedGiftCard(null)}
               />
 
+              {/* Saved cards (signed-in users) — pay with a card on file or a new
+                  card. Hidden when a gift card already covers the whole total. */}
+              {savedCards.length > 0 &&
+                !(amountDueCents <= 0 && appliedGiftCard) && (
+                  <SavedCardPicker
+                    cards={savedCards}
+                    selectedCardId={selectedSavedCardId}
+                    onSelect={setSelectedSavedCardId}
+                    disabled={isProcessing}
+                  />
+                )}
+
               {amountDueCents <= 0 && appliedGiftCard ? (
                 <>
                   {error && (
@@ -445,16 +472,55 @@ export default function EventCheckout(): ReactElement {
                     {isProcessing ? "Completing…" : "Complete booking with gift card"}
                   </Button>
                 </>
+              ) : selectedSavedCardId ? (
+                <>
+                  {error && (
+                    <p className="text-[var(--color-error)] text-sm bg-red-50 border border-red-200 rounded-[var(--radius-md)] px-3 py-2">
+                      {error}
+                    </p>
+                  )}
+                  <Button
+                    variant="primary"
+                    disabled={!formValid || isProcessing}
+                    onClick={() => void submitBooking()}
+                  >
+                    {isProcessing
+                      ? "Completing…"
+                      : `Pay $${(amountDueCents / 100).toFixed(2)} with saved card`}
+                  </Button>
+                </>
               ) : paymentConfig ? (
-                <PaymentStep
-                  applicationId={paymentConfig.applicationId}
-                  locationId={paymentConfig.locationId}
-                  amountDollars={(amountDueCents / 100).toFixed(2)}
-                  ready={formValid}
-                  onToken={submitBooking}
-                  isProcessing={isProcessing}
-                  error={error}
-                />
+                <>
+                  <PaymentStep
+                    applicationId={paymentConfig.applicationId}
+                    locationId={paymentConfig.locationId}
+                    amountDollars={(amountDueCents / 100).toFixed(2)}
+                    ready={formValid}
+                    onToken={submitBooking}
+                    isProcessing={isProcessing}
+                    error={error}
+                    verification={{
+                      intent: "CHARGE",
+                      billingContact: {
+                        givenName: contact.firstName,
+                        familyName: contact.lastName,
+                        email: contact.email,
+                        phone: contact.phone || undefined,
+                      },
+                    }}
+                  />
+                  {isAuthenticated && (
+                    <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+                      <input
+                        type="checkbox"
+                        checked={saveNewCard}
+                        onChange={(e) => setSaveNewCard(e.target.checked)}
+                        className="h-4 w-4 cursor-pointer accent-[var(--color-primary)]"
+                      />
+                      Save this card for faster checkout
+                    </label>
+                  )}
+                </>
               ) : (
                 <div className="rounded-[var(--radius-lg)] border-2 border-dashed border-[var(--color-border-lighter)] px-4 py-6 text-center text-sm text-[var(--color-text-subtle)]">
                   Loading secure payment…

--- a/components/checkout/PaymentStep.tsx
+++ b/components/checkout/PaymentStep.tsx
@@ -38,6 +38,34 @@ const PaymentFormSkeleton = (): ReactElement => (
   </div>
 );
 
+/**
+ * Buyer billing details for Strong Customer Authentication (SCA). All fields are
+ * optional — Square verifies more successfully with more data, but we only ever
+ * pass what we already collect (never a new billing-address form). The card iframe
+ * still captures the postal code for AVS independently.
+ */
+export interface PaymentBillingContact {
+  givenName?: string;
+  familyName?: string;
+  email?: string;
+  phone?: string;
+  addressLines?: string[];
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  countryCode?: string;
+}
+
+/**
+ * Opt-in SCA config. When provided, the card is tokenized WITH verification
+ * details (Square's recommended path — `tokenize()` handles 3DS automatically and
+ * returns a verificationToken). Omit it to tokenize without verification.
+ */
+export interface PaymentVerification {
+  intent: "CHARGE" | "STORE";
+  billingContact: PaymentBillingContact;
+}
+
 interface PaymentStepProps {
   applicationId: string;
   locationId: string;
@@ -49,10 +77,18 @@ interface PaymentStepProps {
   amountDollars: string | null;
   /** Card form is dimmed + non-interactive until true (e.g. contact complete). */
   ready: boolean;
-  onToken: (token: string) => Promise<void>;
+  /**
+   * Receives the card token, plus a verificationToken when `verification` is set
+   * (forward it to payments.create / cards.create for SCA).
+   */
+  onToken: (token: string, verificationToken?: string) => Promise<void>;
   isProcessing: boolean;
   error: string | null;
   processingLabel?: string;
+  /** Optional SCA verification (CHARGE for payments, STORE for saving a card). */
+  verification?: PaymentVerification;
+  /** Override the submit button label (e.g. "Save card"); defaults to Pay/$amount. */
+  submitLabel?: string;
 }
 
 /**
@@ -71,6 +107,8 @@ export default function PaymentStep({
   isProcessing,
   error,
   processingLabel = "Processing…",
+  verification,
+  submitLabel,
 }: PaymentStepProps): ReactElement {
   // The Square SDK re-initializes (re-injecting the card iframe → duplicate forms)
   // whenever createPaymentRequest / cardTokenizeResponseReceived change identity.
@@ -78,10 +116,12 @@ export default function PaymentStep({
   const readyRef = useRef(ready);
   const amountRef = useRef(amountDollars);
   const onTokenRef = useRef(onToken);
+  const verificationRef = useRef(verification);
   useEffect(() => {
     readyRef.current = ready;
     amountRef.current = amountDollars;
     onTokenRef.current = onToken;
+    verificationRef.current = verification;
   });
 
   const createPaymentRequest = useCallback(
@@ -93,11 +133,30 @@ export default function PaymentStep({
     []
   );
 
+  // SCA verification details (stable identity). Built from the latest verification
+  // config at call time; returns CHARGE (with amount) or STORE shape.
+  const createVerificationDetails = useCallback(() => {
+    const v = verificationRef.current;
+    const billingContact = v?.billingContact ?? {};
+    if (v?.intent === "STORE") {
+      return { intent: "STORE" as const, billingContact };
+    }
+    return {
+      intent: "CHARGE" as const,
+      amount: amountRef.current ?? "0",
+      currencyCode: "USD",
+      billingContact,
+    };
+  }, []);
+
   const cardTokenizeResponseReceived = useCallback(
-    async (token: { status: string; token?: string }) => {
+    async (
+      token: { status: string; token?: string },
+      verifiedBuyer?: { token: string } | null
+    ) => {
       if (!readyRef.current) return; // never tokenize before prerequisites are met
       if (token.status === "OK" && token.token) {
-        await onTokenRef.current(token.token);
+        await onTokenRef.current(token.token, verifiedBuyer?.token);
       }
     },
     []
@@ -127,12 +186,16 @@ export default function PaymentStep({
                 applicationId={applicationId}
                 locationId={locationId}
                 createPaymentRequest={createPaymentRequest}
+                createVerificationDetails={
+                  verification ? createVerificationDetails : undefined
+                }
                 cardTokenizeResponseReceived={cardTokenizeResponseReceived}
               >
                 <DynamicCreditCard
                   render={(Button) => (
                     <Button isLoading={isProcessing}>
-                      {amountDollars ? `Pay $${amountDollars}` : "Pay"}
+                      {submitLabel ??
+                        (amountDollars ? `Pay $${amountDollars}` : "Pay")}
                     </Button>
                   )}
                 />

--- a/components/checkout/SavedCardPicker.tsx
+++ b/components/checkout/SavedCardPicker.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { RiBankCardLine } from "react-icons/ri";
+import type { SavedCard } from "@/lib/square/cards";
+
+interface SavedCardPickerProps {
+  cards: SavedCard[];
+  /** Selected saved card id, or null for "use a new card". */
+  selectedCardId: string | null;
+  onSelect: (cardId: string | null) => void;
+  disabled?: boolean;
+}
+
+function brandLabel(brand: string): string {
+  return brand
+    .split("_")
+    .map((w) => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+/**
+ * Lets a signed-in customer pay with a card on file or choose "use a new card".
+ * The list is custom UI built from saved-card metadata (Square doesn't provide a
+ * hosted picker); the actual card entry is still Square's secure iframe.
+ */
+export default function SavedCardPicker({
+  cards,
+  selectedCardId,
+  onSelect,
+  disabled = false,
+}: SavedCardPickerProps): ReactElement {
+  const options = [
+    ...cards.map((card) => ({
+      id: card.id,
+      label: `${brandLabel(card.brand)} •••• ${card.last4}`,
+    })),
+    { id: null as string | null, label: "Use a new card" },
+  ];
+
+  return (
+    <div
+      className={`flex flex-col gap-2 ${disabled ? "opacity-50 pointer-events-none" : ""}`}
+      role="radiogroup"
+      aria-label="Payment method"
+    >
+      {options.map((opt) => {
+        const selected = selectedCardId === opt.id;
+        return (
+          <label
+            key={opt.id ?? "new-card"}
+            className={`flex cursor-pointer items-center gap-3 rounded-[var(--radius-lg)] border-2 px-4 py-3 text-sm transition-colors ${
+              selected
+                ? "border-[var(--color-secondary)] bg-[var(--color-light)]"
+                : "border-[var(--color-border-lighter)] hover:bg-gray-50"
+            }`}
+          >
+            <input
+              type="radio"
+              name="saved-card"
+              checked={selected}
+              onChange={() => onSelect(opt.id)}
+              className="h-4 w-4 accent-[var(--color-primary)]"
+            />
+            {opt.id && <RiBankCardLine className="h-4 w-4 text-gray-400" />}
+            <span className="font-medium text-[var(--color-primary)]">
+              {opt.label}
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/email-templates/DeliveryConfirmationEmail.tsx
+++ b/components/email-templates/DeliveryConfirmationEmail.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { Text, Link } from "@react-email/components";
-import { EmailShell, InfoCard, DetailRow, emailText } from "./shared";
+import {
+  EmailShell,
+  InfoCard,
+  DetailRow,
+  emailText,
+  getStudioEmail,
+} from "./shared";
 
 /**
  * Sent automatically when the Shippo tracking webhook reports DELIVERED
@@ -35,10 +41,7 @@ export const DeliveryConfirmationEmail = ({
 
     <Text style={emailText.subParagraph}>
       Something not right with your order? Reply to this email or reach us at{" "}
-      <Link href="mailto:ashley@coastalcreationsstudio.com">
-        ashley@coastalcreationsstudio.com
-      </Link>
-      .
+      <Link href={`mailto:${getStudioEmail()}`}>{getStudioEmail()}</Link>.
     </Text>
   </EmailShell>
 );

--- a/components/email-templates/EmailTemplate.tsx
+++ b/components/email-templates/EmailTemplate.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { Text } from "@react-email/components";
-import { EmailShell, InfoCard, DetailRow, emailText } from "./shared";
+import {
+  EmailShell,
+  InfoCard,
+  DetailRow,
+  emailText,
+  getStudioEmail,
+} from "./shared";
 
 interface EmailTemplateProps {
   firstName: string;
@@ -9,8 +15,7 @@ interface EmailTemplateProps {
 export const EmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
   firstName,
 }) => {
-  const studioEmail =
-    process.env.STUDIO_EMAIL || "info@coastalcreationsstudio.com";
+  const studioEmail = getStudioEmail();
   return (
     <EmailShell preview={`Welcome to Coastal Creations Studio, ${firstName}`}>
       <Text style={emailText.heroTitle}>Welcome, {firstName}!</Text>

--- a/components/email-templates/EventEmailTemplate.tsx
+++ b/components/email-templates/EventEmailTemplate.tsx
@@ -4,6 +4,7 @@ import {
   EmailShell,
   InfoCard,
   DetailRow,
+  ReceiptButton,
   emailText,
 } from "./shared";
 
@@ -73,11 +74,20 @@ interface Event {
 interface EventEmailTemplateProps {
   customer: Customer;
   event: Event;
+  /** Square-hosted receipt link for this payment, when available. */
+  receiptUrl?: string;
 }
+
+const formatUsd = (n: number): string =>
+  `$${n.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 
 export const EventEmailTemplate = ({
   customer,
   event,
+  receiptUrl,
 }: EventEmailTemplateProps) => {
   // Format currency
 
@@ -201,7 +211,12 @@ export const EventEmailTemplate = ({
         {event.description && (
           <DetailRow label="Description">{event.description}</DetailRow>
         )}
+        {typeof customer.total === "number" && customer.total > 0 && (
+          <DetailRow label="Amount Paid">{formatUsd(customer.total)}</DetailRow>
+        )}
       </InfoCard>
+
+      <ReceiptButton href={receiptUrl} />
     </EmailShell>
   );
 };

--- a/components/email-templates/OrderConfirmationEmail.tsx
+++ b/components/email-templates/OrderConfirmationEmail.tsx
@@ -90,6 +90,12 @@ export const OrderConfirmationEmail = ({
     </InfoCard>
 
     <Text style={emailText.subParagraph}>
+      <strong>What&apos;s next?</strong> We&apos;ll email you a tracking number
+      as soon as your order ships, so you can follow it to your door — no account
+      needed.
+    </Text>
+
+    <Text style={emailText.subParagraph}>
       Questions about your order? Reply to this email or contact us at{" "}
       <a href="mailto:ashley@coastalcreationsstudio.com">
         ashley@coastalcreationsstudio.com

--- a/components/email-templates/OrderConfirmationEmail.tsx
+++ b/components/email-templates/OrderConfirmationEmail.tsx
@@ -4,7 +4,9 @@ import {
   EmailShell,
   InfoCard,
   DetailRow,
+  ReceiptButton,
   emailText,
+  getStudioEmail,
 } from "./shared";
 import { formatCents } from "@/lib/utils/moneyHelpers";
 
@@ -33,6 +35,8 @@ export interface OrderConfirmationData {
     postalCode: string;
   };
   shippingMethod: string;
+  /** Square-hosted receipt link for this payment, when available. */
+  receiptUrl?: string;
 }
 
 interface OrderConfirmationEmailProps {
@@ -89,6 +93,8 @@ export const OrderConfirmationEmail = ({
       <DetailRow label="Method">{order.shippingMethod}</DetailRow>
     </InfoCard>
 
+    <ReceiptButton href={order.receiptUrl} />
+
     <Text style={emailText.subParagraph}>
       <strong>What&apos;s next?</strong> We&apos;ll email you a tracking number
       as soon as your order ships, so you can follow it to your door — no account
@@ -97,10 +103,7 @@ export const OrderConfirmationEmail = ({
 
     <Text style={emailText.subParagraph}>
       Questions about your order? Reply to this email or contact us at{" "}
-      <a href="mailto:ashley@coastalcreationsstudio.com">
-        ashley@coastalcreationsstudio.com
-      </a>
-      .
+      <a href={`mailto:${getStudioEmail()}`}>{getStudioEmail()}</a>.
     </Text>
   </EmailShell>
 );

--- a/components/email-templates/PrivateEventDepositEmail.tsx
+++ b/components/email-templates/PrivateEventDepositEmail.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+import { Text, Link } from "@react-email/components";
+import { EmailShell, InfoCard, DetailRow, emailText } from "./shared";
+
+export interface PrivateEventDepositEmailProps {
+  customerFirstName: string;
+  customerName: string;
+  customerEmail?: string;
+  customerPhone?: string;
+  eventTitle: string;
+  /** Deposit paid, in dollars. */
+  depositPaid: number;
+  /** Full event price, in dollars (used to show the remaining balance). */
+  fullPrice?: number;
+  /** Admin notification variant (vs. the customer confirmation). */
+  isAdmin?: boolean;
+}
+
+const usd = (n: number): string =>
+  `$${n.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+
+export const PrivateEventDepositEmail = ({
+  customerFirstName,
+  customerName,
+  customerEmail,
+  customerPhone,
+  eventTitle,
+  depositPaid,
+  fullPrice,
+  isAdmin = false,
+}: PrivateEventDepositEmailProps) => {
+  const balanceDue =
+    fullPrice != null && fullPrice > depositPaid
+      ? fullPrice - depositPaid
+      : undefined;
+
+  if (isAdmin) {
+    return (
+      <EmailShell
+        preview={`New private event deposit — ${eventTitle}`}
+        showDisclaimer={false}
+      >
+        <Text style={emailText.badge}>💰 NEW PRIVATE EVENT DEPOSIT</Text>
+        <Text style={emailText.heroTitle}>{eventTitle}</Text>
+        <Text style={emailText.paragraph}>
+          <strong>{customerName}</strong> paid a deposit to book the private
+          event below. Reach out to finalize the details.
+        </Text>
+
+        <InfoCard title="Booking Details">
+          <DetailRow label="Event">{eventTitle}</DetailRow>
+          <DetailRow label="Deposit Paid">{usd(depositPaid)}</DetailRow>
+          {balanceDue != null && (
+            <DetailRow label="Balance Due">{usd(balanceDue)}</DetailRow>
+          )}
+        </InfoCard>
+
+        <InfoCard title="Customer">
+          <DetailRow label="Name">{customerName}</DetailRow>
+          {customerEmail && (
+            <DetailRow label="Email">
+              <Link href={`mailto:${customerEmail}`}>{customerEmail}</Link>
+            </DetailRow>
+          )}
+          {customerPhone && <DetailRow label="Phone">{customerPhone}</DetailRow>}
+        </InfoCard>
+      </EmailShell>
+    );
+  }
+
+  return (
+    <EmailShell preview={`Deposit received for ${eventTitle}`}>
+      <Text style={emailText.badge}>✓ DEPOSIT RECEIVED</Text>
+      <Text style={emailText.heroTitle}>Your event is reserved!</Text>
+      <Text style={emailText.paragraph}>
+        Hi {customerFirstName}, thank you! We&apos;ve received your deposit for{" "}
+        <strong>{eventTitle}</strong>. Your date is being held and a member of
+        our team will reach out shortly to finalize all the details.
+      </Text>
+
+      <InfoCard title="Booking Details">
+        <DetailRow label="Event">{eventTitle}</DetailRow>
+        <DetailRow label="Deposit Paid">{usd(depositPaid)}</DetailRow>
+        {balanceDue != null && (
+          <DetailRow label="Balance Due">{usd(balanceDue)}</DetailRow>
+        )}
+        <DetailRow label="Location">
+          Coastal Creations Studio
+          <br />
+          411 E 8th Street
+          <br />
+          Ocean City, NJ 08226
+        </DetailRow>
+      </InfoCard>
+
+      <Text style={emailText.subParagraph}>
+        Any balance is settled when we confirm the final details of your event.
+        Questions? Just reply to this email and we&apos;ll be happy to help.
+      </Text>
+    </EmailShell>
+  );
+};
+
+export default PrivateEventDepositEmail;

--- a/components/email-templates/PrivateEventDepositEmail.tsx
+++ b/components/email-templates/PrivateEventDepositEmail.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { Text, Link } from "@react-email/components";
-import { EmailShell, InfoCard, DetailRow, emailText } from "./shared";
+import {
+  EmailShell,
+  InfoCard,
+  DetailRow,
+  ReceiptButton,
+  emailText,
+} from "./shared";
 
 export interface PrivateEventDepositEmailProps {
   customerFirstName: string;
@@ -12,6 +18,8 @@ export interface PrivateEventDepositEmailProps {
   depositPaid: number;
   /** Full event price, in dollars (used to show the remaining balance). */
   fullPrice?: number;
+  /** Square-hosted receipt link for the deposit payment, when available. */
+  receiptUrl?: string;
   /** Admin notification variant (vs. the customer confirmation). */
   isAdmin?: boolean;
 }
@@ -30,6 +38,7 @@ export const PrivateEventDepositEmail = ({
   eventTitle,
   depositPaid,
   fullPrice,
+  receiptUrl,
   isAdmin = false,
 }: PrivateEventDepositEmailProps) => {
   const balanceDue =
@@ -95,6 +104,8 @@ export const PrivateEventDepositEmail = ({
           Ocean City, NJ 08226
         </DetailRow>
       </InfoCard>
+
+      <ReceiptButton href={receiptUrl} />
 
       <Text style={emailText.subParagraph}>
         Any balance is settled when we confirm the final details of your event.

--- a/components/email-templates/RefundConfirmationEmail.tsx
+++ b/components/email-templates/RefundConfirmationEmail.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { Text } from "@react-email/components";
-import { EmailShell, InfoCard, DetailRow, emailText } from "./shared";
+import {
+  EmailShell,
+  InfoCard,
+  DetailRow,
+  emailText,
+  getStudioEmail,
+} from "./shared";
 
 export interface RefundLineItem {
   name: string;
@@ -62,9 +68,7 @@ export const RefundConfirmationEmail = ({
         ? "This order has been fully refunded."
         : "If you have questions about this refund, just reply to this email or contact us at "}
       {data.isFullRefund ? null : (
-        <a href="mailto:ashley@coastalcreationsstudio.com">
-          ashley@coastalcreationsstudio.com
-        </a>
+        <a href={`mailto:${getStudioEmail()}`}>{getStudioEmail()}</a>
       )}
       {data.isFullRefund ? null : "."}
     </Text>

--- a/components/email-templates/ShippingConfirmationEmail.tsx
+++ b/components/email-templates/ShippingConfirmationEmail.tsx
@@ -5,6 +5,7 @@ import {
   InfoCard,
   DetailRow,
   emailText,
+  getStudioEmail,
 } from "./shared";
 
 export interface ShippingConfirmationEmailProps {
@@ -59,10 +60,7 @@ export const ShippingConfirmationEmail = ({
     <Text style={emailText.subParagraph}>
       Estimated delivery times vary by carrier. If you have any questions,
       reply to this email or reach us at{" "}
-      <Link href="mailto:ashley@coastalcreationsstudio.com">
-        ashley@coastalcreationsstudio.com
-      </Link>
-      .
+      <Link href={`mailto:${getStudioEmail()}`}>{getStudioEmail()}</Link>.
     </Text>
   </EmailShell>
 );

--- a/components/email-templates/shared.tsx
+++ b/components/email-templates/shared.tsx
@@ -11,7 +11,15 @@ import {
   Link,
   Img,
   Hr,
+  Button,
 } from "@react-email/components";
+
+/**
+ * The studio's public contact address. Single source of truth so templates stop
+ * hardcoding it. STUDIO_EMAIL in prod; a sensible fallback otherwise.
+ */
+export const getStudioEmail = (): string =>
+  process.env.STUDIO_EMAIL || "ashley@coastalcreationsstudio.com";
 
 /**
  * Shared email design system for Coastal Creations transactional emails.
@@ -148,8 +156,35 @@ export const CardText = ({ children }: { children: React.ReactNode }) => (
   </tr>
 );
 
+/**
+ * "View Square Receipt" link button — a subtle outlined CTA so it never competes
+ * with a primary action. Renders nothing when no receipt URL is available.
+ */
+export const ReceiptButton = ({ href }: { href?: string }) => {
+  if (!href) return null;
+  return (
+    <Button
+      href={href}
+      style={{
+        display: "inline-block",
+        border: `1px solid ${c.lightBorder}`,
+        color: c.secondary,
+        backgroundColor: c.white,
+        fontSize: "14px",
+        fontWeight: 600,
+        padding: "10px 22px",
+        borderRadius: "8px",
+        textDecoration: "none",
+        margin: "0 0 16px",
+      }}
+    >
+      View Square Receipt
+    </Button>
+  );
+};
+
 export const EmailFooter = () => {
-  const studioEmail = process.env.STUDIO_EMAIL || "info@coastalcreationsstudio.com";
+  const studioEmail = getStudioEmail();
   return (
     <Section style={footer.wrap}>
       <Hr style={footer.rule} />

--- a/components/reservations/PaymentForm.tsx
+++ b/components/reservations/PaymentForm.tsx
@@ -533,6 +533,7 @@ export default function PaymentForm({
       }
 
       const squarePaymentId = paymentResult.result.payment.id;
+      const squareReceiptUrl = paymentResult.result.payment.receiptUrl;
       console.log(
         "[PaymentForm-handleCardTokenizeResponse] Payment completed:",
         squarePaymentId
@@ -614,9 +615,13 @@ export default function PaymentForm({
       }
 
       setPaymentStatus("success");
-      router.push(
-        `/reservations/confirmation?bookingId=${result.data._id}&total=${grandTotal}&name=${encodeURIComponent(reservation.eventName)}`
-      );
+      const confirmParams = new URLSearchParams({
+        bookingId: result.data._id,
+        total: String(grandTotal),
+        name: reservation.eventName,
+      });
+      if (squareReceiptUrl) confirmParams.set("receiptUrl", squareReceiptUrl);
+      router.push(`/reservations/confirmation?${confirmParams.toString()}`);
     } catch (error) {
       console.error(
         "[PaymentForm-handleSubmit] Error processing payment:",

--- a/components/store/CheckoutForm.tsx
+++ b/components/store/CheckoutForm.tsx
@@ -12,6 +12,8 @@ import ContactFields, {
   type ContactValues,
 } from "@/components/store/ContactFields";
 import PaymentStep from "@/components/checkout/PaymentStep";
+import SavedCardPicker from "@/components/checkout/SavedCardPicker";
+import { useSavedCards } from "@/hooks/queries/use-saved-cards";
 import GiftCardRedemption from "@/components/checkout/GiftCardRedemption";
 import { isValidUsPhone } from "@/components/checkout/ContactForm";
 import { isValidEmail } from "@/lib/utils/validation";
@@ -73,6 +75,13 @@ export default function CheckoutForm({
   const [error, setError] = useState<string | null>(null);
   const [orderCompleted, setOrderCompleted] = useState(false);
   const [appliedGiftCard, setAppliedGiftCard] = useState<AppliedGiftCard | null>(null);
+
+  // Cards on file (signed-in users). null selection = pay with a new card.
+  const { data: savedCardsData } = useSavedCards();
+  const savedCards = savedCardsData?.cards ?? [];
+  const isAuthenticated = savedCardsData?.authenticated ?? false;
+  const [selectedSavedCardId, setSelectedSavedCardId] = useState<string | null>(null);
+  const [saveNewCard, setSaveNewCard] = useState(false);
   // One stable idempotency key per mount — reused across retries of THIS cart
   // attempt so a lost-response retry returns the original charge (no double
   // charge). A new mount (new cart attempt after clearCart) gets a fresh key.
@@ -149,7 +158,10 @@ export default function CheckoutForm({
     }
   };
 
-  const placeOrder = async (token?: string): Promise<void> => {
+  const placeOrder = async (
+    token?: string,
+    verificationToken?: string
+  ): Promise<void> => {
     if (!selectedRate) return;
     setIsProcessing(true);
     setError(null);
@@ -159,6 +171,12 @@ export default function CheckoutForm({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           paymentToken: token,
+          verificationToken,
+          savedCardId: selectedSavedCardId ?? undefined,
+          saveCard:
+            saveNewCard && !selectedSavedCardId && isAuthenticated
+              ? true
+              : undefined,
           customer: {
             firstName: contact.firstName,
             lastName: contact.lastName,
@@ -380,6 +398,18 @@ export default function CheckoutForm({
             </p>
           </div>
 
+          {/* Saved cards (signed-in users) — choose a card on file or a new card.
+              Hidden when a gift card already covers the whole order. */}
+          {savedCards.length > 0 &&
+            !(amountDueCents <= 0 && appliedGiftCard) && (
+              <SavedCardPicker
+                cards={savedCards}
+                selectedCardId={selectedSavedCardId}
+                onSelect={setSelectedSavedCardId}
+                disabled={isProcessing}
+              />
+            )}
+
           {amountDueCents <= 0 && appliedGiftCard && selectedRate ? (
             <>
               {error && (
@@ -395,16 +425,68 @@ export default function CheckoutForm({
                 {isProcessing ? "Placing order…" : "Place order with gift card"}
               </Button>
             </>
+          ) : selectedSavedCardId ? (
+            <>
+              {error && (
+                <p className="text-[var(--color-error)] text-sm bg-red-50 border border-red-200 rounded-[var(--radius-md)] px-3 py-2">
+                  {error}
+                </p>
+              )}
+              <Button
+                variant="primary"
+                disabled={isProcessing || !canPay || !selectedRate}
+                onClick={() => void placeOrder()}
+              >
+                {isProcessing
+                  ? "Placing order…"
+                  : `Pay $${(amountDueCents / 100).toFixed(2)} with saved card`}
+              </Button>
+            </>
           ) : paymentConfig ? (
-            <PaymentStep
-              applicationId={paymentConfig.applicationId}
-              locationId={paymentConfig.locationId}
-              amountDollars={selectedRate ? (amountDueCents / 100).toFixed(2) : null}
-              ready={canPay && !!selectedRate}
-              onToken={placeOrder}
-              isProcessing={isProcessing}
-              error={error}
-            />
+            <>
+              <PaymentStep
+                applicationId={paymentConfig.applicationId}
+                locationId={paymentConfig.locationId}
+                amountDollars={selectedRate ? (amountDueCents / 100).toFixed(2) : null}
+                ready={canPay && !!selectedRate}
+                onToken={placeOrder}
+                isProcessing={isProcessing}
+                error={error}
+                verification={{
+                  intent: "CHARGE",
+                  billingContact: {
+                    givenName: contact.firstName,
+                    familyName: contact.lastName,
+                    email: contact.email,
+                    phone: contact.phone || undefined,
+                    // Use the shipping address as a billing hint only when not a gift.
+                    ...(!isGift
+                      ? {
+                          addressLines: [
+                            shipping.addressLine1,
+                            shipping.addressLine2,
+                          ].filter(Boolean) as string[],
+                          city: shipping.city,
+                          state: shipping.state,
+                          postalCode: shipping.zip,
+                          countryCode: "US",
+                        }
+                      : {}),
+                  },
+                }}
+              />
+              {isAuthenticated && (
+                <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+                  <input
+                    type="checkbox"
+                    checked={saveNewCard}
+                    onChange={(e) => setSaveNewCard(e.target.checked)}
+                    className="h-4 w-4 cursor-pointer accent-[var(--color-primary)]"
+                  />
+                  Save this card for faster checkout
+                </label>
+              )}
+            </>
           ) : (
             <div className="rounded-[var(--radius-lg)] border-2 border-dashed border-[var(--color-border-lighter)] px-4 py-6 text-center text-sm text-[var(--color-text-subtle)]">
               Loading secure payment…

--- a/components/store/CheckoutForm.tsx
+++ b/components/store/CheckoutForm.tsx
@@ -74,13 +74,16 @@ export default function CheckoutForm({
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [orderCompleted, setOrderCompleted] = useState(false);
-  const [appliedGiftCard, setAppliedGiftCard] = useState<AppliedGiftCard | null>(null);
+  const [appliedGiftCard, setAppliedGiftCard] =
+    useState<AppliedGiftCard | null>(null);
 
   // Cards on file (signed-in users). null selection = pay with a new card.
   const { data: savedCardsData } = useSavedCards();
   const savedCards = savedCardsData?.cards ?? [];
   const isAuthenticated = savedCardsData?.authenticated ?? false;
-  const [selectedSavedCardId, setSelectedSavedCardId] = useState<string | null>(null);
+  const [selectedSavedCardId, setSelectedSavedCardId] = useState<string | null>(
+    null,
+  );
   const [saveNewCard, setSaveNewCard] = useState(false);
   // One stable idempotency key per mount — reused across retries of THIS cart
   // attempt so a lost-response retry returns the original charge (no double
@@ -110,7 +113,10 @@ export default function CheckoutForm({
     setContact((prev) => ({ ...prev, [field]: value }));
   };
 
-  const updateShipping = (field: keyof AddressFormValues, value: string): void => {
+  const updateShipping = (
+    field: keyof AddressFormValues,
+    value: string,
+  ): void => {
     setShipping((prev) => ({ ...prev, [field]: value }));
     // Address (not name) changes invalidate the quoted rates.
     if (field !== "firstName" && field !== "lastName") resetRates();
@@ -146,7 +152,10 @@ export default function CheckoutForm({
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error ?? "Could not fetch shipping rates. Please check the address.");
+        setError(
+          data.error ??
+            "Could not fetch shipping rates. Please check the address.",
+        );
         return;
       }
       setRates(data.rates);
@@ -160,7 +169,7 @@ export default function CheckoutForm({
 
   const placeOrder = async (
     token?: string,
-    verificationToken?: string
+    verificationToken?: string,
   ): Promise<void> => {
     if (!selectedRate) return;
     setIsProcessing(true);
@@ -197,7 +206,10 @@ export default function CheckoutForm({
           subtotalCents,
           idempotencyKey,
           giftCard: appliedGiftCard
-            ? { giftCardId: appliedGiftCard.giftCardId, amountCents: giftCardCents }
+            ? {
+                giftCardId: appliedGiftCard.giftCardId,
+                amountCents: giftCardCents,
+              }
             : undefined,
         }),
       });
@@ -209,7 +221,14 @@ export default function CheckoutForm({
       }
       setOrderCompleted(true);
       clearCart();
-      router.push(`/order-confirmation?orderNumber=${data.orderNumber}`);
+      const params = new URLSearchParams({ orderNumber: data.orderNumber });
+      if (data.receiptUrl) params.set("receiptUrl", data.receiptUrl);
+      if (typeof data.totalCents === "number") {
+        params.set("total", (data.totalCents / 100).toFixed(2));
+      }
+      if (contact.firstName) params.set("firstName", contact.firstName);
+      if (contact.email) params.set("email", contact.email);
+      router.push(`/order-confirmation?${params.toString()}`);
     } catch {
       setError("Network error. Please try again.");
       setIsProcessing(false);
@@ -219,18 +238,18 @@ export default function CheckoutForm({
   // Buyer contact must be valid to pay (and receive the receipt).
   const contactComplete = Boolean(
     contact.firstName.trim() &&
-      contact.lastName.trim() &&
-      isValidEmail(contact.email) &&
-      isValidUsPhone(contact.phone)
+    contact.lastName.trim() &&
+    isValidEmail(contact.email) &&
+    isValidUsPhone(contact.phone),
   );
 
   // Destination address must be complete; gifting also requires a recipient name.
   const shippingComplete = Boolean(
     shipping.addressLine1.trim() &&
-      shipping.city.trim() &&
-      shipping.state.trim() &&
-      shipping.zip.trim() &&
-      (!isGift || (shipping.firstName.trim() && shipping.lastName.trim()))
+    shipping.city.trim() &&
+    shipping.state.trim() &&
+    shipping.zip.trim() &&
+    (!isGift || (shipping.firstName.trim() && shipping.lastName.trim())),
   );
 
   const canPay = contactComplete && shippingComplete;
@@ -244,11 +263,15 @@ export default function CheckoutForm({
     }, 600);
 
     return () => clearTimeout(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isGift,
-    shipping.addressLine1, shipping.city, shipping.state, shipping.zip,
-    shipping.firstName, shipping.lastName,
+    shipping.addressLine1,
+    shipping.city,
+    shipping.state,
+    shipping.zip,
+    shipping.firstName,
+    shipping.lastName,
   ]);
 
   useEffect(() => {
@@ -261,10 +284,8 @@ export default function CheckoutForm({
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-10 items-start">
-
       {/* Left column: form (below the summary when stacked, left on desktop) */}
       <div className="order-2 lg:order-1 flex flex-col gap-8 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-white p-6 sm:p-8 shadow-[var(--shadow-card)]">
-
         {/* Contact (buyer) */}
         <div className="flex flex-col gap-5">
           <h2 className="text-base font-semibold text-[var(--color-primary)]">
@@ -288,14 +309,14 @@ export default function CheckoutForm({
                 onChange={(e) => toggleGift(e.target.checked)}
                 className="h-4 w-4 cursor-pointer accent-[var(--color-primary)]"
               />
-              This is a gift — ship to a different address
+              Ship to a different address?
             </label>
           </div>
 
           {isGift && (
             <p className="rounded-[var(--radius-md)] bg-[var(--color-light)] px-3 py-2 text-xs text-[var(--color-text-subtle)]">
-              We&apos;ll ship to the recipient below. Your order confirmation and
-              receipt come to you.
+              We&apos;ll ship to the recipient below. Your order confirmation
+              and receipt come to you.
             </p>
           )}
 
@@ -447,7 +468,9 @@ export default function CheckoutForm({
               <PaymentStep
                 applicationId={paymentConfig.applicationId}
                 locationId={paymentConfig.locationId}
-                amountDollars={selectedRate ? (amountDueCents / 100).toFixed(2) : null}
+                amountDollars={
+                  selectedRate ? (amountDueCents / 100).toFixed(2) : null
+                }
                 ready={canPay && !!selectedRate}
                 onToken={placeOrder}
                 isProcessing={isProcessing}

--- a/components/store/CheckoutForm.tsx
+++ b/components/store/CheckoutForm.tsx
@@ -38,7 +38,17 @@ const EMPTY_SHIPPING: AddressFormValues = {
   zip: "",
 };
 
-export default function CheckoutForm(): ReactElement | null {
+export interface CheckoutFormProps {
+  // Prefilled contact/shipping for a signed-in returning customer (from their last
+  // order or Square profile). Undefined for guests → the form starts empty.
+  initialContact?: Partial<ContactValues>;
+  initialShipping?: Partial<AddressFormValues>;
+}
+
+export default function CheckoutForm({
+  initialContact,
+  initialShipping,
+}: CheckoutFormProps = {}): ReactElement | null {
   const router = useRouter();
   const { items, subtotalCents, clearCart } = useCart();
   const { data: paymentConfig } = usePaymentConfig();
@@ -46,9 +56,15 @@ export default function CheckoutForm(): ReactElement | null {
   // Buyer (payer + receipt) is always `contact`. The shipment goes to `shipping`.
   // When `isGift`, the buyer collects the recipient's name in the shipping block;
   // otherwise the shipment is addressed to the buyer.
-  const [contact, setContact] = useState<ContactValues>(EMPTY_CONTACT);
+  const [contact, setContact] = useState<ContactValues>({
+    ...EMPTY_CONTACT,
+    ...initialContact,
+  });
   const [isGift, setIsGift] = useState(false);
-  const [shipping, setShipping] = useState<AddressFormValues>(EMPTY_SHIPPING);
+  const [shipping, setShipping] = useState<AddressFormValues>({
+    ...EMPTY_SHIPPING,
+    ...initialShipping,
+  });
 
   const [rates, setRates] = useState<ShippingRate[]>([]);
   const [selectedRate, setSelectedRate] = useState<ShippingRate | null>(null);

--- a/hooks/queries/use-saved-cards.ts
+++ b/hooks/queries/use-saved-cards.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import type { SavedCard } from "@/lib/square/cards";
+
+export interface SavedCardsResult {
+  cards: SavedCard[];
+  /** True when the request was authorized — distinguishes a guest from a
+   * signed-in user who simply has no saved cards (drives the "save card" opt-in). */
+  authenticated: boolean;
+}
+
+/**
+ * The signed-in user's saved cards. Returns `authenticated: false` for guests
+ * (the API 401s) so checkout can hide saved-card UI + the save-card checkbox.
+ */
+export function useSavedCards() {
+  return useQuery<SavedCardsResult>({
+    queryKey: ["saved-cards"],
+    queryFn: async () => {
+      const res = await fetch("/api/account/cards");
+      if (!res.ok) return { cards: [], authenticated: false };
+      const data = await res.json();
+      return {
+        cards: (data.cards ?? []) as SavedCard[],
+        authenticated: true,
+      };
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/lib/account/queries.ts
+++ b/lib/account/queries.ts
@@ -23,10 +23,27 @@ export function emailMatch(email: string): { $regex: string; $options: string } 
   return { $regex: `^${escaped}$`, $options: "i" };
 }
 
+/**
+ * Match orders owned by the signed-in user. An order is theirs if it carries their
+ * stamped `userId` (orders placed while signed in) OR its buyer email matches the
+ * session email (guest orders, and any placed before userId stamping existed).
+ * `userId` is optional so callers that only have an email still work.
+ */
+function orderOwnerMatch(
+  sessionEmail: string,
+  userId?: string
+): Record<string, unknown> {
+  const byEmail = { "customer.email": emailMatch(sessionEmail) };
+  return userId ? { $or: [{ userId }, byEmail] } : byEmail;
+}
+
 /** Store orders belonging to the signed-in user, newest first. */
-export async function getMyOrders(sessionEmail: string): Promise<IOrder[]> {
+export async function getMyOrders(
+  sessionEmail: string,
+  userId?: string
+): Promise<IOrder[]> {
   await connectMongo();
-  return Order.find({ "customer.email": emailMatch(sessionEmail) })
+  return Order.find(orderOwnerMatch(sessionEmail, userId))
     .sort({ createdAt: -1 })
     .lean<IOrder[]>();
 }
@@ -34,13 +51,28 @@ export async function getMyOrders(sessionEmail: string): Promise<IOrder[]> {
 /** A single order by number, ONLY if it belongs to the signed-in user (else null). */
 export async function getMyOrderByNumber(
   sessionEmail: string,
-  orderNumber: string
+  orderNumber: string,
+  userId?: string
 ): Promise<IOrder | null> {
   await connectMongo();
   return Order.findOne({
     orderNumber,
-    "customer.email": emailMatch(sessionEmail),
+    ...orderOwnerMatch(sessionEmail, userId),
   }).lean<IOrder | null>();
+}
+
+/**
+ * The signed-in user's most recent order, used to prefill checkout (name, phone,
+ * shipping address). Returns null when they have no prior order.
+ */
+export async function getLatestOrderForPrefill(
+  sessionEmail: string,
+  userId?: string
+): Promise<IOrder | null> {
+  await connectMongo();
+  return Order.findOne(orderOwnerMatch(sessionEmail, userId))
+    .sort({ createdAt: -1 })
+    .lean<IOrder | null>();
 }
 
 /** Event/class bookings belonging to the signed-in user, newest first. */

--- a/lib/email/recipients.ts
+++ b/lib/email/recipients.ts
@@ -1,9 +1,11 @@
 /**
  * Centralized transactional-email recipient routing.
  *
- * In production, customer emails go to the customer and admin emails go to
- * STUDIO_EMAIL (with a hard fallback). In dev/stage, EVERYTHING redirects to
- * DEV_EMAIL so we never email real customers from a non-prod environment.
+ * The CUSTOMER copy always goes to the real customer address (the sending domain
+ * is verified, so Resend can deliver anywhere) — this lets us test the checkout
+ * flow as a genuine customer in dev. Only the ADMIN copy is redirected in
+ * non-production: in prod it goes to STUDIO_EMAIL (with a hard fallback), in
+ * dev/stage it goes to DEV_EMAIL so Ashley never gets test-order notifications.
  *
  * This is the single source of truth — every send site should call it instead
  * of re-deriving the prod/dev branch inline (which had drifted across routes).
@@ -29,6 +31,7 @@ export function resolveEmailRecipients(
   customerEmail: string | null | undefined
 ): EmailRecipients {
   const isProduction = process.env.VERCEL_ENV === "production";
+  // The customer copy always goes to the real address — in every environment.
   const customer = customerEmail ?? "";
 
   // Use `||` so an empty-string env var (a misconfiguration) is treated as unset.
@@ -39,8 +42,8 @@ export function resolveEmailRecipients(
     };
   }
 
-  // dev / stage: redirect both to DEV_EMAIL (falling back to the customer email
-  // only if DEV_EMAIL is not configured).
-  const devEmail = process.env.DEV_EMAIL || customer;
-  return { customer: devEmail, admin: devEmail };
+  // dev / stage: only the ADMIN copy is redirected, so test orders never reach
+  // Ashley. Fall back to the customer address if DEV_EMAIL is not configured.
+  const adminInDev = process.env.DEV_EMAIL || customer;
+  return { customer, admin: adminInDev };
 }

--- a/lib/email/sendBookingConfirmation.ts
+++ b/lib/email/sendBookingConfirmation.ts
@@ -7,18 +7,20 @@
  * legacy route share one implementation. Never throws — an email failure must
  * not fail an already-completed (already-charged) booking.
  *
- * Parity note: confirmation emails are only sent for `eventType === "Event"`
- * (the existing templates load the Event model). PrivateEvent/Reservation
- * bookings do not send a confirmation email today; this preserves that behavior.
+ * Coverage: `Event` bookings send the full registration confirmation;
+ * `PrivateEvent` bookings send a deposit-received confirmation. `Reservation`
+ * bookings still send no confirmation email (no template wired today).
  */
 import { Resend } from "resend";
 import { render } from "@react-email/render";
 import * as React from "react";
 import { EventEmailTemplate } from "@/components/email-templates/EventEmailTemplate";
 import { CustomerDetailsTemplate } from "@/components/email-templates/CustomerDetailsTemplate";
+import { PrivateEventDepositEmail } from "@/components/email-templates/PrivateEventDepositEmail";
 import { connectMongo } from "@/lib/mongoose";
 import Customer from "@/lib/models/Customer";
 import Event from "@/lib/models/Event";
+import PrivateEvent from "@/lib/models/PrivateEvent";
 import { resolveEmailRecipients, EMAIL_FROM } from "@/lib/email/recipients";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -32,10 +34,73 @@ export async function sendBookingConfirmationEmails(
     await connectMongo();
 
     const customerDoc = await Customer.findById(customerId).lean();
-    const eventDoc = await Event.findById(eventId).lean();
-    if (!customerDoc || !eventDoc) {
+    if (!customerDoc) {
       console.warn(
-        "[SEND-BOOKING-CONFIRMATION] Skipping email — customer or event not found",
+        "[SEND-BOOKING-CONFIRMATION] Skipping email — customer not found",
+        { customerId, eventId }
+      );
+      return;
+    }
+
+    const customerEmail = customerDoc.billingInfo.emailAddress;
+    const { customer: customerRecipient, admin: adminRecipient } =
+      resolveEmailRecipients(customerEmail);
+
+    // Private events send a deposit-received confirmation instead of the full
+    // registration email (no class date/time; the team finalizes details later).
+    if (customerDoc.eventType === "PrivateEvent") {
+      const privateEventDoc = await PrivateEvent.findById(eventId).lean();
+      if (!privateEventDoc) {
+        console.warn(
+          "[SEND-BOOKING-CONFIRMATION] Skipping email — private event not found",
+          { customerId, eventId }
+        );
+        return;
+      }
+      const customerName =
+        `${customerDoc.billingInfo.firstName} ${customerDoc.billingInfo.lastName}`.trim();
+      const shared = {
+        customerFirstName: customerDoc.billingInfo.firstName,
+        customerName,
+        customerEmail: customerEmail ?? undefined,
+        customerPhone: customerDoc.billingInfo.phoneNumber,
+        eventTitle: privateEventDoc.title,
+        depositPaid: customerDoc.total,
+        fullPrice: privateEventDoc.price,
+      };
+
+      if (customerEmail && customerRecipient) {
+        const html = await render(
+          React.createElement(PrivateEventDepositEmail, shared)
+        );
+        await resend.emails.send({
+          from: FROM,
+          to: [customerRecipient],
+          subject: `Deposit received for ${privateEventDoc.title}`,
+          html,
+        });
+      }
+      if (adminRecipient) {
+        const html = await render(
+          React.createElement(PrivateEventDepositEmail, { ...shared, isAdmin: true })
+        );
+        await resend.emails.send({
+          from: FROM,
+          to: [adminRecipient],
+          subject: `New Private Event Deposit: ${privateEventDoc.title}`,
+          html,
+        });
+      }
+      return;
+    }
+
+    // Reservations have no confirmation template wired today.
+    if (customerDoc.eventType !== "Event") return;
+
+    const eventDoc = await Event.findById(eventId).lean();
+    if (!eventDoc) {
+      console.warn(
+        "[SEND-BOOKING-CONFIRMATION] Skipping email — event not found",
         { customerId, eventId }
       );
       return;
@@ -46,11 +111,8 @@ export async function sendBookingConfirmationEmails(
     const event = JSON.parse(JSON.stringify(eventDoc));
     const eventTitle = event.eventName || "your event";
 
-    const { customer: customerRecipient, admin: adminRecipient } =
-      resolveEmailRecipients(customerDoc.billingInfo.emailAddress);
-
     // Customer email only when they gave an address and we have a recipient.
-    if (customerDoc.billingInfo.emailAddress && customerRecipient) {
+    if (customerEmail && customerRecipient) {
       const html = await render(
         React.createElement(EventEmailTemplate, { customer, event })
       );

--- a/lib/email/sendBookingConfirmation.ts
+++ b/lib/email/sendBookingConfirmation.ts
@@ -43,6 +43,7 @@ export async function sendBookingConfirmationEmails(
     }
 
     const customerEmail = customerDoc.billingInfo.emailAddress;
+    const receiptUrl = customerDoc.squareReceiptUrl;
     const { customer: customerRecipient, admin: adminRecipient } =
       resolveEmailRecipients(customerEmail);
 
@@ -67,6 +68,7 @@ export async function sendBookingConfirmationEmails(
         eventTitle: privateEventDoc.title,
         depositPaid: customerDoc.total,
         fullPrice: privateEventDoc.price,
+        receiptUrl,
       };
 
       if (customerEmail && customerRecipient) {
@@ -114,7 +116,7 @@ export async function sendBookingConfirmationEmails(
     // Customer email only when they gave an address and we have a recipient.
     if (customerEmail && customerRecipient) {
       const html = await render(
-        React.createElement(EventEmailTemplate, { customer, event })
+        React.createElement(EventEmailTemplate, { customer, event, receiptUrl })
       );
       await resend.emails.send({
         from: FROM,

--- a/lib/models/Customer.ts
+++ b/lib/models/Customer.ts
@@ -39,6 +39,7 @@ export interface ICustomer extends Document {
   };
   squarePaymentId?: string;
   squareCustomerId?: string;
+  squareReceiptUrl?: string;
   refundStatus?: "none" | "partial" | "full";
   refundAmount?: number;
   refundedAt?: Date;
@@ -203,6 +204,11 @@ const CustomerSchema = new Schema<ICustomer>(
       trim: true,
     },
     squareCustomerId: {
+      type: String,
+      required: false,
+      trim: true,
+    },
+    squareReceiptUrl: {
       type: String,
       required: false,
       trim: true,

--- a/lib/models/Order.ts
+++ b/lib/models/Order.ts
@@ -93,6 +93,7 @@ export interface IOrder extends Document {
     paymentId?: string;
     orderId?: string;
     customerId?: string;
+    receiptUrl?: string; // Square-hosted payment receipt
   };
   /** A gift card redeemed against this order (amount in cents). */
   giftCard?: {
@@ -217,6 +218,7 @@ const OrderSchema = new Schema<IOrder>(
       paymentId: { type: String, trim: true },
       orderId: { type: String, trim: true },
       customerId: { type: String, trim: true },
+      receiptUrl: { type: String, trim: true },
     },
     giftCard: {
       giftCardId: { type: String, trim: true },

--- a/lib/models/Order.ts
+++ b/lib/models/Order.ts
@@ -72,6 +72,10 @@ export interface IOrderAddress {
 
 export interface IOrder extends Document {
   orderNumber: string; // human-friendly, unique (e.g. "CC-LXYZ-4821")
+  // Durable link to the authenticated user who placed this order, when signed in.
+  // Guest orders have none — they are still reconciled to a user by email at read
+  // time (see lib/account/queries.ts). Stamped at checkout from the session.
+  userId?: mongoose.Types.ObjectId;
   items: IOrderItem[];
   subtotalCents: number;
   shippingCents: number;
@@ -184,6 +188,11 @@ const OrderSchema = new Schema<IOrder>(
       unique: true,
       trim: true,
     },
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: false,
+    },
     items: {
       type: [OrderItemSchema],
       required: true,
@@ -268,6 +277,7 @@ OrderSchema.pre("validate", function (next) {
 // Indexes for the admin Sales page + Shipments tracker queries.
 OrderSchema.index({ status: 1, createdAt: -1 });
 OrderSchema.index({ "customer.email": 1, createdAt: -1 });
+OrderSchema.index({ userId: 1, createdAt: -1 });
 OrderSchema.index({ "square.paymentId": 1 });
 OrderSchema.index({ "shippo.trackingNumber": 1 });
 

--- a/lib/square/cards.ts
+++ b/lib/square/cards.ts
@@ -1,0 +1,124 @@
+import { getSquareClient } from "@/lib/square/client";
+import { randomUUID } from "crypto";
+
+/**
+ * Square Cards on File service (v44 native `cards` API).
+ *
+ * Card data NEVER touches our server: the Web Payments SDK tokenizes the card
+ * (intent STORE) into a one-time `sourceId`; `CreateCard` exchanges it for a
+ * durable card id (`ccof:...`) on the customer's Square profile. We persist only
+ * the id + display metadata. Charging a saved card later is a normal
+ * `payments.create` with `sourceId = card id` + `customerId` (see the checkout routes).
+ */
+
+// Display-safe view of a saved card. No PAN — last4/brand/expiry only.
+export interface SavedCard {
+  id: string;
+  brand: string; // e.g. "VISA", "MASTERCARD"
+  last4: string;
+  expMonth: number;
+  expYear: number;
+  cardholderName?: string;
+}
+
+export interface CreateCardInput {
+  sourceId: string; // one-time nonce from the Web Payments SDK
+  customerId: string; // Square customer the card is filed under
+  cardholderName?: string;
+  verificationToken?: string; // from verifyBuyer (SCA), when present
+  referenceId?: string; // our user id, for cross-referencing
+}
+
+const client = getSquareClient();
+
+function mapCard(card: {
+  id?: string | null;
+  cardBrand?: string | null;
+  last4?: string | null;
+  expMonth?: bigint | null;
+  expYear?: bigint | null;
+  cardholderName?: string | null;
+}): SavedCard {
+  return {
+    id: card.id ?? "",
+    brand: card.cardBrand ?? "CARD",
+    last4: card.last4 ?? "",
+    expMonth: card.expMonth != null ? Number(card.expMonth) : 0,
+    expYear: card.expYear != null ? Number(card.expYear) : 0,
+    cardholderName: card.cardholderName ?? undefined,
+  };
+}
+
+export class SquareCardService {
+  /** Save a card on file for a customer. Throws if Square returns no card. */
+  async createCard(input: CreateCardInput): Promise<SavedCard> {
+    const response = await client.cards.create({
+      idempotencyKey: randomUUID(),
+      sourceId: input.sourceId,
+      verificationToken: input.verificationToken,
+      card: {
+        customerId: input.customerId,
+        cardholderName: input.cardholderName,
+        referenceId: input.referenceId,
+      },
+    });
+
+    if (!response.card) {
+      throw new Error("Failed to save card in Square");
+    }
+    return mapCard(response.card);
+  }
+
+  /** Enabled saved cards for a customer, newest activity first (Square order). */
+  async listCards(customerId: string): Promise<SavedCard[]> {
+    const cards: SavedCard[] = [];
+    try {
+      const page = await client.cards.list({
+        customerId,
+        includeDisabled: false,
+      });
+      for await (const card of page) {
+        if (card.enabled === false) continue;
+        const mapped = mapCard(card);
+        if (mapped.id) cards.push(mapped);
+        if (cards.length >= 50) break; // sane cap — a customer won't have this many
+      }
+    } catch (error) {
+      console.error("[SQUARE-CARDS-listCards] Error:", error);
+    }
+    return cards;
+  }
+
+  /**
+   * A single card by id, including the owning customerId (used for ownership
+   * checks before disabling). Null if it does not exist.
+   */
+  async getCard(
+    cardId: string
+  ): Promise<(SavedCard & { customerId?: string }) | null> {
+    try {
+      const response = await client.cards.get({ cardId });
+      if (!response.card) return null;
+      return {
+        ...mapCard(response.card),
+        customerId: response.card.customerId ?? undefined,
+      };
+    } catch (error) {
+      console.error("[SQUARE-CARDS-getCard] Error:", error);
+      return null;
+    }
+  }
+
+  /** Disable (remove) a saved card. Idempotent in Square. */
+  async disableCard(cardId: string): Promise<boolean> {
+    try {
+      await client.cards.disable({ cardId });
+      return true;
+    } catch (error) {
+      console.error("[SQUARE-CARDS-disableCard] Error:", error);
+      return false;
+    }
+  }
+}
+
+export const squareCardService = new SquareCardService();

--- a/lib/square/cards.ts
+++ b/lib/square/cards.ts
@@ -76,6 +76,9 @@ export class SquareCardService {
       const page = await client.cards.list({
         customerId,
         includeDisabled: false,
+        // Explicit: the v44 client serializes an omitted sortOrder as an empty
+        // string, which Square's API rejects (INVALID_ENUM_VALUE). Newest first.
+        sortOrder: "DESC",
       });
       for await (const card of page) {
         if (card.enabled === false) continue;

--- a/lib/square/userCustomer.ts
+++ b/lib/square/userCustomer.ts
@@ -1,0 +1,69 @@
+import mongoose from "mongoose";
+import { connectMongo } from "@/lib/mongoose";
+import { squareCustomerService } from "@/lib/square/customers";
+import type { SessionUser } from "@/lib/auth/guards";
+
+/**
+ * Resolve the Square customer profile for an authenticated user — the anchor a
+ * card on file must attach to. The link is stored as `squareCustomerId` on the
+ * NextAuth `users` doc (adapter-managed, so accessed via the driver, not a model).
+ * Store checkout also stamps it; this is the read/repair/create path for the
+ * account console and saved-card payments.
+ */
+
+/** The Square customerId linked to a user, or null if none is stored. */
+export async function getUserSquareCustomerId(
+  userId: string
+): Promise<string | null> {
+  await connectMongo();
+  const doc = await mongoose.connection
+    .collection("users")
+    .findOne({ _id: new mongoose.Types.ObjectId(userId) });
+  return (doc?.squareCustomerId as string | undefined) ?? null;
+}
+
+/** Persist the link onto the user doc, only if it is not already set. */
+async function linkSquareCustomerId(
+  userId: string,
+  customerId: string
+): Promise<void> {
+  await mongoose.connection.collection("users").updateOne(
+    {
+      _id: new mongoose.Types.ObjectId(userId),
+      squareCustomerId: { $exists: false },
+    },
+    { $set: { squareCustomerId: customerId } }
+  );
+}
+
+/**
+ * Resolve a user's Square customerId. Order of resolution:
+ *   1. The id already stored on their user doc.
+ *   2. An email lookup in Square (back-fills the stored link for older accounts).
+ *   3. (only when createIfMissing) create a customer from their account identity.
+ * Returns null when none exists and creation was not requested.
+ */
+export async function resolveUserSquareCustomerId(
+  user: SessionUser,
+  opts: { createIfMissing?: boolean } = {}
+): Promise<string | null> {
+  const stored = await getUserSquareCustomerId(user.id);
+  if (stored) return stored;
+
+  const byEmail = await squareCustomerService.searchByEmail(user.email);
+  if (byEmail) {
+    await linkSquareCustomerId(user.id, byEmail.id);
+    return byEmail.id;
+  }
+
+  if (!opts.createIfMissing) return null;
+
+  const [firstName, ...rest] = (user.name ?? "").trim().split(/\s+/);
+  const result = await squareCustomerService.findOrCreateCustomer({
+    firstName: firstName || user.email.split("@")[0],
+    lastName: rest.join(" "),
+    email: user.email,
+  });
+  await linkSquareCustomerId(user.id, result.customerId);
+  return result.customerId;
+}


### PR DESCRIPTION
Builds the authenticated-customer payments experience on top of the existing checkout, plus receipt + email improvements. Additive and guest-safe — the localStorage cart and guest checkout are unchanged. All commits: tsc clean, 350 tests passing, 0 lint errors, production build passing.

## What's included

### 1. Durable user ↔ order link + checkout prefill (`2b11f0c`)
- `Order.userId` stamped at store checkout; account queries match `userId` OR email so legacy/guest orders still surface.
- Checkout prefilled for signed-in customers (latest order → Square profile fallback).
- `squareCustomerId` linked onto the NextAuth user record.

### 2. Square Cards on File — save, pay, manage (`25dd657`, `d669efa`)
- `lib/square/cards.ts` (create/list/get/disable) + `lib/square/userCustomer.ts` resolver.
- `/api/account/cards` routes (`requireUser`; DELETE enforces ownership).
- Pay with a saved card or a new one on **store + event/booking** checkout; opt-in "Save this card" files it from the payment id after a successful charge.
- SCA best practice: `PaymentStep` tokenizes **with** verification details (Square's current recommended path; `verifyBuyer` is deprecated) and forwards the `verificationToken`. No new billing-address form — `billingContact` uses only data already collected.
- `/account/payment-methods` management page (list / add via Square iframe / remove) + nav entry.
- Card data never touches our server — only the card id (`ccof:…`) is stored.

### 3. Square receipt on every confirmation + store page redesign (`8de804d`, `def7bcd`)
- Capture `payment.receiptUrl` in all three charge flows; show **View Square Receipt** on the store, event, reservation, and account-order-detail pages, and in the order/event/private-event **emails**.
- Store `/order-confirmation` rebuilt to match the event booking confirmation card.

### 4. Email upgrades (`bb64778`, `1a941d5`, `def7bcd`)
- **Customer copies now deliver to the real address in dev** (domain is verified); only the **admin** copy redirects to `DEV_EMAIL`, so checkout can be tested as a genuine customer without spamming Ashley.
- **Private event bookings** now send a "Deposit received" confirmation (customer) + an admin notification.
- Order email sets the tracking expectation ("we'll email you a tracking number when it ships — no account needed").
- Event registration email shows **Amount Paid**; studio contact address centralized via `getStudioEmail()` (no more hardcoded literals).

## Testing
- +52 tests across cards service/routes, saved-card charge/ownership/save/SCA on both checkout routes, receipt capture, and the updated email-routing tests.
- `pnpm typecheck`, `pnpm test` (350 passing), `pnpm lint` (0 errors), `pnpm build` all green.

## Not yet done (follow-ups)
- End-to-end Square **sandbox** walkthrough of the saved-card add/pay/save/remove flow (verified by tests + build, not yet clicked through in-browser).
- Reservation confirmation email + `Event.whatToBring`/`notes` (needs model + admin-form changes) — intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)