### PR TITLE
Release: shop launch-gate polish + Online Sales category gate

### DIFF
--- a/__tests__/utils/catalogHelpers.test.ts
+++ b/__tests__/utils/catalogHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isSellablePhysicalGood,
+  isInOnlineSalesCategory,
   deriveAvailability,
   toStoreProductSummary,
 } from "@/lib/utils/catalogHelpers";
@@ -53,6 +54,56 @@ describe("isSellablePhysicalGood", () => {
     expect(
       isSellablePhysicalGood({ ...baseItem, productType: "LEGACY_SQUARE_ONLINE_SERVICE" })
     ).toBe(false);
+  });
+});
+
+describe("isInOnlineSalesCategory", () => {
+  it("returns true for items in an 'Online Sales …' category", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["Online Sales - Art Kits"],
+      })
+    ).toBe(true);
+  });
+
+  it("matches the prefix case-insensitively", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["ONLINE SALES - Stickers"],
+      })
+    ).toBe(true);
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["online sales - art kits"],
+      })
+    ).toBe(true);
+  });
+
+  it("returns true when any of several categories matches", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["Coastal Creations", "Online Sales - Art Kits"],
+      })
+    ).toBe(true);
+  });
+
+  it("returns false for non-matching categories", () => {
+    expect(
+      isInOnlineSalesCategory({
+        ...baseItem,
+        categoryNames: ["Coastal Creations"],
+      })
+    ).toBe(false);
+  });
+
+  it("returns false for items with no categories", () => {
+    expect(isInOnlineSalesCategory({ ...baseItem, categoryNames: [] })).toBe(
+      false
+    );
   });
 });
 

--- a/app/api/store/products/[id]/route.ts
+++ b/app/api/store/products/[id]/route.ts
@@ -4,6 +4,7 @@ import StoreProductSettings from "@/lib/models/StoreProductSettings";
 import { retrieveCatalogItem, getInventoryCounts } from "@/lib/square/catalog";
 import {
   isSellablePhysicalGood,
+  isInOnlineSalesCategory,
   toStoreProduct,
 } from "@/lib/utils/catalogHelpers";
 import type { IStoreProductSettings } from "@/lib/models/StoreProductSettings";
