### PR TITLE
fix(events): autosave event images, fix asset-delete and upload dedupe bugs

### DIFF
--- a/app/api/delete-image/route.ts
+++ b/app/api/delete-image/route.ts
@@ -71,11 +71,23 @@ export async function DELETE(request: NextRequest) {
       }
     }
 
-    // Then delete the asset itself if we have the asset ID
+    // Then delete the asset itself, but only if no other document still
+    // references it (the same photo can be reused across eventPictures docs).
     let assetDeleted = false;
     if (fullAssetId) {
       try {
-        assetDeleted = true;
+        const stillReferenced = await client.fetch(
+          `count(*[references($fullAssetId)])`,
+          { fullAssetId }
+        );
+        if (stillReferenced === 0) {
+          await client.delete(fullAssetId);
+          assetDeleted = true;
+        } else {
+          console.log(
+            `[DELETE-IMAGE-ROUTE] Skipped asset delete for ${fullAssetId} — still referenced by ${stillReferenced} document(s)`
+          );
+        }
       } catch (assetError) {
         console.error(`[DELETE-IMAGE-ROUTE] Error deleting asset ${fullAssetId}:`, assetError);
       }

--- a/app/api/upload-image/route.ts
+++ b/app/api/upload-image/route.ts
@@ -31,18 +31,52 @@ export async function POST(request: NextRequest) {
       contentType: file.type,
     });
 
