### PR TITLE
fix(homepage): disable Google Reviews, not wired to real data yet

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,10 +6,13 @@ import Offerings from "@/components/landing/Offerings";
 import Calendar from "@/components/landing/Calendar";
 import ShopPreview from "@/components/landing/ShopPreview";
 import GiftCardBanner from "@/components/landing/GiftCardBanner";
-import GoogleReviews from "@/components/landing/GoogleReviews";
+// TEMP DISABLED (Ben, 2026-08-02): Google Reviews isn't wired to real data yet —
+// keep it out of prod until the Places API key is actually configured.
+// import GoogleReviews from "@/components/landing/GoogleReviews";
 import SectionDivider from "@/components/landing/SectionDivider";
 import PhotoCorral from "@/components/gallery/PhotoCorral";
-import { isShopEnabled } from "@/lib/constants/featureFlags";
+// Only referenced inside the disabled GoogleReviews block below — commented out with it.
+// import { isShopEnabled } from "@/lib/constants/featureFlags";
 
 export const metadata: Metadata = {
   title: "Coastal Creations Studio | Art Classes & Workshops in Ocean City, NJ",
@@ -33,13 +36,15 @@ export default function Home() {
       </div>
       <PhotoCorral destination="home-page" />
       <SectionDivider />
-      {/* Hidden behind the shop launch gate alongside the store (client request). */}
-      {isShopEnabled() && (
+      {/* TEMP DISABLED (Ben, 2026-08-02): not wired to real data yet, don't show in prod.
+          Was previously gated behind the shop launch flag alongside the store (client request);
+          re-enable that gate (isShopEnabled()) once real reviews are wired up. */}
+      {/* {isShopEnabled() && (
         <>
           <GoogleReviews />
           <SectionDivider />
         </>
-      )}
+      )} */}
       <Offerings />
       <SectionDivider />
       <ShopPreview />


### PR DESCRIPTION
## Summary
Urgent — Google Reviews was gated behind `isShopEnabled()`, so flipping `NEXT_PUBLIC_SHOP_ENABLED` to true (going live) silently turned this section on in prod, showing unconfigured/placeholder review content to real visitors. Commented out (not deleted) the render + its now-unused imports in `app/page.tsx` so it can't ship until it's actually wired to real Places API data.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint app/page.tsx` clean (no unused-import warnings)
- [ ] Manual: confirm homepage no longer shows a Reviews section after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)