### PR TITLE
fix(store): don't quick-add a sold-out variation from the grid

### DIFF
--- a/__tests__/utils/catalogHelpers.test.ts
+++ b/__tests__/utils/catalogHelpers.test.ts
@@ -200,4 +200,35 @@ describe("toStoreProductSummary", () => {
     const summary = toStoreProductSummary(item, baseSettings, stock);
     expect(summary.availability).toBe("sold_out");
   });
+
+  it("skips a sold-out first-ordinal variation when picking defaultVariation", () => {
+    // Regression: grid quick-add must not silently pick a sold-out flavor just
+    // because it's ordinal 0 — CartProvider refuses to add sold-out variations,
+    // so this used to fail with no feedback (see Mini Travel Art Kits in prod).
+    const item: RawCatalogItem = {
+      ...baseItem,
+      variations: [
+        { ...baseVariation, id: "V1", ordinal: 0, trackInventory: true }, // sold out
+        { ...baseVariation, id: "V2", ordinal: 1, trackInventory: true }, // in stock
+      ],
+    };
+    const stock = new Map([["V2", 3]]); // V1 absent -> no inventory record -> sold_out
+    const summary = toStoreProductSummary(item, baseSettings, stock);
+    expect(summary.defaultVariation?.id).toBe("V2");
+    expect(summary.defaultVariation?.availability).not.toBe("sold_out");
+  });
+
+  it("falls back to the ordinal-first variation when every variation is sold out", () => {
+    const item: RawCatalogItem = {
+      ...baseItem,
+      variations: [
+        { ...baseVariation, id: "V1", ordinal: 0, trackInventory: true },
+        { ...baseVariation, id: "V2", ordinal: 1, trackInventory: true },
+      ],
+    };
+    const stock = new Map<string, number>();
+    const summary = toStoreProductSummary(item, baseSettings, stock);
+    expect(summary.defaultVariation?.id).toBe("V1");
+    expect(summary.availability).toBe("sold_out");
+  });
 });

--- a/lib/utils/catalogHelpers.ts
+++ b/lib/utils/catalogHelpers.ts
@@ -161,7 +161,18 @@ export function toStoreProductSummary(
 
   // First variation by ordinal — lets the grid card add to cart directly with a
   // real Square variation id (checkout-correct) without loading the detail payload.
-  const firstRaw = [...item.variations].sort((a, b) => a.ordinal - b.ordinal)[0];
+  // Prefer the first variation that's actually in stock: if ordinal 0 happens to be
+  // sold out while other flavors aren't, quick-add from the grid must not silently
+  // pick the sold-out one (CartProvider.addItem refuses sold-out variations, so that
+  // used to fail with no feedback). Only fall back to the sorted-first variation when
+  // every variation is sold out, matching rollupAvailability's own "sold_out" rule.
+  const sortedVariations = [...item.variations].sort(
+    (a, b) => a.ordinal - b.ordinal
+  );
+  const firstRaw =
+    sortedVariations.find(
+      (v) => deriveAvailability(v, stock.get(v.id)) !== "sold_out"
+    ) ?? sortedVariations[0];
   const defaultVariation = firstRaw
     ? toStoreProductVariation(firstRaw, stock.get(firstRaw.id))
     : undefined;


### PR DESCRIPTION
## Summary
Reproduced live on prod: **Mini Travel Art Kits** wasn't addable to cart from the shop grid. Root cause — `toStoreProductSummary` (`lib/utils/catalogHelpers.ts`) picked `defaultVariation` as the ordinal-first variation with no regard for whether that specific variation was in stock. Ordinal 0 for this item is "Mini Unicorn Art Kit," which is sold out, while the other 8 flavors aren't. Clicking "Add to Cart" called `CartProvider.addItem` with the sold-out Unicorn variation, which silently no-ops by design — but `AddToCartButton` still flashed a false "Added!" confirmation regardless, since it doesn't know the add failed.

Fix: `defaultVariation` now prefers the first variation that isn't sold out, only falling back to the ordinal-first one when every variation is sold out (which is also when the product-level availability rolls up to `sold_out` and the button correctly disables).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run __tests__/utils/catalogHelpers.test.ts` — 22/22 pass, added 2 regression tests (skips sold-out first-ordinal variation; falls back to it when everything's sold out)
- [x] Confirmed against live prod data via `/api/store/products` — Mini Travel Art Kits' `defaultVariation` was `Mini Unicorn Art Kit` (sold_out, qty 0) before reasoning through this fix
- [ ] Manual: once deployed, add Mini Travel Art Kits to cart from the grid and confirm it actually lands in the cart

🤖 Generated with [Claude Code](https://claude.com/claude-code)