### PR TITLE
release: Google Reviews disable + sold-out product fixes

### DIFF
--- a/__tests__/utils/catalogHelpers.test.ts
+++ b/__tests__/utils/catalogHelpers.test.ts
@@ -200,4 +200,35 @@ describe("toStoreProductSummary", () => {
     const summary = toStoreProductSummary(item, baseSettings, stock);
     expect(summary.availability).toBe("sold_out");
   });
+
+  it("skips a sold-out first-ordinal variation when picking defaultVariation", () => {
+    // Regression: grid quick-add must not silently pick a sold-out flavor just
+    // because it's ordinal 0 — CartProvider refuses to add sold-out variations,
+    // so this used to fail with no feedback (see Mini Travel Art Kits in prod).
+    const item: RawCatalogItem = {
+      ...baseItem,
+      variations: [
+        { ...baseVariation, id: "V1", ordinal: 0, trackInventory: true }, // sold out
+        { ...baseVariation, id: "V2", ordinal: 1, trackInventory: true }, // in stock
+      ],
+    };
+    const stock = new Map([["V2", 3]]); // V1 absent -> no inventory record -> sold_out
+    const summary = toStoreProductSummary(item, baseSettings, stock);
+    expect(summary.defaultVariation?.id).toBe("V2");
+    expect(summary.defaultVariation?.availability).not.toBe("sold_out");
+  });
+
+  it("falls back to the ordinal-first variation when every variation is sold out", () => {
+    const item: RawCatalogItem = {
+      ...baseItem,
+      variations: [
+        { ...baseVariation, id: "V1", ordinal: 0, trackInventory: true },
+        { ...baseVariation, id: "V2", ordinal: 1, trackInventory: true },
+      ],
+    };
+    const stock = new Map<string, number>();
+    const summary = toStoreProductSummary(item, baseSettings, stock);
+    expect(summary.defaultVariation?.id).toBe("V1");
+    expect(summary.availability).toBe("sold_out");
+  });
 });

