### PR TITLE
fix: phone autofill formatting + private events card alignment

### DIFF
--- a/__tests__/checkout/contactFormPhone.test.ts
+++ b/__tests__/checkout/contactFormPhone.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatUsPhone,
+  isValidUsPhone,
+} from "@/components/checkout/ContactForm";
+
+describe("formatUsPhone", () => {
+  it("formats a plain 10-digit number", () => {
+    expect(formatUsPhone("5093207586")).toBe("(509) 320-7586");
+  });
+
+  it("drops the E.164 +1 country code from autofilled numbers", () => {
+    expect(formatUsPhone("+15093207586")).toBe("(509) 320-7586");
+    expect(formatUsPhone("+1 (509) 320-7586")).toBe("(509) 320-7586");
+    expect(formatUsPhone("1-509-320-7586")).toBe("(509) 320-7586");
+  });
+
+  it("formats partial input as the user types", () => {
+    expect(formatUsPhone("")).toBe("");
+    expect(formatUsPhone("509")).toBe("(509");
+    expect(formatUsPhone("509320")).toBe("(509) 320");
+    expect(formatUsPhone("5093207")).toBe("(509) 320-7");
+  });
+
+  it("caps input at 10 digits", () => {
+    expect(formatUsPhone("50932075869999")).toBe("(509) 320-7586");
+  });
+});
+
+describe("isValidUsPhone", () => {
+  it("accepts a formatted 10-digit number", () => {
+    expect(isValidUsPhone("(509) 320-7586")).toBe(true);
+  });
+
+  it("accepts an E.164 +1 number", () => {
+    expect(isValidUsPhone("+15093207586")).toBe(true);
+  });
+
+  it("rejects too-short and too-long numbers", () => {
+    expect(isValidUsPhone("509320758")).toBe(false);
+    expect(isValidUsPhone("+2509320758611")).toBe(false);
+  });
+});

--- a/components/checkout/ContactForm.tsx
+++ b/components/checkout/ContactForm.tsx
@@ -10,18 +10,30 @@ export interface ContactFormValues {
   phone: string;
 }
 
+/**
+ * Strip to digits, dropping the "1" US country code from an 11-digit number —
+ * browser autofill often supplies E.164 ("+15093207586"), which would otherwise
+ * truncate to the wrong 10 digits ("(150) 932-0758").
+ */
+function usPhoneDigits(input: string): string {
+  const digits = input.replace(/\D/g, "");
+  return digits.length === 11 && digits.startsWith("1")
+    ? digits.slice(1)
+    : digits;
+}
+
 /** Format a US phone as the user types: (XXX) XXX-XXXX, capped at 10 digits. */
 export function formatUsPhone(input: string): string {
-  const digits = input.replace(/\D/g, "").slice(0, 10);
+  const digits = usPhoneDigits(input).slice(0, 10);
   if (digits.length === 0) return "";
   if (digits.length < 4) return `(${digits}`;
   if (digits.length < 7) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
   return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
 }
 
