### PR TITLE
fix(store): hide sold-out products from the shop grid

### DIFF
--- a/app/api/store/products/route.ts
+++ b/app/api/store/products/route.ts
@@ -36,6 +36,10 @@ export async function GET(): Promise<Response> {
 
     const products: StoreProductSummary[] = items
       .map((item) => toStoreProductSummary(item, byId.get(item.id), stock))
+      // Sold-out items (all variations out of stock) don't show up while browsing —
+      // still directly reachable at /shop/[slug] via toStoreProduct/getInventoryCounts,
+      // just not surfaced in the grid.
+      .filter((product) => product.availability !== "sold_out")
       .sort((a, b) => a.displayOrder - b.displayOrder);
 
     return NextResponse.json({ success: true, products });


### PR DESCRIPTION
## Summary
- The data model already correctly tracked sold-out state (`rollupAvailability` in `lib/utils/catalogHelpers.ts` returns `sold_out` only when every variation of an item is out of stock, already well-covered by existing tests) — but a sold-out item still appeared in the shop grid, just as a disabled card with a "Sold out" badge.
- `app/api/store/products/route.ts` now filters `availability === "sold_out"` out of the listing response entirely, so sold-out items don't display while browsing.
- Scoped to the grid/listing only — a sold-out product is still reachable directly via `/shop/[slug]` (the detail page keeps showing its "Sold out" state / disabled add-to-cart), only the discovery surface hides it. Flag if you'd rather it 404 on direct link too.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run __tests__/utils/catalogHelpers.test.ts` — 20/20 pass (sold-out derivation logic unchanged, already covered)
- [ ] Manual: mark a product's inventory to 0 in Square, confirm it drops out of the shop grid but its direct product-detail link still loads showing "Sold out"

🤖 Generated with [Claude Code](https://claude.com/claude-code)