### PR TITLE
feat(shop): restore "Online Sales" category gate — only flagged items display

### DIFF
--- a/__tests__/utils/catalogHelpers.test.ts
+++ b/__tests__/utils/catalogHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isSellablePhysicalGood,
+  isInOnlineSalesCategory,
   deriveAvailability,
   toStoreProductSummary,
 } from "@/lib/utils/catalogHelpers";
@@ -53,6 +54,56 @@ describe("isSellablePhysicalGood", () => {
     expect(
       isSellablePhysicalGood({ ...baseItem, productType: "LEGACY_SQUARE_ONLINE_SERVICE" })
     ).toBe(false);
+  });
+});
+
+describe("isInOnlineSalesCategory", () => {
+  it("returns true for items in an 'Online Sales …' category", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["Online Sales - Art Kits"],
+      })
+    ).toBe(true);
+  });
+
+  it("matches the prefix case-insensitively", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["ONLINE SALES - Stickers"],
+      })
+    ).toBe(true);
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["online sales - art kits"],
+      })
+    ).toBe(true);
+  });
+
+  it("returns true when any of several categories matches", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["Coastal Creations", "Online Sales - Art Kits"],
+      })
+    ).toBe(true);
+  });
+
+  it("returns false for non-matching categories", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["Coastal Creations"],
+      })
+    ).toBe(false);
+  });
+
+  it("returns false for items with no categories", () => {
+    expect(isInOnlineSalesCategory({ ...baseItem, categoryNames: [] })).toBe(
+      false
+    );
   });
 });
 

--- a/app/api/store/products/[id]/route.ts
+++ b/app/api/store/products/[id]/route.ts
@@ -4,6 +4,7 @@ import StoreProductSettings from "@/lib/models/StoreProductSettings";
 import { retrieveCatalogItem, getInventoryCounts } from "@/lib/square/catalog";
 import {
   isSellablePhysicalGood,
+  isInOnlineSalesCategory,
   toStoreProduct,
 } from "@/lib/utils/catalogHelpers";
 import type { IStoreProductSettings } from "@/lib/models/StoreProductSettings";