-/** True when the phone contains exactly 10 digits. */
+/** True when the phone contains exactly 10 digits (a leading +1 is ignored). */
 export function isValidUsPhone(phone: string): boolean {
-  return phone.replace(/\D/g, "").length === 10;
+  return usPhoneDigits(phone).length === 10;
 }
 
 interface ContactFormProps {
@@ -110,7 +122,6 @@ export default function ContactForm({
             inputMode="tel"
             autoComplete="tel"
             placeholder="(555) 555-5555"
-            maxLength={14}
             value={values.phone}
             error={errors?.phone}
             disabled={disabled}

--- a/components/classes/privateEvents/PrivateEventCard.tsx
+++ b/components/classes/privateEvents/PrivateEventCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, type ReactElement } from "react";
+import type { ReactElement } from "react";
 import styled from "@emotion/styled";
 import { Box } from "@mui/material";
 import { PrivateEvent } from "@/types/interfaces";
@@ -21,14 +21,14 @@ const urlFor = (source: SanityImageSource) =>
 
 const TITLE_ICONS = [FaBirthdayCake, GiCupcake, GiBalloons, GiPartyPopper];
 
-const TRUNCATE_LENGTH = 180;
-
 // --- Styled Components ---
 
 const CardWrapper = styled("div")({
   borderRadius: "16px",
   overflow: "hidden",
   height: "100%",
+  display: "flex",
+  flexDirection: "column",
   position: "relative",
   backgroundColor: "white",
   boxShadow: "0 2px 12px rgba(0, 0, 0, 0.08)",
@@ -83,11 +83,17 @@ const TitleIcon = styled("span")({
   color: "#326C85",
 });
 
+// Cap long descriptions and let the overflow scroll inside the card (same
+// pattern as the Shop grid card) so card heights stay aligned across the row.
 const Description = styled("p")({
   marginTop: "0.75rem",
   color: "#4b5563",
   lineHeight: 1.65,
-  flex: "1 1 auto",
+  maxHeight: "9rem",
+  overflowY: "auto",
+  overscrollBehavior: "contain",
+  paddingRight: "0.25rem",
+  scrollbarWidth: "thin",
   textAlign: "left",
   fontWeight: "400",
   fontSize: "0.9rem",
@@ -126,19 +132,8 @@ const PrivateEventCard = ({
   privateEvent,
   index,
 }: PrivateEventCardProps): ReactElement => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   const IconComponent = TITLE_ICONS[index % TITLE_ICONS.length];
   const descriptionText = (privateEvent.description || "").trim();
-
-  const needsTruncation = descriptionText.length > TRUNCATE_LENGTH;
-  const displayText =
-    !isExpanded && needsTruncation
-      ? descriptionText.slice(
-          0,
-          descriptionText.lastIndexOf(" ", TRUNCATE_LENGTH),
-        ) + "..."
-      : descriptionText;
 
   return (
     <div className="animate-fade-in-up" style={{ height: "100%", animationDelay: `${index * 60}ms` }}>
@@ -177,25 +172,7 @@ const PrivateEventCard = ({
             <Price>${privateEvent.price}/person</Price>
           </div>
 
-          <Description>
-            {displayText}
-            {needsTruncation && (
-              <button
-                onClick={() => setIsExpanded(!isExpanded)}
-                style={{
-                  background: "none",
-                  border: "none",
-                  color: "#326C85",
-                  cursor: "pointer",
-                  fontWeight: "600",
-                  fontSize: "0.85rem",
-                  padding: "0 0.25rem",
-                }}
-              >
-                {isExpanded ? "Read less" : "Read more"}
-              </button>
-            )}
-          </Description>
+          <Description>{descriptionText}</Description>
 
           {privateEvent.options && privateEvent.options.length > 0 && (
             <div className="mt-4 space-y-3">
@@ -233,22 +210,26 @@ const PrivateEventCard = ({
           )}
 
           {privateEvent.isDepositRequired && privateEvent.depositAmount && (
-            <div className="mt-4 bg-blue-50 border border-blue-200 rounded-lg p-3">
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <p className="text-sm font-medium text-blue-800">
-                    <strong>Deposit Required:</strong> $
-                    {privateEvent.depositAmount}
-                  </p>
+            // mt-auto pins the deposit row to the card bottom so the Pay
+            // Deposit buttons align across the row regardless of card content.
+            <div className="mt-auto pt-4">
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <p className="text-sm font-medium text-blue-800">
+                      <strong>Deposit Required:</strong> $
+                      {privateEvent.depositAmount}
+                    </p>
+                  </div>
+                  <Link
+                    href={`/payments?eventId=${privateEvent._id}&eventTitle=${encodeURIComponent(privateEvent.title)}&price=${privateEvent.depositAmount}&isPrivateEvent=true`}
+                    style={{ textDecoration: "none" }}
+                  >
+                    <Button variant="primary" size="sm">
+                      Pay Deposit
+                    </Button>
+                  </Link>
                 </div>
-                <Link
-                  href={`/payments?eventId=${privateEvent._id}&eventTitle=${encodeURIComponent(privateEvent.title)}&price=${privateEvent.depositAmount}&isPrivateEvent=true`}
-                  style={{ textDecoration: "none" }}
-                >
-                  <Button variant="primary" size="sm">
-                    Pay Deposit
-                  </Button>
-                </Link>
               </div>
             </div>
           )}

--- a/components/store/ContactFields.tsx
+++ b/components/store/ContactFields.tsx
@@ -73,7 +73,6 @@ export default function ContactFields({
             inputMode="tel"
             autoComplete="tel"
             placeholder="(555) 555-5555"
-            maxLength={14}
             value={values.phone}
             onChange={(e) => onChange("phone", formatUsPhone(e.target.value))}
             onBlur={() => touch("phone")}


### PR DESCRIPTION
## Summary

Two customer-facing fixes:

**Phone formatting (checkout + store)**
- `formatUsPhone` kept the first 10 digits of the input, so a browser-autofilled E.164 number (`+15093207586`) rendered as `(150) 932-0758` in the form and flowed mangled into confirmation emails.
- The formatter (and `isValidUsPhone`) now drops the leading `1` country code from 11-digit input, so `+1 (509) 320-7586` formats to `(509) 320-7586` and passes validation.
- Removed `maxLength={14}` from both phone inputs: HTML maxlength truncated autofilled values before the formatter could see them, which would silently re-create the bug. The formatter still caps at 10 digits.
- Covers event/private-event checkout (`components/checkout/ContactForm.tsx`) and store checkout (`components/store/ContactFields.tsx`), which share the formatter.

**Private events cards**
- Removed the Read more/Read less toggle; long descriptions are now capped at ~6 lines with an inner thin scrollbar, matching the Shop grid card pattern.
- Card is now a flex column with the Deposit Required / Pay Deposit row pinned to the bottom via `mt-auto`, so buttons align across the row regardless of content height.

## Testing

- New regression test `__tests__/checkout/contactFormPhone.test.ts` covering the exact `+1` autofill case, partial-input formatting, and validation.
- Full suite passes: 357 tests / 45 files. Typecheck and lint clean.
- Visually verified `/events/private-events` on the dev server: all deposit buttons bottom-align, no Read more links remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)