### PR TITLE
feat(ui): gate navbar cart icon behind shop flag; tighten landing + sign-in copy

### DIFF
--- a/components/authentication/LoginForm.tsx
+++ b/components/authentication/LoginForm.tsx
@@ -56,7 +56,7 @@ export default function LoginForm(): ReactElement {
       <CardHeader className="text-center">
         <CardTitle className="text-2xl">Sign in</CardTitle>
         <CardDescription>
-          Access your bookings and orders. No password needed.
+          Access your bookings and orders.
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">

--- a/components/landing/ShopPreview.tsx
+++ b/components/landing/ShopPreview.tsx
@@ -53,8 +53,7 @@ const ShopPreview = (): ReactElement => {
                 Take home a little creativity.
               </h2>
               <p className="max-w-xl text-lg leading-relaxed text-slate-700">
-                Art kits, studio goods, and works of art from local artists —
-                shipped right to your door.
+                Art kits and studio goods shipped to your door.
               </p>
             </div>
             <Button

--- a/components/layout/nav/NavBar.tsx
+++ b/components/layout/nav/NavBar.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { motion, AnimatePresence } from "motion/react";
 import CartIcon from "@/components/store/CartIcon";
+import { isShopEnabled } from "@/lib/constants/featureFlags";
 import AccountNavLink from "@/components/authentication/AccountNavLink";
 import { useReservations } from "@/hooks/queries";
 import { Reservation } from "@/lib/types/reservationTypes";
@@ -342,14 +343,14 @@ export default function NavBar() {
               className="flex items-center gap-4 border-l border-gray-200 pl-5 xl:pl-8 2xl:pl-10"
             >
               <AccountNavLink />
-              <CartIcon />
+              {isShopEnabled() && <CartIcon />}
             </motion.div>
           </motion.nav>
 
           {/* Mobile Menu Button */}
           <div className="lg:hidden flex items-center gap-3">
             <AccountNavLink />
-            <CartIcon />
+            {isShopEnabled() && <CartIcon />}
             <motion.button
             className="flex items-center"
             onClick={() => setIsMenuOpen(!isMenuOpen)}


### PR DESCRIPTION
## Summary
- **NavBar** (`components/layout/nav/NavBar.tsx`): both `<CartIcon />` renders (desktop nav + mobile header) are now gated behind the existing `isShopEnabled()` launch flag from `lib/constants/featureFlags.ts`, so the cart icon only appears when the shop is enabled. `NEXT_PUBLIC_SHOP_ENABLED` is inlined at build time, so this is safe in a client component.
- **ShopPreview** (`components/landing/ShopPreview.tsx`): landing shop blurb tightened to "Art kits and studio goods shipped to your door."
- **LoginForm** (`components/authentication/LoginForm.tsx`): sign-in card description now reads "Access your bookings and orders." ("No password needed." removed).

No new flags introduced; `StoreCartButton` and other cart surfaces untouched.

## Validation
- `pnpm install --frozen-lockfile` + `pnpm run build` — build passes
- `pnpm run lint` — 0 errors (46 pre-existing warnings, none introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)