### PR TITLE
feat(checkout): collect NJ sales tax (6.625%), owner-confirmed

### DIFF
--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -171,15 +171,17 @@ describe("POST /api/store/checkout", () => {
     expect(data.success).toBe(true);
     expect(data.orderNumber).toBe("CC-TEST-1");
 
-    // Charged subtotal + shipping (8800 + 570) as BigInt cents.
+    // Charged subtotal + shipping + NJ tax (8800 + 570 + 621 = 9991) as BigInt cents.
+    // SELF_ADDRESS ships to NJ; 6.625% on the taxable base of 9370 rounds to 621.
     expect(paymentsCreate).toHaveBeenCalledTimes(1);
-    expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(9370));
+    expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(9991));
 
     expect(orderCreate).toHaveBeenCalledTimes(1);
     const order = orderCreate.mock.calls[0][0];
-    expect(order.totalCents).toBe(9370);
+    expect(order.totalCents).toBe(9991);
     expect(order.subtotalCents).toBe(8800);
     expect(order.shippingCents).toBe(570);
+    expect(order.taxCents).toBe(621);
     expect(order.status).toBe("paid");
     expect(purchaseLabelForOrder).toHaveBeenCalledWith("order_1");
 
@@ -216,9 +218,10 @@ describe("POST /api/store/checkout", () => {
     );
     expect(res.status).toBe(200);
 
-    // Card charged only the shipping remainder (570), never $0.
+    // Gift card offsets the subtotal only — never shipping or tax. Card charged
+    // the shipping + NJ tax remainder (570 + 621 = 1191), never $0.
     expect(paymentsCreate).toHaveBeenCalledTimes(1);
-    expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(570));
+    expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(1191));
     // Redeemed exactly the subtotal.
     expect(giftCardRedeem).toHaveBeenCalledWith("gc_1", 8800, "buyer@example.com");
     const order = orderCreate.mock.calls[0][0];

--- a/__tests__/utils/salesTax.test.ts
+++ b/__tests__/utils/salesTax.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { computeSalesTaxCents, NJ_SALES_TAX_RATE } from "@/lib/utils/salesTax";
+
+describe("computeSalesTaxCents", () => {
+  it("charges 6.625% for NJ ship-to addresses", () => {
+    expect(computeSalesTaxCents("NJ", 10000)).toBe(663); // $100.00 -> $6.63 (rounds up from 662.5)
+  });
+
+  it("matches the documented NJ rate constant", () => {
+    expect(NJ_SALES_TAX_RATE).toBe(0.06625);
+  });
+
+  it("charges nothing for out-of-state addresses", () => {
+    expect(computeSalesTaxCents("NY", 10000)).toBe(0);
+    expect(computeSalesTaxCents("CA", 10000)).toBe(0);
+  });
+
+  it("charges nothing when state is missing", () => {
+    expect(computeSalesTaxCents(undefined, 10000)).toBe(0);
+    expect(computeSalesTaxCents(null, 10000)).toBe(0);
+    expect(computeSalesTaxCents("", 10000)).toBe(0);
+  });
+
+  it("matches case-insensitively and trims whitespace", () => {
+    expect(computeSalesTaxCents("nj", 10000)).toBe(663);
+    expect(computeSalesTaxCents(" NJ ", 10000)).toBe(663);
+  });
+
+  it("returns 0 tax on a $0 taxable base", () => {
+    expect(computeSalesTaxCents("NJ", 0)).toBe(0);
+  });
+
+  it("taxes the combined items + shipping base, not just items", () => {
+    // $50.00 items + $6.48 shipping = $56.48 taxable
+    expect(computeSalesTaxCents("NJ", 5648)).toBe(374); // 5648 * 0.06625 = 374.18 -> 374
+  });
+});

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -6,7 +6,9 @@
  * from the Square catalog and shipping from a fresh Shippo re-quote (lib/checkout/
  * storePricing.ts). The body's `subtotalCents` and `selectedRate.rateCents` are
  * ignored for charging; only `selectedRate.carrier`/`service` select which fresh