-    // Create eventPictures document with the uploaded image
-    const document = await client.create({
-      _type: "eventPictures",
-      title: title,
-      image: {
-        _type: "image",
-        asset: {
-          _type: "reference",
-          _ref: asset._id,
-        },
+    // Reuse the existing eventPictures doc for this title instead of piling
+    // up a new document on every re-upload; drop the previous asset once
+    // nothing else references it.
+    const existing = await client.fetch(
+      `*[_type == "eventPictures" && title == $title][0]{_id, "previousAssetId": image.asset._ref}`,
+      { title }
+    );
+
+    const imagePayload = {
+      _type: "image",
+      asset: {
+        _type: "reference",
+        _ref: asset._id,
       },
-    });
+    };
+
+    let document;
+    if (existing) {
+      document = await client
+        .patch(existing._id)
+        .set({ image: imagePayload })
+        .commit();
+
+      if (existing.previousAssetId && existing.previousAssetId !== asset._id) {
+        try {
+          const stillReferenced = await client.fetch(
+            `count(*[references($previousAssetId)])`,
+            { previousAssetId: existing.previousAssetId }
+          );
+          if (stillReferenced === 0) {
+            await client.delete(existing.previousAssetId);
+          }
+        } catch (assetError) {
+          console.error(
+            `[UPLOAD-IMAGE-ROUTE] Error deleting previous asset ${existing.previousAssetId}:`,
+            assetError
+          );
+        }
+      }
+    } else {
+      document = await client.create({
+        _type: "eventPictures",
+        title: title,
+        image: imagePayload,
+      });
+    }
 
     return NextResponse.json({
       success: true,

--- a/components/dashboard/event-form/EventFormBase.tsx
+++ b/components/dashboard/event-form/EventFormBase.tsx
@@ -100,6 +100,7 @@ const EventFormBase = ({
             actions={actions}
             errors={errors}
             existingImageUrl={existingImageUrl}
+            autosaveEventId={mode === "edit" ? eventId : undefined}
           />
 
           <EventInstagramField

--- a/components/dashboard/event-form/shared/fields/EventImageUpload.tsx
+++ b/components/dashboard/event-form/shared/fields/EventImageUpload.tsx
@@ -8,6 +8,9 @@ interface EventImageUploadProps {
   actions: EventFormActions;
   errors: { [key: string]: string };
   existingImageUrl?: string | null;
+  // Existing event's id (edit mode only) — enables immediate autosave of
+  // just the image field, independent of the rest of the form's Save.
+  autosaveEventId?: string;
 }
 
 const EventImageUpload = ({
@@ -15,6 +18,7 @@ const EventImageUpload = ({
   actions,
   errors,
   existingImageUrl,
+  autosaveEventId,
 }: EventImageUploadProps): ReactElement => {
   const {
     uploadedImageUrl,
@@ -27,6 +31,7 @@ const EventImageUpload = ({
     setIsImageLoading,
   } = useImageUpload({
     eventName: formData.eventName,
+    autosaveEventId,
     onSuccess: (imageUrl) => {
       actions.handleInputChange("imageUrl", imageUrl);
     },

--- a/components/dashboard/event-form/shared/hooks/useImageUpload.ts
+++ b/components/dashboard/event-form/shared/hooks/useImageUpload.ts
@@ -6,6 +6,10 @@ interface UseImageUploadOptions {
   apiEndpoint?: string;
   onSuccess?: (imageUrl: string | null) => void;
   onError?: (error: string) => void;
+  // When set (edit mode, existing event), upload/delete immediately PATCH
+  // this event's image field instead of waiting for the form's own Save —
+  // every other field still requires the explicit Update Event click.
+  autosaveEventId?: string;
 }
 
 export const useImageUpload = ({
@@ -13,11 +17,37 @@ export const useImageUpload = ({
   apiEndpoint = "/api/upload-image",
   onSuccess,
   onError,
+  autosaveEventId,
 }: UseImageUploadOptions) => {
   const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
   const [isImageUploading, setIsImageUploading] = useState(false);
   const [isImageLoading, setIsImageLoading] = useState(false);
   const [imageUploadStatus, setImageUploadStatus] = useState<string | null>(null);
+
+  const persistImageToEvent = useCallback(
+    async (imageUrl: string | null): Promise<boolean> => {
+      if (!autosaveEventId) return true;
+
+      try {
+        const response = await fetch(`/api/event/${autosaveEventId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ image: imageUrl }),
+        });
+        if (!response.ok) {
+          throw new Error("Failed to save image to event");
+        }
+        return true;
+      } catch (error) {
+        console.error(
+          "[useImageUpload-persistImageToEvent] Failed to autosave image:",
+          error
+        );
+        return false;
+      }
+    },
+    [autosaveEventId]
+  );
 
   const handleImageUpload = useCallback(
     async (file: File) => {
@@ -46,8 +76,19 @@ export const useImageUpload = ({
 
         const data = await response.json();
         setUploadedImageUrl(data.imageUrl);
-        setImageUploadStatus("Image uploaded successfully!");
         onSuccess?.(data.imageUrl);
+
+        const saved = await persistImageToEvent(data.imageUrl);
+        setImageUploadStatus(
+          autosaveEventId
+            ? saved
+              ? "Image uploaded and saved to the event!"
+              : "Image uploaded, but saving to the event failed — click Update Event to save it."
+            : "Image uploaded successfully!"
+        );
+        if (autosaveEventId && !saved) {
+          toast.error("Image uploaded, but couldn't be saved automatically. Click Update Event to save it.");
+        }
 
         setTimeout(() => setImageUploadStatus(null), 3000);
       } catch (error) {
@@ -59,7 +100,7 @@ export const useImageUpload = ({
         setIsImageUploading(false);
       }
     },
-    [eventName, apiEndpoint, onSuccess, onError]
+    [eventName, apiEndpoint, onSuccess, onError, autosaveEventId, persistImageToEvent]
   );
 
   const handleImageDelete = useCallback(async () => {
@@ -79,14 +120,24 @@ export const useImageUpload = ({
 
       setUploadedImageUrl(null);
       onSuccess?.(null);
+
+      const saved = await persistImageToEvent(null);
       toast.dismiss(loadingToastId);
-      toast.success("Image deleted successfully!");
+      if (autosaveEventId && !saved) {
+        toast.error("Image removed here, but couldn't be saved automatically. Click Update Event to save it.");
+      } else {
+        toast.success(
+          autosaveEventId
+            ? "Image deleted and saved to the event!"
+            : "Image deleted successfully!"
+        );
+      }
     } catch (error) {
       console.error("[useImageUpload-handleImageDelete] Error deleting image:", error);
       toast.dismiss(loadingToastId);
       toast.error("Failed to delete image");
     }
-  }, [uploadedImageUrl, onSuccess]);
+  }, [uploadedImageUrl, onSuccess, autosaveEventId, persistImageToEvent]);
 
   const setImageUrl = useCallback((url: string | null) => {
     setUploadedImageUrl(url);


### PR DESCRIPTION
Cherry-pick of #170 onto \`develop\` (same fix, same commit, no conflicts).

See #170 for full context — autosave on event-image upload/delete in edit
mode, real asset deletion in \`delete-image\`, and dedupe-on-upload in
\`upload-image\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)