### PR TITLE
feat(events): add Adult & Kid Class event type

### DIFF
--- a/app/events/adult-classes/page.tsx
+++ b/app/events/adult-classes/page.tsx
@@ -30,7 +30,7 @@ export default function AdultClassesPage() {
             title: "",
             sectionTitle: "",
             eventTypeFilter: (eventType) => {
-              return eventType === "adult-class";
+              return eventType === "adult-class" || eventType === "adult-kid-class";
             },
             layout: "list",
             cardConfig: {

--- a/app/events/kid-classes/page.tsx
+++ b/app/events/kid-classes/page.tsx
@@ -30,7 +30,7 @@ export default function KidClassesPage() {
             title: "",
             sectionTitle: "",
             eventTypeFilter: (eventType) => {
-              return eventType === "kid-class";
+              return eventType === "kid-class" || eventType === "adult-kid-class";
             },
             layout: "list",
             cardConfig: {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,6 +9,7 @@ const BASE_URL = "https://coastalcreationsstudio.com";
 const EVENT_TYPE_PATHS: Record<string, string> = {
   "adult-class": "adult-classes",
   "kid-class": "kid-classes",
+  "adult-kid-class": "classes-workshops",
   camp: "camps",
   event: "events",
   artist: "live-artist",

--- a/components/calendar/NewCalendar.tsx
+++ b/components/calendar/NewCalendar.tsx
@@ -386,6 +386,7 @@ export default function NewCalendar() {
     switch (eventType) {
       case "kid-class":
       case "adult-class":
+      case "adult-kid-class":
       case "class":
         return "#0c4a6e"; // --color-primary
       case "camp":

--- a/components/dashboard/event-form/AddEventForm.tsx
+++ b/components/dashboard/event-form/AddEventForm.tsx
@@ -4,11 +4,11 @@ import EventFormBase from "./EventFormBase";
 
 const AddEventForm = (): ReactElement => {
   const [, setSelectedEventType] = useState<
-    "adult-class" | "kid-class" | "event" | "camp" | "artist"
+    "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist"
   >("adult-class");
 
   const handleEventTypeChange = (
-    eventType: "adult-class" | "kid-class" | "event" | "camp" | "artist"
+    eventType: "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist"
   ) => {
     setSelectedEventType(eventType);
   };

--- a/components/dashboard/event-form/EventFormBase.tsx
+++ b/components/dashboard/event-form/EventFormBase.tsx
@@ -17,7 +17,7 @@ interface EventFormBaseProps extends EventFormProps {
   existingImageUrl?: string | null;
   initialData?: EventFormState;
   onEventTypeChange?: (
-    eventType: "adult-class" | "kid-class" | "event" | "camp" | "artist",
+    eventType: "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist",
   ) => void;
 }
 
@@ -47,7 +47,7 @@ const EventFormBase = ({
   const imagePreviewUrl = useImagePreview(formData.image);
 
   const handleEventTypeChange = (
-    eventType: "adult-class" | "kid-class" | "event" | "camp" | "artist",
+    eventType: "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist",
   ) => {
     if (onEventTypeChange) {
       onEventTypeChange(eventType);

--- a/components/dashboard/event-form/shared/fields/EventBasicFields.tsx
+++ b/components/dashboard/event-form/shared/fields/EventBasicFields.tsx
@@ -6,7 +6,7 @@ interface EventBasicFieldsProps {
   formData: EventFormState;
   actions: EventFormActions;
   errors: { [key: string]: string };
-  onEventTypeChange: (eventType: "adult-class" | "kid-class" | "event" | "camp" | "artist") => void;
+  onEventTypeChange: (eventType: "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist") => void;
 }
 
 const EventBasicFields = ({
@@ -43,6 +43,7 @@ const EventBasicFields = ({
         >
           <option value="adult-class">Adult Class</option>
           <option value="kid-class">Kid Class</option>
+          <option value="adult-kid-class">Adult & Kid Class</option>
           <option value="event">Event</option>
           <option value="camp">Camp</option>
           <option value="artist">Live Artist Event</option>

--- a/components/dashboard/event-form/shared/types/eventForm.types.ts
+++ b/components/dashboard/event-form/shared/types/eventForm.types.ts
@@ -18,7 +18,7 @@ export interface EventDiscount {
 
 export interface EventFormState {
   eventName: string;
-  eventType: "adult-class" | "kid-class" | "event" | "camp" | "artist";
+  eventType: "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist";
   description: string;
   isFree: boolean;
   price?: number;

--- a/lib/models/Event.ts
+++ b/lib/models/Event.ts
@@ -11,7 +11,7 @@ dayjs.extend(timezone);
 const LOCAL_TIMEZONE = "America/New_York"; 
 export interface IEvent extends Document {
   eventName: string;
-  eventType: "adult-class" | "kid-class" | "event" | "camp" | "artist" | "class" | "workshop"; // Temporarily allow old values
+  eventType: "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist" | "class" | "workshop"; // Temporarily allow old values
   description: string;
   isFree?: boolean;
   price?: number;
@@ -191,7 +191,7 @@ const EventSchema = new Schema<IEvent>(
     eventType: {
       type: String,
       required: true,
-      enum: ["adult-class", "kid-class", "event", "camp", "artist", "class", "workshop"], // Temporarily allow old values for migration
+      enum: ["adult-class", "kid-class", "adult-kid-class", "event", "camp", "artist", "class", "workshop"], // Temporarily allow old values for migration
     },
     description: {
       type: String,

--- a/lib/types/eventTypes.ts
+++ b/lib/types/eventTypes.ts
@@ -8,7 +8,7 @@ import { isValidEmail } from "@/lib/utils/validation";
 /**
  * Event type enumeration.
  */
-export type EventType = "adult-class" | "kid-class" | "event" | "camp" | "artist";
+export type EventType = "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist";
 
 /**
  * Recurring pattern enumeration.
@@ -358,6 +358,11 @@ export function getDefaultValuesForEventType(
       return {
         ...defaultEventFormValues,
         eventType: "kid-class" as const,
+      };
+    case "adult-kid-class":
+      return {
+        ...defaultEventFormValues,
+        eventType: "adult-kid-class" as const,
       };
     case "event":
       return {

--- a/lib/utils/eventTypeHelpers.ts
+++ b/lib/utils/eventTypeHelpers.ts
@@ -3,7 +3,7 @@
  */
 
 export type OldEventType = "class" | "workshop";
-export type NewEventType = "adult-class" | "kid-class" | "event" | "camp" | "artist";
+export type NewEventType = "adult-class" | "kid-class" | "adult-kid-class" | "event" | "camp" | "artist";
 export type EventType = OldEventType | NewEventType;
 
 /**
@@ -25,6 +25,7 @@ export function normalizeEventType(eventType: string): NewEventType {
   if (
     eventType === "adult-class" ||
     eventType === "kid-class" ||
+    eventType === "adult-kid-class" ||
     eventType === "event" ||
     eventType === "camp" ||
     eventType === "artist"
@@ -58,6 +59,7 @@ export function getEventTypeDisplayName(eventType: string): string {
   const displayNames: Record<NewEventType, string> = {
     "adult-class": "Adult Class",
     "kid-class": "Kid Class",
+    "adult-kid-class": "Adult & Kid Class",
     event: "Event",
     camp: "Camp",
     artist: "Live Artist Event",


### PR DESCRIPTION
## Summary
- Adds a new `adult-kid-class` event type the admin can select when creating or editing an event ("Adult & Kid Class" in the Event Type dropdown).
- Events with this type show on the customer classes pages under **all three** filters: Adults (`/events/adult-classes`), Kids (`/events/kid-classes`), and All Events (`/events/classes-workshops`).

## Changes
- `lib/models/Event.ts` — Mongoose enum + interface union accept the new value
- `lib/types/eventTypes.ts`, `lib/utils/eventTypeHelpers.ts` — type unions, "Adult & Kid Class" display name, normalize helper, default form values
- `components/dashboard/event-form/*` — dropdown option + prop-type unions (AddEventForm, EventFormBase, EventBasicFields, eventForm.types)
- `app/events/adult-classes/page.tsx`, `app/events/kid-classes/page.tsx` — listing filters include the new type
- `components/calendar/NewCalendar.tsx` — calendar uses the same class color for the new type
- `app/sitemap.ts` — detail URLs for the new type map under `/events/classes-workshops`

Purely additive — existing events and the photo-gallery category system are untouched.

## Testing
- `npx tsc --noEmit` clean
- `pnpm run test:run` — 357 tests / 45 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)