### PR TITLE
chore: add humans.txt crediting team and technology stack

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,0 +1,14 @@
+/* TEAM */
+
+Studio: Crystal Edge Digital
+Role: Design & Development
+Site: https://coastalcreationsstudio.com/
+Location: Ocean City, NJ, USA
+
+/* SITE */
+
+Last update: 2026/07/13
+Language: English
+Doctype: HTML5
+Standards: HTML5, CSS3
+Components: Next.js 16, Tailwind CSS v4


### PR DESCRIPTION
## Summary

Adds a single new static file, `public/humans.txt`, following the [humanstxt.org](https://humanstxt.org/) convention. No existing files are modified — this is a zero-code-change, additive task.

- **TEAM** section credits **Crystal Edge Digital** as the studio (design & development).
- **SITE** section lists the technology stack: **Next.js 16** and **Tailwind CSS v4**.

The file is served statically from `/humans.txt` (Next.js serves `public/` assets at the site root).

## Validation

- `npm run build` (Next.js 16.2.7 / Turbopack) — ✅ compiles successfully, 98/98 static pages generated, exit 0.
- Only `public/humans.txt` is added; no other files touched.

## Notes

Deliberately tiny, scoped task — no scope expansion. Opened as a **draft** into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)