--- a/app/api/store/products/route.ts
+++ b/app/api/store/products/route.ts
@@ -36,11 +36,15 @@ export async function GET(): Promise<Response> {
 
     const products: StoreProductSummary[] = items
       .map((item) => toStoreProductSummary(item, byId.get(item.id), stock))
-      // Sold-out items (all variations out of stock) don't show up while browsing —
-      // still directly reachable at /shop/[slug] via toStoreProduct/getInventoryCounts,
-      // just not surfaced in the grid.
-      .filter((product) => product.availability !== "sold_out")
-      .sort((a, b) => a.displayOrder - b.displayOrder);
+      // Sold-out items still display, but always sink to the end of the grid —
+      // available/low-stock items sort first; displayOrder only breaks ties
+      // within each group.
+      .sort((a, b) => {
+        const aSoldOut = a.availability === "sold_out" ? 1 : 0;
+        const bSoldOut = b.availability === "sold_out" ? 1 : 0;
+        if (aSoldOut !== bSoldOut) return aSoldOut - bSoldOut;
+        return a.displayOrder - b.displayOrder;
+      });
 
     return NextResponse.json({ success: true, products });
   } catch (error) {

--- a/app/api/store/products/route.ts
+++ b/app/api/store/products/route.ts
@@ -36,6 +36,10 @@ export async function GET(): Promise<Response> {
 
     const products: StoreProductSummary[] = items
       .map((item) => toStoreProductSummary(item, byId.get(item.id), stock))
+      // Sold-out items (all variations out of stock) don't show up while browsing —
+      // still directly reachable at /shop/[slug] via toStoreProduct/getInventoryCounts,
+      // just not surfaced in the grid.
+      .filter((product) => product.availability !== "sold_out")
       .sort((a, b) => a.displayOrder - b.displayOrder);
 
     return NextResponse.json({ success: true, products });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,10 +6,13 @@ import Offerings from "@/components/landing/Offerings";
 import Calendar from "@/components/landing/Calendar";
 import ShopPreview from "@/components/landing/ShopPreview";
 import GiftCardBanner from "@/components/landing/GiftCardBanner";
-import GoogleReviews from "@/components/landing/GoogleReviews";
+// TEMP DISABLED (Ben, 2026-08-02): Google Reviews isn't wired to real data yet —
+// keep it out of prod until the Places API key is actually configured.
+// import GoogleReviews from "@/components/landing/GoogleReviews";
 import SectionDivider from "@/components/landing/SectionDivider";
 import PhotoCorral from "@/components/gallery/PhotoCorral";
-import { isShopEnabled } from "@/lib/constants/featureFlags";
+// Only referenced inside the disabled GoogleReviews block below — commented out with it.
+// import { isShopEnabled } from "@/lib/constants/featureFlags";
 
 export const metadata: Metadata = {
   title: "Coastal Creations Studio | Art Classes & Workshops in Ocean City, NJ",
@@ -33,13 +36,15 @@ export default function Home() {
       </div>
       <PhotoCorral destination="home-page" />
       <SectionDivider />
-      {/* Hidden behind the shop launch gate alongside the store (client request). */}
-      {isShopEnabled() && (
+      {/* TEMP DISABLED (Ben, 2026-08-02): not wired to real data yet, don't show in prod.
+          Was previously gated behind the shop launch flag alongside the store (client request);
+          re-enable that gate (isShopEnabled()) once real reviews are wired up. */}
+      {/* {isShopEnabled() && (
         <>
           <GoogleReviews />
           <SectionDivider />
         </>
-      )}
+      )} */}
       <Offerings />
       <SectionDivider />
       <ShopPreview />

--- a/lib/utils/catalogHelpers.ts
+++ b/lib/utils/catalogHelpers.ts
@@ -161,7 +161,18 @@ export function toStoreProductSummary(
 
   // First variation by ordinal — lets the grid card add to cart directly with a
   // real Square variation id (checkout-correct) without loading the detail payload.
-  const firstRaw = [...item.variations].sort((a, b) => a.ordinal - b.ordinal)[0];
+  // Prefer the first variation that's actually in stock: if ordinal 0 happens to be
+  // sold out while other flavors aren't, quick-add from the grid must not silently
+  // pick the sold-out one (CartProvider.addItem refuses sold-out variations, so that
+  // used to fail with no feedback). Only fall back to the sorted-first variation when
+  // every variation is sold out, matching rollupAvailability's own "sold_out" rule.
+  const sortedVariations = [...item.variations].sort(
+    (a, b) => a.ordinal - b.ordinal
+  );
+  const firstRaw =
+    sortedVariations.find(
+      (v) => deriveAvailability(v, stock.get(v.id)) !== "sold_out"
+    ) ?? sortedVariations[0];
   const defaultVariation = firstRaw
     ? toStoreProductVariation(firstRaw, stock.get(firstRaw.id))
     : undefined;


### PR DESCRIPTION
## Summary
Promotes `develop` → `main`. Contains 4 fixes, all already merged into `develop`:

- **fix(homepage): disable Google Reviews** (#181) — not wired to real data yet; was silently turned on when the shop launch flag flipped, showing placeholder content to real visitors. Highest priority in this batch — currently still live/wrong on prod until this merges.
- **fix(store): hide sold-out products** (#180) → superseded in behavior by #183 below (kept for history; net effect after #183 is "sort to end," not "hide").
- **fix(store): don't quick-add a sold-out variation from the grid** (#182) — fixes Mini Travel Art Kits (and any item where the ordinal-first variation happens to be sold out) silently failing to add to cart.
- **fix(store): sort sold-out products to the end instead of hiding** (#183) — final behavior: sold-out items stay visible, sort after all available/low-stock items.

## Test plan
- [x] Each fix individually typechecked + tested (see #180–#183)
- [ ] Manual smoke test once deployed: homepage has no Reviews section; shop grid shows sold-out items last, not hidden; Mini Travel Art Kits adds to cart successfully

I have not merged this — per project policy the agent never merges to `main`. Merge when ready to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)