### PR TITLE
fix(store): stock label reflects defaultVariation, not sum across flavors

### DIFF
--- a/__tests__/utils/catalogHelpers.test.ts
+++ b/__tests__/utils/catalogHelpers.test.ts
@@ -231,4 +231,28 @@ describe("toStoreProductSummary", () => {
     expect(summary.defaultVariation?.id).toBe("V1");
     expect(summary.availability).toBe("sold_out");
   });
+
+  it("labels remaining stock from defaultVariation, not the sum across all flavors", () => {
+    // Regression: "Mini Travel Art Kits" in prod showed "Only 3 remaining" (3
+    // different flavors with 1 unit each) but quick-add always adds ONE specific
+    // flavor (defaultVariation), which only had 1 unit — the badge overpromised
+    // what the button could actually deliver.
+    const item: RawCatalogItem = {
+      ...baseItem,
+      variations: [
+        { ...baseVariation, id: "V1", ordinal: 0, trackInventory: true }, // sold out
+        { ...baseVariation, id: "V2", ordinal: 1, trackInventory: true }, // 1 left
+        { ...baseVariation, id: "V3", ordinal: 2, trackInventory: true }, // 1 left
+        { ...baseVariation, id: "V4", ordinal: 3, trackInventory: true }, // 1 left
+      ],
+    };
+    const stock = new Map([
+      ["V2", 1],
+      ["V3", 1],
+      ["V4", 1],
+    ]); // V1 absent -> sold_out; total across all flavors = 3
+    const summary = toStoreProductSummary(item, baseSettings, stock);
+    expect(summary.defaultVariation?.id).toBe("V2");
+    expect(summary.availabilityLabel).toBe("Only 1 remaining");
+  });
 });

--- a/lib/utils/catalogHelpers.ts
+++ b/lib/utils/catalogHelpers.ts
@@ -189,9 +189,14 @@ export function toStoreProductSummary(
     priceRange: priceRange(item.variations),
     hasMultipleVariations: item.variations.length > 1,
     availability,
+    // The "Only N remaining" count must match what quick-add from the grid can
+    // actually deliver — the stock of defaultVariation specifically, not the sum
+    // across every flavor. A multi-variation item can show 3 total units spread
+    // across 3 different flavors while the one flavor quick-add would add only
+    // has 1 — showing "3 remaining" there overpromises what the button can do.
     availabilityLabel: buildAvailabilityLabel(
       availability,
-      totalInStock(item.variations, stock)
+      defaultVariation?.inStockQuantity ?? totalInStock(item.variations, stock)
     ),
     displayOrder: (settings?.displayOrder as number | undefined) ?? 0,
     defaultVariation,


### PR DESCRIPTION
## Summary
Reproduced live on prod via your screenshot + a direct fetch of `/api/store/products/[id]`: **Mini Travel Art Kits** showed "Only 3 remaining" on the grid card, but that's the *sum* across 3 different flavors (1 Lizard + 1 Beach + 1 Giraffe each). Quick-add from the grid only ever adds ONE specific flavor — `defaultVariation`, which the earlier sold-out-skip fix (#182) correctly resolved to "Mini Lizard Art Kit" — and that flavor itself only had 1 unit. So the badge said 3, the button could only ever add 1, and incrementing past 1 correctly failed (that part was never broken — CartProvider was right to cap it).

Fix: `availabilityLabel`'s remaining count now comes from `defaultVariation.inStockQuantity`, not the summed total across every variation. Single-variation products (most of the catalog) are unaffected — their one variation already is the defaultVariation.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run __tests__/utils/catalogHelpers.test.ts` — 23/23 pass, added a regression test matching the exact prod scenario (3 flavors summing to 3, one with only 1 unit as defaultVariation → label reads "Only 1 remaining")
- [ ] Manual: confirm Mini Travel Art Kits now shows "Only 1 remaining" on the grid, matching what quick-add can actually deliver

🤖 Generated with [Claude Code](https://claude.com/claude-code)