### PR TITLE
release: promote shipping fixes to production (store going live)

### DIFF
--- a/__tests__/checkout/storePricing.test.ts
+++ b/__tests__/checkout/storePricing.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/shippo/rates", () => ({
 const settingsSelect = vi.fn();
 vi.mock("@/lib/models/StoreProductSettings", () => ({
   default: { find: () => ({ select: settingsSelect }) },
-  DEFAULT_PARCEL_PRESET: "MEDIUM",
+  DEFAULT_PARCEL_PRESET: "SMALL",
 }));
 
 import {
@@ -166,5 +166,22 @@ describe("resolveShippingRate", () => {
     await expect(
       resolveShippingRate(destination, [cartItem()], clientRate)
     ).rejects.toBeInstanceOf(PriceIntegrityError);
+  });
+
+  it("falls back to DEFAULT_PARCEL_PRESET when an item has no StoreProductSettings row", async () => {
+    settingsSelect.mockResolvedValue([]); // no matching setting for ITEM1
+    getShippingRates.mockResolvedValue([
+      {
+        rateId: "FRESH_ID",
+        carrier: "USPS",
+        service: "usps_priority",
+        serviceName: "USPS Priority",
+        rateCents: 899,
+      },
+    ]);
+
+    await resolveShippingRate(destination, [cartItem({ quantity: 1 })], clientRate);
+
+    expect(getShippingRates).toHaveBeenCalledWith(destination, ["SMALL"]);
   });
 });

--- a/app/api/store/shipping-rates/route.ts
+++ b/app/api/store/shipping-rates/route.ts
@@ -5,7 +5,9 @@
 import { NextResponse } from "next/server";
 import { isShopEnabled } from "@/lib/constants/featureFlags";
 import { connectMongo } from "@/lib/mongoose";
-import StoreProductSettings from "@/lib/models/StoreProductSettings";
+import StoreProductSettings, {
+  DEFAULT_PARCEL_PRESET,
+} from "@/lib/models/StoreProductSettings";
 import { getShippingRates } from "@/lib/shippo/rates";
 import type { ShipToAddress } from "@/lib/shippo/rates";
 import type { ParcelPreset } from "@/lib/models/StoreProductSettings";
