### PR TITLE
fix(store): sort sold-out products to the end instead of hiding

### DIFF
--- a/app/api/store/products/route.ts
+++ b/app/api/store/products/route.ts
@@ -36,11 +36,15 @@ export async function GET(): Promise<Response> {
 
     const products: StoreProductSummary[] = items
       .map((item) => toStoreProductSummary(item, byId.get(item.id), stock))
-      // Sold-out items (all variations out of stock) don't show up while browsing —
-      // still directly reachable at /shop/[slug] via toStoreProduct/getInventoryCounts,
-      // just not surfaced in the grid.
-      .filter((product) => product.availability !== "sold_out")
-      .sort((a, b) => a.displayOrder - b.displayOrder);
+      // Sold-out items still display, but always sink to the end of the grid —
+      // available/low-stock items sort first; displayOrder only breaks ties
+      // within each group.
+      .sort((a, b) => {
+        const aSoldOut = a.availability === "sold_out" ? 1 : 0;
+        const bSoldOut = b.availability === "sold_out" ? 1 : 0;
+        if (aSoldOut !== bSoldOut) return aSoldOut - bSoldOut;
+        return a.displayOrder - b.displayOrder;
+      });
 
     return NextResponse.json({ success: true, products });
   } catch (error) {


### PR DESCRIPTION
## Summary
Ben's follow-up direction on PR #180 (already merged): don't hide sold-out products from the shop grid — keep them visible, just sink them to the end of the list, with available/low-stock items always first.

`app/api/store/products/route.ts` now sorts by sold-out status first (not sold out before sold out), then by `displayOrder` within each group, instead of filtering sold-out items out entirely.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual: confirm sold-out products (e.g. "Decorate Your Own Flower Sunglasses Kit") appear at the bottom of the grid, after all in-stock items, in both grid and list view

🤖 Generated with [Claude Code](https://claude.com/claude-code)