### PR TITLE
fix(store): critical/high security & payment-integrity fixes

### DIFF
--- a/__tests__/checkout/idempotency.test.ts
+++ b/__tests__/checkout/idempotency.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeIdempotencyKey } from "@/lib/checkout/idempotency";
+import { normalizeIdempotencyKey, refundIdempotencyKey } from "@/lib/checkout/idempotency";
 
 const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -39,5 +39,35 @@ describe("normalizeIdempotencyKey", () => {
 
   it("generates a distinct fallback key per call when none is provided", () => {
     expect(normalizeIdempotencyKey()).not.toBe(normalizeIdempotencyKey());
+  });
+});
+
+describe("refundIdempotencyKey", () => {
+  const parts = { paymentId: "pay_1", amountCents: 3000, alreadyRefundedCents: 0 };
+
+  it("is deterministic — identical inputs (e.g. a double-click) hash to the same key", () => {
+    expect(refundIdempotencyKey(parts)).toBe(refundIdempotencyKey({ ...parts }));
+  });
+
+  it("changes when the amount differs", () => {
+    expect(refundIdempotencyKey(parts)).not.toBe(
+      refundIdempotencyKey({ ...parts, amountCents: 3001 })
+    );
+  });
+
+  it("changes once alreadyRefundedCents has moved (a genuine follow-up refund)", () => {
+    expect(refundIdempotencyKey(parts)).not.toBe(
+      refundIdempotencyKey({ ...parts, alreadyRefundedCents: 3000 })
+    );
+  });
+
+  it("changes for a different payment", () => {
+    expect(refundIdempotencyKey(parts)).not.toBe(
+      refundIdempotencyKey({ ...parts, paymentId: "pay_2" })
+    );
+  });
+
+  it("stays within Square's 45-character idempotency key limit", () => {
+    expect(refundIdempotencyKey(parts).length).toBeLessThanOrEqual(45);
   });
 });

--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PriceIntegrityError } from "@/lib/checkout/errors";
 
 // --- Mock every dependency the store checkout route orchestrates ---