- * rate to charge. See ecommerce/09-checkout-price-integrity.md.
+ * rate to charge. Sales tax is computed server-side too, from the ship-to state
+ * (lib/utils/salesTax.ts) — see ecommerce/09-checkout-price-integrity.md and
+ * ecommerce/nj-sales-tax-research.md.
  *
  * Request body:
  *   paymentToken   — Square nonce from the card form
@@ -40,6 +42,7 @@ import {
   PriceIntegrityError,
 } from "@/lib/checkout/storePricing";
 import { normalizeIdempotencyKey } from "@/lib/checkout/idempotency";
+import { computeSalesTaxCents } from "@/lib/utils/salesTax";
 import { resolveEmailRecipients, EMAIL_FROM } from "@/lib/email/recipients";
 import type { LabelResult } from "@/lib/shippo/labels";
 import type { CartItem } from "@/lib/types/cartTypes";
@@ -146,9 +149,15 @@ export async function POST(request: Request): Promise<Response> {
 
     const subtotalCents = pricedCart.subtotalCents;
 
-    // Sales tax temporarily disabled (pending the studio's nexus/rate decision — see
-    // ecommerce/ecommerce-sales-tax-guide.md). Order keeps taxCents: 0 for now.
-    const totalCents = subtotalCents + serverRate.rateCents;
+    // NJ sales tax (6.625%, flat statewide) on items + shipping combined — the
+    // only taxed state right now (physical nexus; owner-confirmed 2026-08-02).
+    // Ship-to state, not billing (destination-based sourcing). See
+    // ecommerce/nj-sales-tax-research.md for the full research + sign-off.
+    const taxCents = computeSalesTaxCents(
+      shippingAddress.stateProvince,
+      subtotalCents + serverRate.rateCents
+    );
+    const totalCents = subtotalCents + serverRate.rateCents + taxCents;
 
     console.log("[API-STORE-CHECKOUT-POST] Processing checkout for:", customer.email, "Server total:", totalCents);
 
@@ -307,7 +316,7 @@ export async function POST(request: Request): Promise<Response> {
       items: orderItems,
       subtotalCents,
       shippingCents: serverRate.rateCents,
-      taxCents: 0,
+      taxCents,
       totalCents,
       customer: {
         firstName: customer.firstName,
@@ -412,6 +421,7 @@ export async function POST(request: Request): Promise<Response> {
             })),
             subtotalCents,
             shippingCents: serverRate.rateCents,
+            taxCents,
             totalCents,
             shippingAddress: {
               name: shippingAddress.name,
@@ -434,6 +444,7 @@ export async function POST(request: Request): Promise<Response> {
           items: orderItems,
           subtotalCents,
           shippingCents: serverRate.rateCents,
+          taxCents,
           totalCents,
           shippingAddress: {
             name: shippingAddress.name,

--- a/components/store/CartSummary.tsx
+++ b/components/store/CartSummary.tsx
@@ -9,6 +9,8 @@ interface CartSummaryProps {
   items: CartItem[];
   subtotalCents: number;
   selectedRate: ShippingRate | null;
+  /** Sales tax preview (cents) — 0 for out-of-state orders. */
+  taxCents?: number;
   /** Gift card applied at checkout (cents) — shown as a deduction. */
   giftCardCents?: number;
 }
@@ -17,10 +19,11 @@ export default function CartSummary({
   items,
   subtotalCents,
   selectedRate,
+  taxCents = 0,
   giftCardCents = 0,
 }: CartSummaryProps): ReactElement {
   const totalCents = selectedRate
-    ? Math.max(0, subtotalCents + selectedRate.rateCents - giftCardCents)
+    ? Math.max(0, subtotalCents + selectedRate.rateCents + taxCents - giftCardCents)
     : null;
   const itemCount = items.reduce((sum, i) => sum + i.quantity, 0);
 
@@ -95,6 +98,13 @@ export default function CartSummary({
             </span>
           )}
         </div>
+
+        {taxCents > 0 && (
+          <div className="flex justify-between text-[var(--color-text-primary)]">
+            <span>Sales Tax</span>
+            <span>{formatCents(taxCents)}</span>
+          </div>
+        )}
 
         {giftCardCents > 0 && (
           <div className="flex justify-between">

--- a/components/store/CheckoutForm.tsx
+++ b/components/store/CheckoutForm.tsx
@@ -21,6 +21,7 @@ import type { AppliedGiftCard } from "@/components/checkout/eventCheckoutTypes";
 import CartSummary from "@/components/store/CartSummary";
 import { Button } from "@/components/ui";
 import { formatCents } from "@/lib/utils/moneyHelpers";
+import { computeSalesTaxCents } from "@/lib/utils/salesTax";
 import type { ShippingRate } from "@/lib/shippo/rates";
 
 const EMPTY_CONTACT: ContactValues = {
@@ -95,8 +96,14 @@ export default function CheckoutForm({
   const recipientLastName = isGift ? shipping.lastName : contact.lastName;
   const recipientName = `${recipientFirstName} ${recipientLastName}`.trim();
 
-  // Gift cards apply to the PRODUCT SUBTOTAL ONLY — never to shipping.
-  const orderTotalCents = subtotalCents + (selectedRate?.rateCents ?? 0);
+  // Preview only — the server recomputes tax authoritatively at checkout (same
+  // price-integrity pattern as subtotal/shipping). Needed here so the amount
+  // shown to Square's payment form (and used for SCA verification) matches what
+  // will actually be charged; a mismatch there is a hard failure, not cosmetic.
+  const taxableCents = subtotalCents + (selectedRate?.rateCents ?? 0);
+  const taxCents = computeSalesTaxCents(shipping.state, taxableCents);
+  // Gift cards apply to the PRODUCT SUBTOTAL ONLY — never to shipping or tax.
+  const orderTotalCents = taxableCents + taxCents;
   const giftCardCents = appliedGiftCard
     ? Math.min(appliedGiftCard.amountApplied, subtotalCents)
     : 0;
@@ -525,6 +532,7 @@ export default function CheckoutForm({
           items={items}
           subtotalCents={subtotalCents}
           selectedRate={selectedRate}
+          taxCents={taxCents}
           giftCardCents={giftCardCents}
         />
       </div>

--- a/ecommerce/nj-sales-tax-research.md
+++ b/ecommerce/nj-sales-tax-research.md
@@ -1,0 +1,134 @@
+# NJ E-Commerce Sales Tax — Research Findings & Owner Email
+
+*Research date: July 8, 2026. Companion to [ecommerce-sales-tax-guide.md](./ecommerce-sales-tax-guide.md). This is general information, not tax advice.*
+
+---
+
+## The Three Questions, Answered
+
+### 1. Is it state by state?
+
+**Yes.** Sales tax obligations are determined per state via "nexus":
+
+- **Physical nexus** — the business is physically in New Jersey, so it owes NJ collection from day one.
+- **Economic nexus** — every other state can only require collection after sales *into that state* cross that state's own threshold (commonly $100,000/year; some states also use a 200-transaction count, though the trend is toward dropping it).
+
+A single Texas customer buying a $40 art kit creates **zero** Texas obligation. Obligations in other states only begin if/when volume into that state crosses its threshold — unlikely in year one for a small studio store.
+
+### 2. Do customers only get charged NJ tax?
+
+**Practically, at launch: yes — and only NJ customers get charged anything.**
+
+- **Orders shipped to NJ addresses** → charge NJ sales tax.
+- **Orders shipped out of state** → charge **no tax at all**. NJ is destination-based: NJ tax does not apply to goods delivered outside NJ, and we can't collect another state's tax without being registered there (and shouldn't be registered without nexus). Out-of-state buyers technically owe "use tax" to their own state, but that is the *buyer's* obligation, not the store's.
+
+So the launch policy is simply: **NJ ship-to → 6.625%; everywhere else → 0%.**
+
+### 3. Is it cut and dry?
+
+**The rules are cut and dry. The reason to involve the owner is that the obligations attach to the business, not the website.**
+
+What's mechanical (developer territory):
+
+- Detecting the ship-to state and applying the right rate at checkout.
+
+What only the owner/business can do (and why the decision was escalated):
+
+1. **Registration** — collecting NJ tax requires the business to be registered with NJ (NJ-REG / Certificate of Authority). Turning on collection in code does **not** register anyone. If the studio already collects NJ tax on in-person sales (walk-ins, kits sold at the register), it's almost certainly registered already — but that needs confirming, not assuming.
+2. **Filing & remitting** — collected tax is the state's money held in trust. Someone (owner/bookkeeper/accountant) must file NJ returns on the assigned schedule and include the online sales. Collecting online without remitting is the classic audit penalty scenario.
+3. **Accountant sign-off** — product taxability calls and the filing cadence belong with their tax professional.
+4. **Growth monitoring** — deciding who watches per-state sales totals as the store grows, and whether to eventually pay for a filing service (DAVO/TaxJar/Avalara — overkill below ~5 states).
+
+Shipping tax without registration = penalties. Shipping *no* tax to NJ customers while registered = under-collection the business eats. Either wrong guess costs the owner money, which is why it's their call.
+
+---
+
+## New Jersey Specifics (verified July 2026)
+
+| Fact | Detail |
+|------|--------|
+| **State rate** | **6.625%**, flat statewide — NJ has **no local/city/county sales taxes**. One rate for every NJ address. |
+| **Sourcing** | **Destination-based** — tax is owed based on where the buyer receives the goods. Out-of-state deliveries are not NJ-taxable. |
+| **Art kits / craft products** | Tangible personal property → **taxable**. (NJ's big exemptions — clothing, most groceries — don't apply to art supplies/kits.) |
+| **Shipping charges** | **Taxable when the goods are taxable**, even if separately stated (N.J.A.C. 18:24-27.2). For this store, that means NJ orders are taxed on **items + shipping**. Mixed taxable/exempt shipments require allocation, otherwise the whole delivery charge is taxable — not currently relevant since all products are taxable. |
+| **Gift cards** | Buying a gift card is **not** a taxable sale; tax applies when the card is redeemed for taxable goods. Gift-card-funded store orders still get taxed like any other order. |
+| **NJ's own economic nexus (for inbound remote sellers)** | $100,000 gross revenue **or** 200 transactions into NJ (current or prior calendar year). 30-day grace period to register after crossing. Bills S711/A3419 (introduced Jan 2026) would drop the 200-transaction test, keeping only $100k — pending. Mirrors how other states will treat this store in reverse. |
+| **UEZ half-rate (3.3125%)** | Only for businesses located in an Urban Enterprise Zone, and generally in-person sales. Not applicable here. |
+
+---
+
+## Implementation Notes
+
+**Current state (2026-08-02): LIVE.** Ashley confirmed the plan (registered, accountant aware, 6.625% on NJ-shipped orders incl. shipping). Implemented in `lib/utils/salesTax.ts` (`computeSalesTaxCents`), wired into `app/api/store/checkout/route.ts` as the server-authoritative source, with a same-formula client preview in `CheckoutForm.tsx` (so the Square payment amount matches what's actually charged). Tax line shows in `CartSummary`, both order emails, and the admin order page. Everything below this line is the original pre-launch research/spec — kept for reference.
+
+**Why Square doesn't "just handle it":** Square's automatic tax calculator applies to Square Online sites and Square POS. Our checkout is a **custom Next.js flow using the Square v44 API**, so tax must be applied by our code (either computed directly or via a Catalog tax object attached to the order). Square never registers, files, or remits regardless — that's always the merchant's job.
+
+**The good news — NJ is the easiest possible state to implement:**
+
+Because NJ has one flat statewide rate and no local jurisdictions, v1 needs no tax service, no rate tables, no geocoding:
+
+```
+if (shippingAddress.state === "NJ") {
+  taxCents = round((taxableItemsCents + shippingCents) * 0.06625)
+} else {
+  taxCents = 0
+}
+```
+
+Details for the real implementation:
+
+1. Key off the **ship-to** address (destination sourcing), not billing.
+2. Tax base = merchandise **plus shipping** (NJ taxes delivery charges on taxable goods).
+3. Show the tax line in the checkout summary and order confirmation email, and persist it on the Order (`taxCents` already exists on the model).
+4. Rate should live in a constant/config, not be hardcoded inline, in case NJ changes it (there was 2025–26 legislative chatter about rate changes).
+5. Keep collecting **additive** (tax on top of listed price) — matches how the summary is displayed today.
+6. Reporting: order records already capture ship-to state, so "taxable NJ sales this period" is a simple query for whoever files. Also usable later to watch other states' thresholds.
+
+**Not needed at launch:** TaxJar/Avalara/DAVO, per-state rate tables, tax on out-of-state orders. Revisit only if some state's sales approach ~$100k/year.
+
+---
+
+## Draft Email to Owner
+
+> **Subject: Online store sales tax — what I need from you before I turn it on**
+>
+> Hi [Owner],
+>
+> Quick update on the online store: everything is built and working, but I've intentionally left **sales tax collection turned off** until we make one business decision together. I didn't want to guess on something that creates legal filing obligations for the business, so here's the short version of how it works and what I need from you.
+>
+> **How online sales tax works (it's simpler than it sounds):**
+>
+> - We charge **New Jersey sales tax (6.625%) only on orders shipped to NJ addresses** — including on the shipping charge, which NJ taxes too.
+> - **Out-of-state orders get charged no tax at all.** We'd only ever owe another state once we sell roughly $100,000/year into that state, which isn't a year-one concern. I'll set up reporting so we can see per-state totals and will flag it if any state ever gets close.
+>
+> **Why I paused instead of just turning it on:**
+>
+> Charging tax at checkout is the easy part — I can enable it in an afternoon. But the tax we collect has to be **filed and remitted to New Jersey** by the business, and collecting it without being registered/remitting is what triggers penalties. That side lives with you and your accountant, not the website. So before I flip the switch, I need:
+>
+> 1. **Confirmation the studio is registered to collect NJ sales tax** (if you're already charging tax on in-person sales through Square, you almost certainly are — I just need a yes).
+> 2. **Confirmation that whoever files your NJ sales tax returns** (you/bookkeeper/accountant) knows online sales will be added to the same returns.
+> 3. **A quick OK from your accountant** that the plan — 6.625% on NJ-shipped orders including shipping, nothing on out-of-state — matches how they want it handled.
+>
+> Once I have those, I'll enable tax at checkout, add the tax line to receipts and confirmation emails, and make sure your order reports show taxable NJ sales so filing stays easy.
+>
+> Happy to hop on a call with your accountant if that's faster.
+>
+> Thanks,
+> Ben
+
+---
+
+## Sources
+
+- [NJ Division of Taxation — Sales and Use Tax](https://nj.gov/treasury/taxation/businesses/salestax/index.shtml)
+- [NJ Division of Taxation — Remote Sellers FAQ](https://www.nj.gov/treasury/taxation/remotesellersfaq.shtml)
+- [NJ Division of Taxation — Out-of-State Sales & New Jersey Sales Tax (ANJ-10, PDF)](https://www.nj.gov/treasury/taxation/pdf/pubs/sales/anj10.pdf)
+- [N.J.A.C. 18:24-27.2 — Delivery charges (Cornell LII)](https://www.law.cornell.edu/regulations/new-jersey/N-J-A-C-18-24-27-2)
+- [TaxJar — Is shipping in New Jersey taxable?](https://www.taxjar.com/blog/retail/shipping-new-jersey-taxable)
+- [Avalara — New Jersey Sales & Use Tax Guide](https://www.avalara.com/us/en/taxrates/state-rates/new-jersey/new-jersey-sales-tax-guide.html)
+- [Avalara — NJ could lower sales tax rate, eliminate transaction threshold](https://www.avalara.com/blog/en/north-america/2025/01/new-jersey-to-cut-sales-tax-nexus-transaction-threshold.html)
+- [TaxCloud — New Jersey Sales Tax Rates 2026](https://taxcloud.com/sales-tax/new-jersey/)
+- [Galvix — New Jersey Sales Tax 2026 Guide](https://www.galvix.com/sales-tax/new-jersey/)
+- [Square Support — Create and manage sales tax settings](https://squareup.com/help/us/en/article/5061-create-and-manage-your-tax-settings)
+- [Square Developer — Apply Taxes, Discounts, and Service Charges (Orders API)](https://developer.squareup.com/docs/orders-api/apply-taxes-and-discounts)
+- [TaxConnex — Square & Sales Tax compliance](https://www.taxconnex.com/blog-/square-sales-tax-simplified-what-you-need-to-know)

--- a/lib/utils/salesTax.ts
+++ b/lib/utils/salesTax.ts
@@ -1,0 +1,31 @@
+/**
+ * Sales tax for the online store. Pure — no I/O, safe to import from both server
+ * routes and client components (the client uses it only for a checkout preview;
+ * the server call in app/api/store/checkout/route.ts is the authoritative one).
+ *
+ * NJ is the only state currently taxed — Coastal Creations Studio has physical
+ * nexus there (home state), so NJ collection is owed from day one. Every other
+ * state stays $0 until sales into that state cross its own economic nexus
+ * threshold (commonly $100k/year) — not a year-one concern. Owner-confirmed
+ * 2026-08-02 (Ashley). Full research + rationale: ecommerce/nj-sales-tax-research.md.
+ */
+
+// Flat statewide rate — NJ has no local/city/county sales taxes, so no rate
+// table or geocoding is needed, unlike most states.
+export const NJ_SALES_TAX_RATE = 0.06625;
+
+const TAXED_STATE = "NJ";
+
+/**
+ * Computes sales tax owed, in cents, for an order shipping to `state` (a 2-letter
+ * USPS code). `taxableCents` should be items + shipping combined — NJ taxes
+ * delivery charges on taxable goods (N.J.A.C. 18:24-27.2), and every product this
+ * store sells (art kits, craft supplies) is taxable tangible personal property.
+ */
+export function computeSalesTaxCents(
+  state: string | undefined | null,
+  taxableCents: number
+): number {
+  if ((state ?? "").trim().toUpperCase() !== TAXED_STATE) return 0;
+  return Math.round(taxableCents * NJ_SALES_TAX_RATE);
+}


### PR DESCRIPTION
## Summary
Ben confirmed Ashley wants sales tax collection turned on — she's registered, her accountant knows online sales are coming, and signed off on the plan already researched back in July (`ecommerce/nj-sales-tax-research.md`): **6.625% flat on orders shipping to NJ, applied to items + shipping combined**, $0 everywhere else. This PR turns it on; no new research needed, it was already fully spec'd.

- `lib/utils/salesTax.ts` — new pure `computeSalesTaxCents(state, taxableCents)` helper.
- `app/api/store/checkout/route.ts` — server-authoritative tax calc, replacing the hardcoded `taxCents: 0`. Persisted on the Order and passed to both order emails (their templates already had an optional `taxCents` prop sitting unused).
- `components/store/CheckoutForm.tsx` — same-formula client-side **preview** only (server always recomputes) — needed so the amount shown to Square's payment form for SCA verification matches the real charge; the price-integrity doctrine already used for subtotal/shipping.
- `components/store/CartSummary.tsx` — visible "Sales Tax" line, shown only when > 0.
- Fixed `__tests__/checkout/storeCheckoutRoute.test.ts`'s hardcoded NJ-address total assertions, which were still asserting the old $0-tax numbers.
- The admin order page and both email templates already had tax display built in from months ago — nothing needed there.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 373 total, 357 pass; the only failures are the pre-existing, unrelated `storeCheckoutRoute.test.ts` 503/env-mock issue (confirmed via `git stash` in an earlier PR — same 16 failures exist with none of this branch's changes applied)
- [x] New `__tests__/utils/salesTax.test.ts` — 7/7 pass, hand-verified rounding
- [x] **Verified live in local dev**: added a $50 item, entered a NJ address → "Sales Tax $3.31" appears (50000 × 0.06625 → rounds to 331); switched to NY → tax line disappears entirely
- [ ] Manual on preview/prod: one real NJ order end-to-end, confirm the tax line appears on both emails and the admin order page, and the charged amount matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)