### PR TITLE
test(e2e): fix gift-toggle selector after checkbox label rename

### DIFF
--- a/e2e/checkout-gift.spec.ts
+++ b/e2e/checkout-gift.spec.ts
@@ -32,7 +32,7 @@ test.describe("store checkout — gift shipping", () => {
     await expect(page.getByRole("heading", { name: "Shipping address" })).toBeVisible();
     await expect(page.getByText("Recipient First Name")).toHaveCount(0);
 
-    await page.getByRole("checkbox", { name: /this is a gift/i }).check();
+    await page.getByRole("checkbox", { name: /ship to a different address/i }).check();
 
     await expect(page.getByRole("heading", { name: "Ship to recipient" })).toBeVisible();
     await expect(page.getByText("Recipient First Name")).toBeVisible();


### PR DESCRIPTION
Follow-up to #159. The store gift-shipping E2E spec was failing because the gift checkbox label had been renamed from "This is a gift — ship to a different address" to **"Ship to a different address?"**, so `getByRole('checkbox', { name: /this is a gift/i })` matched nothing and `.check()` timed out (30s).

Reproduced locally against a dev server (ruling out the placeholder-Square-creds theory), confirmed via Playwright's ARIA snapshot that the accessible name is now "Ship to a different address?", and updated the selector to `/ship to a different address/i`. No product code change.

## Testing
- `pnpm exec playwright test` — all 3 e2e specs pass locally (checkout-gift, navigation, contact-validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)