@@ -138,6 +138,9 @@ function baseBody(overrides: Record<string, unknown> = {}): Record<string, unkno
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Launch gate: the route 503s unless the shop is enabled (lib/constants/
+  // featureFlags.ts). Every test here exercises the route past that gate.
+  vi.stubEnv("NEXT_PUBLIC_SHOP_ENABLED", "true");
   priceCartFromCatalog.mockResolvedValue({
     items: [
       { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
@@ -158,6 +161,10 @@ beforeEach(() => {
   resolveUserSquareCustomerId.mockResolvedValue("acct_cust_1");
   cardGetCard.mockResolvedValue({ id: "ccof:1", customerId: "acct_cust_1" });
   cardCreateCard.mockResolvedValue({ id: "ccof:new" });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 const SIGNED_IN = { id: "user_1", email: "u@example.com", isAdmin: false, role: "customer" };
@@ -259,6 +266,24 @@ describe("POST /api/store/checkout", () => {
 
   it("returns 400 on missing required fields and never charges", async () => {
     const res = await POST(req({ customer: BUYER, items: [] }));
+    expect(res.status).toBe(400);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and never charges when a required nested field is blank (e.g. shippingAddress.city)", async () => {
+    const res = await POST(
+      req(baseBody({ shippingAddress: { ...SELF_ADDRESS, city: "" } }))
+    );
+    expect(res.status).toBe(400);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and never charges when a required customer field is missing", async () => {
+    const res = await POST(
+      req(baseBody({ customer: { ...BUYER, lastName: undefined } }))
+    );
     expect(res.status).toBe(400);
     expect(paymentsCreate).not.toHaveBeenCalled();
     expect(orderCreate).not.toHaveBeenCalled();

--- a/__tests__/checkout/storePricing.test.ts
+++ b/__tests__/checkout/storePricing.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // --- Mocks for the authoritative sources storePricing reads from ---
 const listCatalogItems = vi.fn();
+const getInventoryCounts = vi.fn();
 vi.mock("@/lib/square/catalog", () => ({
   listCatalogItems: (...args: unknown[]) => listCatalogItems(...args),
+  getInventoryCounts: (...args: unknown[]) => getInventoryCounts(...args),
 }));
 
 const getShippingRates = vi.fn();
@@ -108,6 +110,71 @@ describe("priceCartFromCatalog", () => {
     await expect(priceCartFromCatalog([])).rejects.toBeInstanceOf(
       PriceIntegrityError
     );
+  });
+
+  it("does not check inventory for a variation with tracking disabled", async () => {
+    listCatalogItems.mockResolvedValue([
+      {
+        id: "ITEM1",
+        name: "Art Kit",
+        variations: [
+          { id: "VAR1", name: "Default", priceCents: 5000, variablePricing: false, trackInventory: false },
+        ],
+      },
+    ]);
+    await priceCartFromCatalog([cartItem({ quantity: 5 })]);
+    expect(getInventoryCounts).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the requested quantity exceeds IN_STOCK count for a tracked variation", async () => {
+    listCatalogItems.mockResolvedValue([
+      {
+        id: "ITEM1",
+        name: "Art Kit",
+        variations: [
+          { id: "VAR1", name: "Default", priceCents: 5000, variablePricing: false, trackInventory: true },
+        ],
+      },
+    ]);
+    getInventoryCounts.mockResolvedValue(new Map([["VAR1", 1]]));
+
+    await expect(
+      priceCartFromCatalog([cartItem({ quantity: 2 })])
+    ).rejects.toBeInstanceOf(PriceIntegrityError);
+  });
+
+  it("allows checkout when a tracked variation has enough stock", async () => {
+    listCatalogItems.mockResolvedValue([
+      {
+        id: "ITEM1",
+        name: "Art Kit",
+        variations: [
+          { id: "VAR1", name: "Default", priceCents: 5000, variablePricing: false, trackInventory: true },
+        ],
+      },
+    ]);
+    getInventoryCounts.mockResolvedValue(new Map([["VAR1", 2]]));
+
+    const result = await priceCartFromCatalog([cartItem({ quantity: 2 })]);
+    expect(result.subtotalCents).toBe(10000);
+  });
+
+  it("combines quantities for the same variation across split cart lines before checking stock", async () => {
+    listCatalogItems.mockResolvedValue([
+      {
+        id: "ITEM1",
+        name: "Art Kit",
+        variations: [
+          { id: "VAR1", name: "Default", priceCents: 5000, variablePricing: false, trackInventory: true },
+        ],
+      },
+    ]);
+    getInventoryCounts.mockResolvedValue(new Map([["VAR1", 3]]));
+
+    // Two lines of 2 each = 4 requested, but only 3 in stock.
+    await expect(
+      priceCartFromCatalog([cartItem({ quantity: 2 }), cartItem({ quantity: 2 })])
+    ).rejects.toBeInstanceOf(PriceIntegrityError);
   });
 });
 

--- a/__tests__/giftcards/giftCards.test.ts
+++ b/__tests__/giftcards/giftCards.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+const requireAdmin = vi.fn();
+vi.mock("@/lib/auth/guards", () => ({
+  requireAdmin: (...a: unknown[]) => requireAdmin(...a),
+}));
 
 const getBalance = vi.fn();
 const getById = vi.fn();
@@ -13,6 +19,9 @@ vi.mock("@/lib/square/gift-cards", () => ({
 
 import { GET as balanceGET } from "@/app/api/gift-cards/balance/route";
 import { POST as redeemPOST } from "@/app/api/gift-cards/redeem/route";
+
+const ADMIN = { id: "admin_1", email: "admin@example.com", isAdmin: true, role: "admin" };
+const UNAUTH = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
 function balanceReq(gan?: string): Request {
   const url = gan
@@ -29,7 +38,10 @@ function redeemReq(body: Record<string, unknown>): Request {
   });
 }
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireAdmin.mockResolvedValue(ADMIN);
+});
 
 describe("GET /api/gift-cards/balance", () => {
   it("400s when no GAN is provided", async () => {
@@ -62,6 +74,14 @@ describe("GET /api/gift-cards/balance", () => {
 });
 
 describe("POST /api/gift-cards/redeem", () => {
+  it("401s when the caller is not an authenticated admin", async () => {
+    requireAdmin.mockResolvedValue(UNAUTH);
+    const res = await redeemPOST(redeemReq({ giftCardId: "gc_1", amountCents: 100 }));
+    expect(res.status).toBe(401);
+    expect(getById).not.toHaveBeenCalled();
+    expect(redeem).not.toHaveBeenCalled();
+  });
+
   it("400s without a gift card id", async () => {
     const res = await redeemPOST(redeemReq({ amountCents: 100 }));
     expect(res.status).toBe(400);

--- a/__tests__/refunds/refundsRoute.test.ts
+++ b/__tests__/refunds/refundsRoute.test.ts
@@ -138,4 +138,30 @@ describe("POST /api/refunds — refund processing", () => {
     expect(doc.refundStatus).toBe("partial");
     expect(doc.refundAmount).toBe(30);
   });
+
+  it("400s and never calls Square when refundAmount exceeds the remaining balance", async () => {
+    mockCustomer(customerDoc({ total: 100, refundAmount: 80 })); // only $20 left
+    const res = await POST(req({ customerId: "c1", refundAmount: 50 }) as never);
+    expect(res.status).toBe(400);
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("400s on a zero or negative refundAmount", async () => {
+    mockCustomer(customerDoc());
+    const res = await POST(req({ customerId: "c1", refundAmount: 0 }) as never);
+    expect(res.status).toBe(400);
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("uses the same idempotency key for two identical requests (double-click safe)", async () => {
+    mockCustomer(customerDoc());
+    await POST(req({ customerId: "c1" }) as never);
+    const firstKey = refundPayment.mock.calls[0][0].idempotencyKey;
+
+    mockCustomer(customerDoc()); // fresh unmodified doc — same starting state
+    await POST(req({ customerId: "c1" }) as never);
+    const secondKey = refundPayment.mock.calls[1][0].idempotencyKey;
+
+    expect(firstKey).toBe(secondKey);
+  });
 });

--- a/app/api/admin/store/orders/[id]/refund/route.ts
+++ b/app/api/admin/store/orders/[id]/refund/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { randomUUID } from "crypto";
 import { SquareError } from "square";
 import { requireAdmin } from "@/lib/auth/guards";
 import { connectMongo } from "@/lib/mongoose";
 import Order, { type IOrderItem } from "@/lib/models/Order";
 import { getSquareClient } from "@/lib/square/client";
 import { formatCents } from "@/lib/utils/moneyHelpers";
+import { refundIdempotencyKey } from "@/lib/checkout/idempotency";
 import { sendRefundConfirmation } from "@/lib/email/sendRefundConfirmation";
 
 const client = getSquareClient();
@@ -131,7 +131,11 @@ export async function POST(
 
     // --- Square refund ---
     const refundResult = await client.refunds.refundPayment({
-      idempotencyKey: randomUUID(),
+      idempotencyKey: refundIdempotencyKey({
+        paymentId: order.square.paymentId,
+        amountCents: refundCents,
+        alreadyRefundedCents: alreadyRefunded,
+      }),
       paymentId: order.square.paymentId,
       amountMoney: {
         amount: BigInt(refundCents),

--- a/app/api/gift-cards/redeem/route.ts
+++ b/app/api/gift-cards/redeem/route.ts
@@ -1,8 +1,16 @@
 /**
  * Gift Card Redeem API Route
  * POST: Redeem a gift card amount
+ *
+ * Admin-only. Every checkout path that legitimately redeems a gift card
+ * (app/api/store/checkout, app/api/checkout/booking) calls
+ * giftCardService.redeem() directly, server-side — this HTTP route is not on
+ * any live customer flow. It stayed reachable with no auth check, and since
+ * gift-card balance/lookup is public (GET /api/gift-cards/balance), that made
+ * it a bare "drain any card to $0" primitive for anyone who knows a GAN.
  */
 import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth/guards";
 import { giftCardService } from "@/lib/square/gift-cards";
 
 interface RedeemRequest {
@@ -12,6 +20,9 @@ interface RedeemRequest {
 }
 
 export async function POST(request: Request): Promise<Response> {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
   try {
     const body: RedeemRequest = await request.json();
 

--- a/app/api/refunds/route.ts
+++ b/app/api/refunds/route.ts
@@ -7,9 +7,9 @@ import "@/lib/models/PrivateEvent";
 import "@/lib/models/Reservations";
 import { getSquareClient } from "@/lib/square/client";
 import { SquareError } from "square";
-import { randomUUID } from "crypto";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/auth";
+import { refundIdempotencyKey } from "@/lib/checkout/idempotency";
 import { sendRefundConfirmation } from "@/lib/email/sendRefundConfirmation";
 
 const client = getSquareClient();
@@ -64,22 +64,48 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    const refundAmountCents = refundAmount
-      ? BigInt(Math.round(refundAmount * 100))
-      : BigInt(Math.round((customer.total - (customer.refundAmount || 0)) * 100));
+    // Bound the refund to what's actually left to refund on this booking —
+    // a client-supplied `refundAmount` is never trusted past the remaining
+    // balance, whether that's from a stale UI, a replayed request, or drift
+    // between the local `customer.total` and Square's real payment.
+    const alreadyRefundedCents = Math.round((customer.refundAmount || 0) * 100);
+    const totalCents = Math.round(customer.total * 100);
+    const remainingCents = totalCents - alreadyRefundedCents;
+
+    const requestedCents =
+      refundAmount != null ? Math.round(refundAmount * 100) : remainingCents;
+
+    if (!Number.isFinite(requestedCents) || requestedCents <= 0) {
+      return NextResponse.json(
+        { error: "Refund amount must be greater than zero" },
+        { status: 400 }
+      );
+    }
+    if (requestedCents > remainingCents) {
+      return NextResponse.json(
+        {
+          error: `Refund exceeds the remaining refundable balance ($${(remainingCents / 100).toFixed(2)})`,
+        },
+        { status: 400 }
+      );
+    }
 
     const refundResult = await client.refunds.refundPayment({
-      idempotencyKey: randomUUID(),
+      idempotencyKey: refundIdempotencyKey({
+        paymentId: customer.squarePaymentId,
+        amountCents: requestedCents,
+        alreadyRefundedCents,
+      }),
       paymentId: customer.squarePaymentId,
       amountMoney: {
-        amount: refundAmountCents,
+        amount: BigInt(requestedCents),
         currency: "USD",
       },
       reason: reason || "Customer requested refund",
     });
 
     if (refundResult.refund) {
-      const refundAmountDollars = refundAmount || customer.total - (customer.refundAmount || 0);
+      const refundAmountDollars = requestedCents / 100;
       const totalRefundedAmount = (customer.refundAmount || 0) + refundAmountDollars;
 
       const isFullRefund = totalRefundedAmount >= customer.total;

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -118,6 +118,32 @@ export async function POST(request: Request): Promise<Response> {
       return NextResponse.json({ error: "Missing required checkout fields" }, { status: 400 });
     }
 
+    // Deep-validate every field the Order schema actually requires, BEFORE
+    // charging Square. A shallow truthiness check on the top-level objects
+    // above is not enough — a blank nested field (e.g. shippingAddress.city)
+    // passes that check, then trips Mongoose's required-field validation on
+    // Order.create() AFTER the card has already been charged, leaving a paid
+    // customer with no order record. Fail closed here instead.
+    const requiredStringFields: Array<[string, unknown]> = [
+      ["customer.firstName", customer.firstName],
+      ["customer.lastName", customer.lastName],
+      ["customer.email", customer.email],
+      ["shippingAddress.name", shippingAddress.name],
+      ["shippingAddress.addressLine1", shippingAddress.addressLine1],
+      ["shippingAddress.city", shippingAddress.city],
+      ["shippingAddress.stateProvince", shippingAddress.stateProvince],
+      ["shippingAddress.postalCode", shippingAddress.postalCode],
+      ["shippingAddress.country", shippingAddress.country],
+    ];
+    for (const [label, value] of requiredStringFields) {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        return NextResponse.json(
+          { error: `Missing required checkout field: ${label}` },
+          { status: 400 }
+        );
+      }
+    }
+
     // Mongo is needed to read parcel presets for the shipping re-quote.
     await connectMongo();
 

--- a/lib/checkout/idempotency.ts
+++ b/lib/checkout/idempotency.ts
@@ -8,7 +8,7 @@
  * a payment can always proceed (Square's max idempotency key length is 45 chars;
  * a UUID v4 is 36).
  */
-import { randomUUID } from "crypto";
+import { randomUUID, createHash } from "crypto";
 
 export function normalizeIdempotencyKey(input?: string): string {
   if (typeof input === "string") {
@@ -18,4 +18,22 @@ export function normalizeIdempotencyKey(input?: string): string {
     }
   }
   return randomUUID();
+}
+
+/**
+ * Deterministic idempotency key for a Square refund, derived from stable
+ * inputs instead of a fresh randomUUID() per call. A double-click or a
+ * lost-response retry of the SAME refund (same payment, same amount, same
+ * already-refunded balance) hashes to the SAME key, so Square dedupes it
+ * into a single refund instead of two — closing the double-refund race that
+ * a per-call random key leaves open. A genuinely new follow-up refund gets a
+ * different key once `alreadyRefundedCents` has moved.
+ */
+export function refundIdempotencyKey(parts: {
+  paymentId: string;
+  amountCents: number;
+  alreadyRefundedCents: number;
+}): string {
+  const raw = `refund:${parts.paymentId}:${parts.amountCents}:${parts.alreadyRefundedCents}`;
+  return createHash("sha256").update(raw).digest("hex").slice(0, 40);
 }

--- a/lib/checkout/storePricing.ts
+++ b/lib/checkout/storePricing.ts
@@ -10,7 +10,7 @@
  * service) a PriceIntegrityError is thrown so the caller rejects the order
  * BEFORE charging. See ecommerce/09-checkout-price-integrity.md.
  */
-import { listCatalogItems } from "@/lib/square/catalog";
+import { listCatalogItems, getInventoryCounts } from "@/lib/square/catalog";
 import StoreProductSettings, {
   DEFAULT_PARCEL_PRESET,
 } from "@/lib/models/StoreProductSettings";
@@ -67,10 +67,16 @@ export async function priceCartFromCatalog(
   const itemIds = Array.from(new Set(items.map((i) => i.squareCatalogItemId)));
   const catalogItems = await listCatalogItems(itemIds);
 
-  // Map every variation id -> { name, variationName, priceCents } from the catalog.
+  // Map every variation id -> { name, variationName, priceCents, trackInventory }
+  // from the catalog.
   const variationById = new Map<
     string,
-    { name: string; variationName: string; priceCents: number | null }
+    {
+      name: string;
+      variationName: string;
+      priceCents: number | null;
+      trackInventory: boolean;
+    }
   >();
   for (const item of catalogItems) {
     for (const v of item.variations) {
@@ -78,6 +84,7 @@ export async function priceCartFromCatalog(
         name: item.name,
         variationName: v.name,
         priceCents: v.priceCents,
+        trackInventory: v.trackInventory,
       });
     }
   }
@@ -105,6 +112,38 @@ export async function priceCartFromCatalog(
       unitPriceCents: match.priceCents,
     };
   });
+
+  // Stock check: reject any line whose requested quantity exceeds Square's
+  // IN_STOCK count, for variations with inventory tracking enabled. Combine
+  // quantities per variation first so a cart split across multiple lines for
+  // the same variation can't slip past the check line-by-line. This closes
+  // the "sold-out item charges forever" gap but is a point-in-time read, not
+  // a hold — two checkouts racing for the last unit can still both pass.
+  const requestedByVariation = new Map<string, number>();
+  for (const item of pricedItems) {
+    requestedByVariation.set(
+      item.squareVariationId,
+      (requestedByVariation.get(item.squareVariationId) ?? 0) + item.quantity
+    );
+  }
+  const trackedVariationIds = Array.from(requestedByVariation.keys()).filter(
+    (id) => variationById.get(id)?.trackInventory
+  );
+  if (trackedVariationIds.length > 0) {
+    const counts = await getInventoryCounts(trackedVariationIds);
+    for (const variationId of trackedVariationIds) {
+      const requested = requestedByVariation.get(variationId) ?? 0;
+      const available = counts.get(variationId) ?? 0;
+      if (requested > available) {
+        const match = variationById.get(variationId);
+        throw new PriceIntegrityError(
+          `Not enough stock for ${match?.name ?? "this item"}${
+            match?.variationName ? ` (${match.variationName})` : ""
+          } — only ${available} left.`
+        );
+      }
+    }
+  }
 
   const subtotalCents = pricedItems.reduce(
     (sum, i) => sum + i.unitPriceCents * i.quantity,


### PR DESCRIPTION
## Summary

Four fixes found in a thorough security/bug audit of the store (checkout, gift cards, refunds), scoped to the critical + high severity findings. Reservation-specific findings (overbooking race, legacy PaymentForm.tsx flow) were intentionally excluded — that feature is currently unused.

- **Gift-card redeem endpoint had no auth check.** `POST /api/gift-cards/redeem` was fully public and, combined with the public balance-lookup endpoint, let anyone drain any gift card to $0 with no purchase or session. Locked to admin-only — no live checkout flow used this HTTP route (they all redeem server-side, in-process).
- **Double-refund race.** Both refund endpoints minted a fresh random idempotency key per call instead of a deterministic one, so a double-click or retry could produce two real Square refunds. Now derived deterministically from `(paymentId, amount, alreadyRefunded)` so Square dedupes retries. Also added the missing server-side bound on `app/api/refunds/route.ts`'s refund amount (the store-order refund route already had this).
- **Store checkout never checked stock.** A sold-out item would charge and create a paid order indefinitely. Added a server-side stock check against Square's IN_STOCK counts before charging (point-in-time, not a hold — noted as a known residual gap for the tightest last-unit race).
- **Store checkout only shallow-validated before charging.** A blank nested field (e.g. `shippingAddress.city`) could pass the top-level check, charge the card via Square, then fail Mongoose's required-field validation — leaving a charged customer with no order record. Added deep validation before any Square call.
- **Bonus:** `storeCheckoutRoute.test.ts` was 18/18 failing against `develop` before this PR (unrelated pre-existing gap — the route's launch-gate `isShopEnabled()` was never stubbed in tests). Fixed so the file actually provides coverage.

## What changed

- `app/api/gift-cards/redeem/route.ts` — `requireAdmin()` guard
- `lib/checkout/idempotency.ts` — new `refundIdempotencyKey()` helper
- `app/api/admin/store/orders/[id]/refund/route.ts`, `app/api/refunds/route.ts` — deterministic refund idempotency key; `app/api/refunds/route.ts` also gets the amount bound
- `lib/checkout/storePricing.ts` — stock check in `priceCartFromCatalog()`
- `app/api/store/checkout/route.ts` — deep field validation before charging
- Test files updated/extended to match, plus the `storeCheckoutRoute.test.ts` env-stub fix

## Test plan

- [x] `pnpm test:run` — 388/388 passing (was 373/388 passing on `develop`, with the checkout route file at 0/18)
- [x] `pnpm run build` — clean, no type errors
- [x] `pnpm run lint` — 0 errors (46 pre-existing warnings, none in touched files)
- [ ] Manual smoke test of store checkout + gift-card redemption in a live/sandbox environment (not done in this session — no browser/Square-sandbox access here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g99zhpE1TVT8b7qEFn165