### PR TITLE
fix(event-form): stop deleted event images from silently re-saving

### DIFF
--- a/components/dashboard/event-form/shared/fields/EventImageUpload.tsx
+++ b/components/dashboard/event-form/shared/fields/EventImageUpload.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { ReactElement, useLayoutEffect } from "react";
 import Image from "next/image";
 import { EventFormState, EventFormActions } from "../types/eventForm.types";
 import { useImageUpload } from "../hooks/useImageUpload";
@@ -35,10 +35,17 @@ const EventImageUpload = ({
     },
   });
 
-  // Set existing image URL if provided (for edit mode)
-  if (existingImageUrl && !uploadedImageUrl) {
-    setImageUrl(existingImageUrl);
-  }
+  // Seed the local image state from the event's saved image once (edit
+  // mode). Keyed only on existingImageUrl, which is set once per event load
+  // and never changes again during the session — so this can't re-fire (and
+  // silently undo an explicit delete) just because uploadedImageUrl went
+  // back to null. useLayoutEffect keeps the timing identical to the old
+  // render-body assignment (no flash of the empty state on mount).
+  useLayoutEffect(() => {
+    if (existingImageUrl) {
+      setImageUrl(existingImageUrl);
+    }
+  }, [existingImageUrl, setImageUrl]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -50,7 +57,10 @@ const EventImageUpload = ({
     }
   };
 
-  const displayImageUrl = uploadedImageUrl || existingImageUrl;
+  // uploadedImageUrl is now the single source of truth (seeded from
+  // existingImageUrl above): null means "no image" — including right after
+  // a delete — rather than falling back to the stale existingImageUrl prop.
+  const displayImageUrl = uploadedImageUrl;
 
   return (
     <div>

--- a/components/dashboard/event-form/shared/hooks/useImageUpload.ts
+++ b/components/dashboard/event-form/shared/hooks/useImageUpload.ts
@@ -4,7 +4,7 @@ import toast from "react-hot-toast";
 interface UseImageUploadOptions {
   eventName: string;
   apiEndpoint?: string;
-  onSuccess?: (imageUrl: string) => void;
+  onSuccess?: (imageUrl: string | null) => void;
   onError?: (error: string) => void;
 }
 
@@ -78,6 +78,7 @@ export const useImageUpload = ({
       }
 
       setUploadedImageUrl(null);
+      onSuccess?.(null);
       toast.dismiss(loadingToastId);
       toast.success("Image deleted successfully!");
     } catch (error) {
@@ -85,7 +86,7 @@ export const useImageUpload = ({
       toast.dismiss(loadingToastId);
       toast.error("Failed to delete image");
     }
-  }, [uploadedImageUrl]);
+  }, [uploadedImageUrl, onSuccess]);
 
   const setImageUrl = useCallback((url: string | null) => {
     setUploadedImageUrl(url);


### PR DESCRIPTION
## Summary
- Hotfix for Ashley's report: the Pet Portrait Workshop (8/13) picture wouldn't change. Root cause investigation (separate from this PR) found the display precedence issue is in how the event page resolves images — see conversation notes; this PR fixes a related, genuinely broken bug found along the way in the same "Edit Event" image flow.
- Deleting an event's image only cleared local component state; the parent form's `imageUrl` was never told, so the next Save could silently re-persist the "deleted" image unchanged.
- `useImageUpload`'s `onSuccess` now fires with `null` on delete so the parent form state clears too.
- Moved the `existingImageUrl` seed out of the render body (which would immediately re-seed the just-deleted image right back) into a `useLayoutEffect` keyed only on `existingImageUrl`, so it seeds once and can't fight a delete.
- `displayImageUrl` now reads `uploadedImageUrl` directly instead of falling back to the stale `existingImageUrl` prop, so the thumbnail correctly shows empty after a delete.

## Test plan
- [x] `npx tsc --noEmit` — no errors introduced by these two files (pre-existing unrelated errors in `.next/types` and test mocks, untouched)
- [ ] Manually verify in the Edit Event dashboard: open an event with an existing image, click delete, confirm thumbnail clears and stays cleared, Save, confirm it doesn't silently restore the old image
- [ ] Manually verify: upload a new image over an existing one, confirm it saves correctly (unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)