@@ -21,9 +22,8 @@ export async function GET(
   try {
     const item = await retrieveCatalogItem(id);
 
-    // Visible for any REGULAR, non-archived physical good — matches the Shop grid,
-    // which no longer gates on the "Online Sales …" Square category.
-    if (!item || !isSellablePhysicalGood(item)) {
+    // Visible only if it's a physical good in an "Online Sales …" Square category.
+    if (!item || !isSellablePhysicalGood(item) || !isInOnlineSalesCategory(item)) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 

--- a/app/api/store/products/route.ts
+++ b/app/api/store/products/route.ts
@@ -4,6 +4,7 @@ import StoreProductSettings from "@/lib/models/StoreProductSettings";
 import { listCatalogItems, getInventoryCounts } from "@/lib/square/catalog";
 import {
   isSellablePhysicalGood,
+  isInOnlineSalesCategory,
   toStoreProductSummary,
 } from "@/lib/utils/catalogHelpers";
 import type { StoreProductSummary } from "@/lib/types/storeTypes";
@@ -11,12 +12,14 @@ import type { IStoreProductSettings } from "@/lib/models/StoreProductSettings";
 
 export async function GET(): Promise<Response> {
   try {
-    // Shop shows the full Square inventory: every REGULAR, non-archived physical good
-    // at the location. The previous "Online Sales …" category gate was removed so the
-    // client sees a realistic view of all products. StoreProductSettings remains an
-    // OPTIONAL layer for parcel size / slug / display order overrides.
+    // Shop visibility is driven entirely by Square: an item appears online when the
+    // merchant adds it to an "Online Sales …" category in the Square dashboard. No
+    // app-side toggle. StoreProductSettings is only an OPTIONAL layer for parcel
+    // size / slug / display order overrides.
     const allItems = await listCatalogItems();
-    const items = allItems.filter((item) => isSellablePhysicalGood(item));
+    const items = allItems.filter(
+      (item) => isSellablePhysicalGood(item) && isInOnlineSalesCategory(item)
+    );
 
     if (items.length === 0) {
       return NextResponse.json({ success: true, products: [] });

--- a/components/authentication/LoginForm.tsx
+++ b/components/authentication/LoginForm.tsx
@@ -56,7 +56,7 @@ export default function LoginForm(): ReactElement {
       <CardHeader className="text-center">
         <CardTitle className="text-2xl">Sign in</CardTitle>
         <CardDescription>
-          Access your bookings and orders. No password needed.
+          Access your bookings and orders.
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">

--- a/components/landing/ShopPreview.tsx
+++ b/components/landing/ShopPreview.tsx
@@ -53,8 +53,7 @@ const ShopPreview = (): ReactElement => {
                 Take home a little creativity.
               </h2>
               <p className="max-w-xl text-lg leading-relaxed text-slate-700">
-                Art kits, studio goods, and works of art from local artists —
-                shipped right to your door.
+                Art kits and studio goods shipped to your door.
               </p>
             </div>
             <Button

--- a/components/layout/nav/NavBar.tsx
+++ b/components/layout/nav/NavBar.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { motion, AnimatePresence } from "motion/react";
 import CartIcon from "@/components/store/CartIcon";
+import { isShopEnabled } from "@/lib/constants/featureFlags";
 import AccountNavLink from "@/components/authentication/AccountNavLink";
 import { useReservations } from "@/hooks/queries";
 import { Reservation } from "@/lib/types/reservationTypes";
@@ -342,14 +343,14 @@ export default function NavBar() {
               className="flex items-center gap-4 border-l border-gray-200 pl-5 xl:pl-8 2xl:pl-10"
             >
               <AccountNavLink />
-              <CartIcon />
+              {isShopEnabled() && <CartIcon />}
             </motion.div>
           </motion.nav>
 
           {/* Mobile Menu Button */}
           <div className="lg:hidden flex items-center gap-3">
             <AccountNavLink />
-            <CartIcon />
+            {isShopEnabled() && <CartIcon />}
             <motion.button
             className="flex items-center"
             onClick={() => setIsMenuOpen(!isMenuOpen)}

--- a/lib/utils/catalogHelpers.ts
+++ b/lib/utils/catalogHelpers.ts
@@ -17,13 +17,31 @@ import { formatCents } from "@/lib/utils/moneyHelpers";
 const LOW_STOCK_THRESHOLD = 5;
 
 /**
+ * Square category-name prefix that controls Shop visibility. The merchant adds an
+ * item to any Square category whose name starts with this prefix (e.g.
+ * "Online Sales - Art Kits", "Online Sales - Stickers") to put it in the online Shop.
+ * This is the SINGLE source of truth for what is sellable online — managed entirely
+ * from the Square dashboard, no app-side toggle. See spec/ecommerce/00-STATUS.md.
+ */
+export const ONLINE_SALES_CATEGORY_PREFIX = "Online Sales";
+
+/**
  * Returns true for items that should be allowed in the Shop:
  * REGULAR physical goods, not archived, present at the merchant's location.
- * The Shop now shows ALL such items — there is no longer an "Online Sales …"
- * category gate (removed so the client sees a realistic view of full inventory).
+ * Shop visibility additionally requires isInOnlineSalesCategory — both gates
+ * apply on the storefront product routes.
  */
 export function isSellablePhysicalGood(item: RawCatalogItem): boolean {
   return item.productType === "REGULAR" && !item.isArchived;
+}
+
+/**
+ * True when the item belongs to an "Online Sales …" Square category — i.e. the
+ * merchant has flagged it for the online Shop from the Square dashboard.
+ */
+export function isInOnlineSalesCategory(item: RawCatalogItem): boolean {
+  const prefix = ONLINE_SALES_CATEGORY_PREFIX.toLowerCase();
+  return item.categoryNames.some((name) => name.toLowerCase().startsWith(prefix));
 }
 
 /**


### PR DESCRIPTION
## Summary

Promotes the latest \`develop\` to production (7 files, +87/−15 — PRs #175 and #176):

- **Online Sales category gate restored** (#176): the Shop grid and product-detail APIs now only serve items in a Square category starting with "Online Sales" (currently "Online Sales - Art Kits", 19 items). In-studio services, brand-only items, and uncategorized items no longer appear online. Visibility is controlled entirely from the Square dashboard; the admin dashboard still sees the full catalog.
- **Navbar cart icon gated behind the shop launch flag** (#175): the bag icon (desktop + mobile) is hidden until \`NEXT_PUBLIC_SHOP_ENABLED=true\` is set in the deployment environment.
- **Copy tweaks** (#175): landing shop blurb now "Art kits and studio goods shipped to your door."; sign-in card no longer says "No password needed."

## Notes for deploy

- The store remains dark in production until \`NEXT_PUBLIC_SHOP_ENABLED=true\` is set (build-time inlined — requires a redeploy when flipping).
- The 16 store-checkout unit tests require that flag to pass; CI sets it (ci.yml) — local runs without it show expected 503-gate failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)