### PR TITLE
fix(events): make the event listing pages trust the event's own image

### DIFF
--- a/components/classes/EventsContainer.tsx
+++ b/components/classes/EventsContainer.tsx
@@ -216,10 +216,16 @@ const EventsContainer: React.FC<EventsContainerProps> = ({ config }) => {
 
   const renderCards = (): ReactElement => {
     const cards = filteredEvents.map((event, index) => {
+      // event.image (the event's own saved picture) is authoritative and
+      // takes priority — matches EventDetails.tsx. Sanity eventPictures is
+      // only a fallback for events that predate the per-event image field,
+      // not a second source of truth to race against it.
       const matchingPicture = findMatchingEventPicture(event.eventName);
-      const imageUrl = matchingPicture?.image
-        ? urlFor(matchingPicture.image)?.width(800).height(600).url()
-        : event.image || null;
+      const imageUrl =
+        event.image ||
+        (matchingPicture?.image
+          ? urlFor(matchingPicture.image)?.width(800).height(600).url()
+          : null);
 
       return (
         <UniversalEventCard


### PR DESCRIPTION
## Summary
Follow-up to #167 (already merged). Confirmed via screenshots that even with the correct picture set through the "Edit Event" form (visible on the admin preview and the checkout page), the event listing pages ("All Events," classes-workshops, camps, adult-classes, kid-classes) still showed the old photo.

Root cause: `EventsContainer.tsx` (backs those listing pages) resolved an event's picture with the **opposite priority** from `EventDetails.tsx` — it checked Sanity's `eventPictures` for a title match first, only falling back to the event's own saved image if nothing matched. Since every image upload through "Edit Event" creates a new `eventPictures` document instead of replacing the old one, and the lookup query has no explicit ordering, listing pages could keep matching a stale entry indefinitely. Not a caching issue — waiting or redeploying doesn't fix it, the data returned is genuinely wrong.

- Flipped the priority in `EventsContainer.tsx` to match `EventDetails.tsx`: the event's own saved image wins whenever it's set; Sanity is only a fallback for events that predate the per-event image field.

## Test plan
- [x] `npx tsc --noEmit` — no errors introduced
- [ ] Manually verify: set an event's image via "Edit Event," confirm it shows correctly on All Events / classes-workshops / camps / adult-classes / kid-classes, not just the single-event/checkout pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)