### PR TITLE
feat(store): show which flavor quick-add will actually add

### DIFF
--- a/components/store/ShopListRow.tsx
+++ b/components/store/ShopListRow.tsx
@@ -57,6 +57,13 @@ export default function ShopListRow({
               {product.name}
             </h3>
           </Link>
+          {/* Multi-variation items quick-add ONE specific flavor (defaultVariation) —
+              show which one, matching ShopProductCard's grid-view treatment. */}
+          {product.hasMultipleVariations && product.defaultVariation && (
+            <span className="text-xs font-medium text-[var(--color-text-subtle)]">
+              {product.defaultVariation.name}
+            </span>
+          )}
           {tag && (
             <span className="rounded-full bg-[var(--color-light)] px-2 py-0.5 text-xs font-medium text-[var(--color-primary)]">
               {tag}

--- a/components/store/ShopProductCard.tsx
+++ b/components/store/ShopProductCard.tsx
@@ -70,6 +70,14 @@ export default function ShopProductCard({
             {product.name}
           </h3>
         </Link>
+        {/* Multi-variation items (e.g. "Mini Travel Art Kits") quick-add ONE
+            specific flavor (defaultVariation) — show which one, so the customer
+            knows what they're actually getting without opening the product page. */}
+        {product.hasMultipleVariations && product.defaultVariation && (
+          <p className="mt-0.5 text-xs font-medium text-[var(--color-text-subtle)]">
+            {product.defaultVariation.name}
+          </p>
+        )}
         {product.description && (
           // Cap long descriptions at ~4 lines and let the overflow scroll inside
           // the card, so the whole blurb is readable without breaking the


### PR DESCRIPTION
## Summary
Follow-up to #185. Multi-variation items like "Mini Travel Art Kits" only showed the parent product name in the grid/list — nothing told the customer which specific flavor (`defaultVariation`) the "Add to Cart" button was about to add. Now a small subtitle under the name shows it, e.g. "Mini Lizard Art Kit" — matching the pattern already used in the cart drawer (product name + variation name).

Applied to both `ShopProductCard` (grid) and `ShopListRow` (list view), gated on `hasMultipleVariations` so single-variation products (most of the catalog) are unaffected.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Verified in local dev (sandbox catalog has no multi-variation items to visually confirm the new subtitle against, but confirmed no regression — single-variation cards render identically, no console errors)
- [ ] Manual on preview/prod once merged: confirm "Mini Travel Art Kits" shows its current flavor (e.g. "Mini Lizard Art Kit") as a subtitle in both grid and list view

🤖 Generated with [Claude Code](https://claude.com/claude-code)