@@ -42,7 +44,7 @@ export async function POST(request: Request): Promise<Response> {
     const presets: ParcelPreset[] = [];
     for (const cartItem of body.cartItems) {
       const setting = settings.find((s) => s.squareItemId === cartItem.squareCatalogItemId);
-      const preset = setting?.parcelPreset ?? "MEDIUM";
+      const preset = setting?.parcelPreset ?? DEFAULT_PARCEL_PRESET;
       for (let i = 0; i < cartItem.quantity; i++) {
         presets.push(preset);
       }

--- a/components/dashboard/store/StoreProductsTable.tsx
+++ b/components/dashboard/store/StoreProductsTable.tsx
@@ -119,7 +119,7 @@ export default function StoreProductsTable(): ReactElement {
               ) : (
                 products.map(({ catalogItem, settings }) => {
                   const isSaving = saving.has(catalogItem.id);
-                  const preset = settings?.parcelPreset ?? "MEDIUM";
+                  const preset = settings?.parcelPreset ?? "SMALL";
 
                   return (
                     <tr key={catalogItem.id} className="hover:bg-gray-50">

--- a/lib/checkout/storePricing.ts
+++ b/lib/checkout/storePricing.ts
@@ -11,7 +11,9 @@
  * BEFORE charging. See ecommerce/09-checkout-price-integrity.md.
  */
 import { listCatalogItems } from "@/lib/square/catalog";
-import StoreProductSettings from "@/lib/models/StoreProductSettings";
+import StoreProductSettings, {
+  DEFAULT_PARCEL_PRESET,
+} from "@/lib/models/StoreProductSettings";
 import type { ParcelPreset } from "@/lib/models/StoreProductSettings";
 import { getShippingRates } from "@/lib/shippo/rates";
 import type { ShipToAddress, ShippingRate } from "@/lib/shippo/rates";
@@ -133,7 +135,7 @@ export async function resolveShippingRate(
     const setting = settings.find(
       (s) => s.squareItemId === item.squareCatalogItemId
     );
-    const preset = (setting?.parcelPreset ?? "MEDIUM") as ParcelPreset;
+    const preset = (setting?.parcelPreset ?? DEFAULT_PARCEL_PRESET) as ParcelPreset;
     const quantity = validateQuantity(item.quantity, item.productName);
     for (let i = 0; i < quantity; i++) presets.push(preset);
   }

--- a/lib/models/StoreProductSettings.ts
+++ b/lib/models/StoreProductSettings.ts
@@ -13,10 +13,12 @@ import mongoose, { Document, Model, Schema } from "mongoose";
 
 // Box-size presets used to build Shippo parcels without per-item measuring.
 // Default dimensions/weights for each preset live in lib/utils/parcelHelpers.ts.
-// Default for a brand-new product is "MEDIUM" (~5lb) so live rates never break.
+// Default for a brand-new product is "SMALL" (~1lb) — the current catalog is 100%
+// micro art-kit items under 1lb. Revisit this default once heavier items are added
+// (per-product weight will eventually come from Square directly, not this field).
 export type ParcelPreset = "SMALL" | "MEDIUM" | "LARGE";
 
-export const DEFAULT_PARCEL_PRESET: ParcelPreset = "MEDIUM";
+export const DEFAULT_PARCEL_PRESET: ParcelPreset = "SMALL";
 
 export type WeightUnit = "oz" | "lb";
 export type DistanceUnit = "in" | "cm";
@@ -34,7 +36,7 @@ export interface IProductShipping {
 export interface IStoreProductSettings extends Document {
   squareItemId: string; // links to a Square Catalog ITEM (unique)
   isOnlineSellable: boolean; // THE Shop visibility flag
-  parcelPreset: ParcelPreset; // default MEDIUM (5lb)
+  parcelPreset: ParcelPreset; // default SMALL (1lb)
   shipping?: IProductShipping; // optional exact override of the preset
   slug?: string; // optional pretty URL for /shop/[slug]
   displayOrder?: number; // optional manual sort within the Shop

--- a/lib/shippo/rates.ts
+++ b/lib/shippo/rates.ts
@@ -1,6 +1,6 @@
 import { Shippo } from "shippo";
 import type { ParcelPreset } from "@/lib/models/StoreProductSettings";
-import { getParcelDimensions } from "@/lib/utils/parcelHelpers";
+import { resolveParcel } from "@/lib/utils/parcelHelpers";
 
 const shippoClient = new Shippo({
   apiKeyHeader: process.env.SHIPPO_API_KEY ?? "",
@@ -47,21 +47,11 @@ export interface ShippingRate {
   estimatedDays?: number;
 }
 
-// Picks the heaviest parcel preset in the cart to produce a single-parcel shipment.
-function heaviestPreset(presets: ParcelPreset[]): ParcelPreset {
-  const order: ParcelPreset[] = ["LARGE", "MEDIUM", "SMALL"];
-  for (const p of order) {
-    if (presets.includes(p)) return p;
-  }
-  return "MEDIUM";
-}
-
 export async function getShippingRates(
   destination: ShipToAddress,
   parcelPresets: ParcelPreset[]
 ): Promise<ShippingRate[]> {
-  const preset = heaviestPreset(parcelPresets);
-  const dims = getParcelDimensions(preset);
+  const dims = resolveParcel(parcelPresets);
 
   const shipment = await shippoClient.shipments.create({
     addressFrom: MERCHANT_SHIP_FROM,

--- a/lib/utils/parcelHelpers.ts
+++ b/lib/utils/parcelHelpers.ts
@@ -20,3 +20,36 @@ const PARCEL_PRESETS: Record<ParcelPreset, ParcelDimensions> = {
 export function getParcelDimensions(preset: ParcelPreset): ParcelDimensions {
   return PARCEL_PRESETS[preset];
 }
+
+const PRESET_ORDER: ParcelPreset[] = ["SMALL", "MEDIUM", "LARGE"];
+
+// Max weight (lb) a preset box is trusted to hold before a multi-item cart should
+// bump to the next size up. Keeps the box dimensions honest once several items are
+// packed into one parcel, instead of always shipping in whatever box the single
+// heaviest item calls for.
+const PRESET_WEIGHT_CAPACITY: Record<ParcelPreset, number> = {
+  SMALL: 2,
+  MEDIUM: 5,
+  LARGE: Infinity,
+};
+
+// Resolves the single parcel Shippo should quote/ship for an entire cart. Weight is
+// the true sum of every item's preset weight (quantity-expanded) — a cart of 3 items
+// now weighs ~3x a single item instead of being quoted at whatever one item weighs.
+// Dimensions start at the largest individual item's preset (never pack a LARGE item
+// into a SMALL box) and step up a tier if the summed weight exceeds that box's
+// capacity, so a full cart of small items doesn't get under-weighted into a box too
+// small to plausibly hold them.
+export function resolveParcel(presets: ParcelPreset[]): ParcelDimensions {
+  const totalWeight = presets.reduce((sum, p) => sum + PARCEL_PRESETS[p].weight, 0);
+  let tierIndex = Math.max(...presets.map((p) => PRESET_ORDER.indexOf(p)));
+
+  while (
+    tierIndex < PRESET_ORDER.length - 1 &&
+    totalWeight > PRESET_WEIGHT_CAPACITY[PRESET_ORDER[tierIndex]]
+  ) {
+    tierIndex++;
+  }
+
+  return { ...PARCEL_PRESETS[PRESET_ORDER[tierIndex]], weight: totalWeight };
+}


### PR DESCRIPTION
## Summary
Promotes `develop` → `main` for production. Contains PR #178 only:
- fix(shipping): sum cart weight instead of using single heaviest item's preset
- fix(shipping): default unset products to SMALL, not MEDIUM

## Context
`NEXT_PUBLIC_SHOP_ENABLED` has just been set to `true` in prod. Both shipping fixes are required before real orders go through — without them, a multi-item cart would under-quote real postage weight, and every one of the 19 current products (none has an explicit `parcelPreset` set) would have been over-quoted at 3lb/item instead of the real ~1lb/item.

## Test plan
- [x] `tsc --noEmit` clean (see PR #178)
- [x] `vitest run` — full suite passes except `storeCheckoutRoute.test.ts`, confirmed pre-existing/unrelated via `git stash` (see PR #178)
- [ ] Manual smoke test of a real order end-to-end once this is live (Shippo live env vars already confirmed present in prod)

I have not merged this — per project policy the agent never merges to `main`. Merge when ready to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)