@@ -21,9 +22,8 @@ export async function GET(
   try {
     const item = await retrieveCatalogItem(id);
 
-    // Visible for any REGULAR, non-archived physical good — matches the Shop grid,
-    // which no longer gates on the "Online Sales …" Square category.
-    if (!item || !isSellablePhysicalGood(item)) {
+    // Visible only if it's a physical good in an "Online Sales …" Square category.
+    if (!item || !isSellablePhysicalGood(item) || !isInOnlineSalesCategory(item)) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 

--- a/app/api/store/products/route.ts
+++ b/app/api/store/products/route.ts
@@ -4,6 +4,7 @@ import StoreProductSettings from "@/lib/models/StoreProductSettings";
 import { listCatalogItems, getInventoryCounts } from "@/lib/square/catalog";
 import {
   isSellablePhysicalGood,
+  isInOnlineSalesCategory,
   toStoreProductSummary,
 } from "@/lib/utils/catalogHelpers";
 import type { StoreProductSummary } from "@/lib/types/storeTypes";
@@ -11,12 +12,14 @@ import type { IStoreProductSettings } from "@/lib/models/StoreProductSettings";
 
 export async function GET(): Promise<Response> {
   try {
-    // Shop shows the full Square inventory: every REGULAR, non-archived physical good
-    // at the location. The previous "Online Sales …" category gate was removed so the
-    // client sees a realistic view of all products. StoreProductSettings remains an
-    // OPTIONAL layer for parcel size / slug / display order overrides.
+    // Shop visibility is driven entirely by Square: an item appears online when the
+    // merchant adds it to an "Online Sales …" category in the Square dashboard. No
+    // app-side toggle. StoreProductSettings is only an OPTIONAL layer for parcel
+    // size / slug / display order overrides.
     const allItems = await listCatalogItems();
-    const items = allItems.filter((item) => isSellablePhysicalGood(item));
+    const items = allItems.filter(
+      (item) => isSellablePhysicalGood(item) && isInOnlineSalesCategory(item)
+    );
 
     if (items.length === 0) {
       return NextResponse.json({ success: true, products: [] });

--- a/lib/utils/catalogHelpers.ts
+++ b/lib/utils/catalogHelpers.ts
@@ -17,13 +17,31 @@ import { formatCents } from "@/lib/utils/moneyHelpers";
 const LOW_STOCK_THRESHOLD = 5;
 
 /**
+ * Square category-name prefix that controls Shop visibility. The merchant adds an
+ * item to any Square category whose name starts with this prefix (e.g.
+ * "Online Sales - Art Kits", "Online Sales - Stickers") to put it in the online Shop.
+ * This is the SINGLE source of truth for what is sellable online — managed entirely
+ * from the Square dashboard, no app-side toggle. See spec/ecommerce/00-STATUS.md.
+ */
+export const ONLINE_SALES_CATEGORY_PREFIX = "Online Sales";
+
+/**
  * Returns true for items that should be allowed in the Shop:
  * REGULAR physical goods, not archived, present at the merchant's location.
- * The Shop now shows ALL such items — there is no longer an "Online Sales …"
- * category gate (removed so the client sees a realistic view of full inventory).
+ * Shop visibility additionally requires isInOnlineSalesCategory — both gates
+ * apply on the storefront product routes.
  */
 export function isSellablePhysicalGood(item: RawCatalogItem): boolean {
   return item.productType === "REGULAR" && !item.isArchived;
+}
+
+/**
+ * True when the item belongs to an "Online Sales …" Square category — i.e. the
+ * merchant has flagged it for the online Shop from the Square dashboard.
+ */
+export function isInOnlineSalesCategory(item: RawCatalogItem): boolean {
+  const prefix = ONLINE_SALES_CATEGORY_PREFIX.toLowerCase();
+  return item.categoryNames.some((name) => name.toLowerCase().startsWith(prefix));
 }
 
 /**


### PR DESCRIPTION
## Summary

Restores the Square "Online Sales" category gate removed in f370f73. The online Shop once again displays **only** items the merchant has placed in a Square category whose name starts with `Online Sales` (e.g. "Online Sales - Art Kits").

- `lib/utils/catalogHelpers.ts` — re-adds `ONLINE_SALES_CATEGORY_PREFIX` and `isInOnlineSalesCategory` (case-insensitive prefix match on `categoryNames`); the plumbing in `lib/square/catalog.ts` that resolves secondary-category names into `RawCatalogItem.categoryNames` was never removed, so no catalog changes needed.
- `app/api/store/products/route.ts` — Shop grid filters on `isSellablePhysicalGood(item) && isInOnlineSalesCategory(item)`.
- `app/api/store/products/[id]/route.ts` — single-product route applies the same gate; non-gated items return the same 404 as nonexistent products (no leaking of hidden catalog items).
- `app/api/admin/store/products/route.ts` — **untouched**: the admin dashboard keeps seeing the full catalog.

## Expected impact

Against the current live Square catalog, the Shop goes from ~58 items to **19** (the "Online Sales - Art Kits" items). No-category items (stickers, "Bday Party") and in-studio services ("Paint party", "Delivery") disappear from the storefront. Visibility is controlled entirely from the Square dashboard — add/remove an item from an "Online Sales …" category, no app deploy needed.

## Validation

- `pnpm run build` — passes
- `pnpm run lint` — 0 errors; no warnings in touched files (46 pre-existing warnings elsewhere, unchanged)
- `pnpm run test:run __tests__/utils/catalogHelpers.test.ts` — 20/20 pass, including 5 new tests for the gate (match, case-insensitivity, multi-category, non-match, empty categories)
- Full suite: 346 passed; the 16 failures in `__tests__/checkout/storeCheckoutRoute.test.ts` (503 vs 200) fail identically on clean `develop` — pre-existing, unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)