### PR TITLE
fix(store): link checkout to real Square Orders for inventory decrement

### DIFF
--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -11,8 +11,18 @@ vi.mock("@/lib/checkout/storePricing", () => ({
 }));
 
 const paymentsCreate = vi.fn();
+const ordersCreate = vi.fn();
+const ordersUpdate = vi.fn();
+const ordersPay = vi.fn();
 vi.mock("@/lib/square/client", () => ({
-  getSquareClient: () => ({ payments: { create: (...a: unknown[]) => paymentsCreate(...a) } }),
+  getSquareClient: () => ({
+    payments: { create: (...a: unknown[]) => paymentsCreate(...a) },
+    orders: {
+      create: (...a: unknown[]) => ordersCreate(...a),
+      update: (...a: unknown[]) => ordersUpdate(...a),
+      pay: (...a: unknown[]) => ordersPay(...a),
+    },
+  }),
 }));
 
 const findOrCreateCustomer = vi.fn();
@@ -141,6 +151,7 @@ beforeEach(() => {
   // Launch gate: the route 503s unless the shop is enabled (lib/constants/
   // featureFlags.ts). Every test here exercises the route past that gate.
   vi.stubEnv("NEXT_PUBLIC_SHOP_ENABLED", "true");
+  vi.stubEnv("SQUARE_LOCATION_ID", "loc_test_1");
   priceCartFromCatalog.mockResolvedValue({
     items: [
       { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
@@ -148,6 +159,9 @@ beforeEach(() => {
     subtotalCents: 8800,
   });
   resolveShippingRate.mockResolvedValue(RATE);
+  ordersCreate.mockResolvedValue({ order: { id: "sqorder_1", version: 1 } });
+  ordersUpdate.mockResolvedValue({ order: { id: "sqorder_1", version: 2, state: "CANCELED" } });
+  ordersPay.mockResolvedValue({ order: { id: "sqorder_1", state: "COMPLETED" } });
   paymentsCreate.mockResolvedValue({
     payment: { id: "pay_1", status: "COMPLETED", receiptUrl: "https://squareup.com/receipt/pay_1" },
   });
@@ -183,6 +197,30 @@ describe("POST /api/store/checkout", () => {
     expect(paymentsCreate).toHaveBeenCalledTimes(1);
     expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(9991));
 
+    // A real Square Order is created BEFORE the charge, with catalog-linked line
+    // items — this is the inventory-decrement fix. One line per cart item, plus a
+    // plain shipping+tax line, no gift-card discount on this order.
+    expect(ordersCreate).toHaveBeenCalledTimes(1);
+    const orderRequest = ordersCreate.mock.calls[0][0];
+    expect(orderRequest.order.locationId).toBe("loc_test_1");
+    expect(orderRequest.order.lineItems).toEqual([
+      {
+        catalogObjectId: "var_1",
+        quantity: "1",
+        basePriceMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+      {
+        name: "Shipping & Tax",
+        quantity: "1",
+        basePriceMoney: { amount: BigInt(1191), currency: "USD" },
+      },
+    ]);
+    expect(orderRequest.order.discounts).toBeUndefined();
+
+    // The payment is linked to that order.
+    expect(paymentsCreate.mock.calls[0][0].orderId).toBe("sqorder_1");
+    expect(paymentsCreate.mock.calls[0][0].locationId).toBe("loc_test_1");
+
     expect(orderCreate).toHaveBeenCalledTimes(1);
     const order = orderCreate.mock.calls[0][0];
     expect(order.totalCents).toBe(9991);
@@ -192,9 +230,63 @@ describe("POST /api/store/checkout", () => {
     expect(order.status).toBe("paid");
     expect(purchaseLabelForOrder).toHaveBeenCalledWith("order_1");
 
-    // Square receipt captured on the order + returned for the confirmation page.
+    // Square receipt + order id captured on the order + receipt returned for the
+    // confirmation page.
     expect(order.square.receiptUrl).toBe("https://squareup.com/receipt/pay_1");
+    expect(order.square.orderId).toBe("sqorder_1");
     expect(data.receiptUrl).toBe("https://squareup.com/receipt/pay_1");
+  });
+
+  it("reuses the same idempotency key for the Square order and the payment", async () => {
+    await POST(req(baseBody({ idempotencyKey: "idem-shared" })));
+    expect(ordersCreate.mock.calls[0][0].idempotencyKey).toBe("idem-shared");
+    expect(paymentsCreate.mock.calls[0][0].idempotencyKey).toBe("idem-shared");
+  });
+
+  it("maps a multi-item cart to one Square order line item per line", async () => {
+    priceCartFromCatalog.mockResolvedValue({
+      items: [
+        { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 2, unitPriceCents: 8800 },
+        { squareCatalogItemId: "item_2", squareVariationId: "var_2", name: "Mushroom Kit", variationName: "Regular", quantity: 1, unitPriceCents: 1500 },
+      ],
+      subtotalCents: 19100,
+    });
+    const res = await POST(req(baseBody()));
+    expect(res.status).toBe(200);
+
+    const lineItems = ordersCreate.mock.calls[0][0].order.lineItems;
+    expect(lineItems[0]).toEqual({
+      catalogObjectId: "var_1",
+      quantity: "2",
+      basePriceMoney: { amount: BigInt(8800), currency: "USD" },
+    });
+    expect(lineItems[1]).toEqual({
+      catalogObjectId: "var_2",
+      quantity: "1",
+      basePriceMoney: { amount: BigInt(1500), currency: "USD" },
+    });
+  });
+
+  it("fails closed (no charge, no order saved) when Square order creation fails", async () => {
+    ordersCreate.mockRejectedValue(new Error("Square Orders API down"));
+    const res = await POST(req(baseBody()));
+
+    expect(res.status).toBe(500);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("best-effort cancels the Square order when the payment is not COMPLETED (non-fatal on cancel failure)", async () => {
+    paymentsCreate.mockResolvedValue({ payment: { id: "pay_x", status: "FAILED" } });
+    ordersUpdate.mockRejectedValue(new Error("cancel also failed"));
+
+    const res = await POST(req(baseBody()));
+
+    expect(res.status).toBe(400);
+    expect(orderCreate).not.toHaveBeenCalled();
+    expect(ordersUpdate).toHaveBeenCalledTimes(1);
+    expect(ordersUpdate.mock.calls[0][0].orderId).toBe("sqorder_1");
+    expect(ordersUpdate.mock.calls[0][0].order.state).toBe("CANCELED");
   });
 
   it("ships to the RECIPIENT on a gift order while charging the BUYER (A1)", async () => {
@@ -233,6 +325,80 @@ describe("POST /api/store/checkout", () => {
     expect(giftCardRedeem).toHaveBeenCalledWith("gc_1", 8800, "buyer@example.com");
     const order = orderCreate.mock.calls[0][0];
     expect(order.giftCard).toEqual({ giftCardId: "gc_1", amountCents: 8800 });
+
+    // The Square order carries an ORDER-scoped FIXED_AMOUNT discount for the
+    // applied gift card, so numbers (never Square's own tax/discount engine)
+    // stay the single source of truth for what's charged.
+    const orderRequest = ordersCreate.mock.calls[0][0];
+    expect(orderRequest.order.discounts).toEqual([
+      {
+        name: "Gift Card Applied",
+        type: "FIXED_AMOUNT",
+        scope: "ORDER",
+        amountMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+    ]);
+  });
+
+  it("completes the Square order with no linked payment when a gift card covers the entire total ($0 charge)", async () => {
+    // Free shipping + $0 tax + a gift card covering the full subtotal exactly.
+    resolveShippingRate.mockResolvedValue({ ...RATE, rateCents: 0 });
+    priceCartFromCatalog.mockResolvedValue({
+      items: [
+        { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
+      ],
+      subtotalCents: 8800,
+    });
+    giftCardGetById.mockResolvedValue({ state: "ACTIVE", balanceMoney: { amount: 8800 } });
+    giftCardRedeem.mockResolvedValue({});
+
+    const res = await POST(
+      req({
+        ...baseBody({ giftCard: { giftCardId: "gc_1", amountCents: 8800 } }),
+        shippingAddress: { ...SELF_ADDRESS, stateProvince: "NY" }, // no NJ tax
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(ordersPay).toHaveBeenCalledTimes(1);
+    expect(ordersPay.mock.calls[0][0]).toEqual({
+      orderId: "sqorder_1",
+      idempotencyKey: "idem-1",
+      paymentIds: [],
+    });
+
+    const order = orderCreate.mock.calls[0][0];
+    expect(order.status).toBe("paid");
+    expect(order.square.orderId).toBe("sqorder_1");
+    expect(order.square.paymentId).toBeUndefined();
+  });
+
+  it("cancels the Square order and never saves it when gift card redemption fails on a $0-charge order", async () => {
+    resolveShippingRate.mockResolvedValue({ ...RATE, rateCents: 0 });
+    priceCartFromCatalog.mockResolvedValue({
+      items: [
+        { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
+      ],
+      subtotalCents: 8800,
+    });
+    giftCardGetById.mockResolvedValue({ state: "ACTIVE", balanceMoney: { amount: 8800 } });
+    giftCardRedeem.mockRejectedValue(new Error("redemption failed"));
+
+    const res = await POST(
+      req({
+        ...baseBody({ giftCard: { giftCardId: "gc_1", amountCents: 8800 } }),
+        shippingAddress: { ...SELF_ADDRESS, stateProvince: "NY" },
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(ordersPay).not.toHaveBeenCalled();
+    expect(ordersUpdate).toHaveBeenCalledTimes(1);
+    expect(ordersUpdate.mock.calls[0][0].order.state).toBe("CANCELED");
+    expect(orderCreate).not.toHaveBeenCalled();
   });
 
   it("rejects (400) and never charges when the cart fails price integrity", async () => {
@@ -242,6 +408,7 @@ describe("POST /api/store/checkout", () => {
 
     expect(res.status).toBe(400);
     expect(data.error).toBe("Item unavailable");
+    expect(ordersCreate).not.toHaveBeenCalled();
     expect(paymentsCreate).not.toHaveBeenCalled();
     expect(orderCreate).not.toHaveBeenCalled();
   });
@@ -250,6 +417,7 @@ describe("POST /api/store/checkout", () => {
     resolveShippingRate.mockRejectedValue(new PriceIntegrityError("Shipping rate unavailable"));
     const res = await POST(req(baseBody()));
     expect(res.status).toBe(400);
+    expect(ordersCreate).not.toHaveBeenCalled();
     expect(paymentsCreate).not.toHaveBeenCalled();
     expect(orderCreate).not.toHaveBeenCalled();
   });

--- a/__tests__/square/storeOrders.test.ts
+++ b/__tests__/square/storeOrders.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PricedItem } from "@/lib/checkout/storePricing";
+
+const ordersCreate = vi.fn();
+const ordersUpdate = vi.fn();
+const ordersPay = vi.fn();
+vi.mock("@/lib/square/client", () => ({
+  getSquareClient: () => ({
+    orders: {
+      create: (...a: unknown[]) => ordersCreate(...a),
+      update: (...a: unknown[]) => ordersUpdate(...a),
+      pay: (...a: unknown[]) => ordersPay(...a),
+    },
+  }),
+}));
+
+import {
+  buildStoreOrderLineItems,
+  createSquareOrderForCart,
+  cancelSquareOrderBestEffort,
+  completeZeroChargeOrder,
+} from "@/lib/square/storeOrders";
+
+const ITEM: PricedItem = {
+  squareCatalogItemId: "item_1",
+  squareVariationId: "var_1",
+  name: "Garden Art Kit",
+  variationName: "Regular",
+  quantity: 2,
+  unitPriceCents: 8800,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("SQUARE_LOCATION_ID", "loc_test_1");
+  ordersCreate.mockResolvedValue({ order: { id: "sqorder_1", version: 1 } });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("buildStoreOrderLineItems", () => {
+  it("maps a priced item to a catalog-linked line item with a string quantity", () => {
+    const lineItems = buildStoreOrderLineItems([ITEM], 0);
+    expect(lineItems).toEqual([
+      {
+        catalogObjectId: "var_1",
+        quantity: "2",
+        basePriceMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+    ]);
+  });
+
+  it("appends a plain shipping+tax line only when non-zero", () => {
+    expect(buildStoreOrderLineItems([ITEM], 0)).toHaveLength(1);
+
+    const withShipping = buildStoreOrderLineItems([ITEM], 1191);
+    expect(withShipping).toHaveLength(2);
+    expect(withShipping[1]).toEqual({
+      name: "Shipping & Tax",
+      quantity: "1",
+      basePriceMoney: { amount: BigInt(1191), currency: "USD" },
+    });
+    expect(withShipping[1].catalogObjectId).toBeUndefined();
+  });
+
+  it("maps multiple items 1:1, preserving order", () => {
+    const second: PricedItem = { ...ITEM, squareCatalogItemId: "item_2", squareVariationId: "var_2", quantity: 1, unitPriceCents: 1500 };
+    const lineItems = buildStoreOrderLineItems([ITEM, second], 0);
+    expect(lineItems).toHaveLength(2);
+    expect(lineItems[0].catalogObjectId).toBe("var_1");
+    expect(lineItems[1].catalogObjectId).toBe("var_2");
+  });
+});
+
+describe("createSquareOrderForCart", () => {
+  it("creates an order with the location id, line items, and no discount by default", async () => {
+    const result = await createSquareOrderForCart({
+      pricedItems: [ITEM],
+      shippingAndTaxCents: 1191,
+      giftCardAppliedCents: 0,
+      idempotencyKey: "idem-1",
+    });
+
+    expect(result).toEqual({ orderId: "sqorder_1", version: 1, locationId: "loc_test_1" });
+    const request = ordersCreate.mock.calls[0][0];
+    expect(request.idempotencyKey).toBe("idem-1");
+    expect(request.order.locationId).toBe("loc_test_1");
+    expect(request.order.lineItems).toHaveLength(2);
+    expect(request.order.discounts).toBeUndefined();
+  });
+
+  it("adds an ORDER-scoped FIXED_AMOUNT discount when a gift card was applied", async () => {
+    await createSquareOrderForCart({
+      pricedItems: [ITEM],
+      shippingAndTaxCents: 0,
+      giftCardAppliedCents: 8800,
+      idempotencyKey: "idem-1",
+    });
+
+    const request = ordersCreate.mock.calls[0][0];
+    expect(request.order.discounts).toEqual([
+      {
+        name: "Gift Card Applied",
+        type: "FIXED_AMOUNT",
+        scope: "ORDER",
+        amountMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+    ]);
+  });
+
+  it("throws (fail closed) when SQUARE_LOCATION_ID is not configured", async () => {
+    vi.stubEnv("SQUARE_LOCATION_ID", "");
+    await expect(
+      createSquareOrderForCart({
+        pricedItems: [ITEM],
+        shippingAndTaxCents: 0,
+        giftCardAppliedCents: 0,
+        idempotencyKey: "idem-1",
+      })
+    ).rejects.toThrow("Square location ID is not configured");
+    expect(ordersCreate).not.toHaveBeenCalled();
+  });
+
+  it("throws (fail closed) when Square returns an order with no id or version", async () => {
+    ordersCreate.mockResolvedValue({ order: {} });
+    await expect(
+      createSquareOrderForCart({
+        pricedItems: [ITEM],
+        shippingAndTaxCents: 0,
+        giftCardAppliedCents: 0,
+        idempotencyKey: "idem-1",
+      })
+    ).rejects.toThrow("Failed to create Square order for cart");
+  });
+});
+
+describe("cancelSquareOrderBestEffort", () => {
+  it("cancels the order with its current version and CANCELED state", async () => {
+    ordersUpdate.mockResolvedValue({ order: { id: "sqorder_1", state: "CANCELED" } });
+    await cancelSquareOrderBestEffort("sqorder_1", 1);
+
+    expect(ordersUpdate).toHaveBeenCalledWith({
+      orderId: "sqorder_1",
+      order: { locationId: "loc_test_1", version: 1, state: "CANCELED" },
+    });
+  });
+
+  it("swallows a thrown error and never rejects", async () => {
+    ordersUpdate.mockRejectedValue(new Error("Square is down"));
+    await expect(cancelSquareOrderBestEffort("sqorder_1", 1)).resolves.toBeUndefined();
+  });
+});
+
+describe("completeZeroChargeOrder", () => {
+  it("pays the order with no linked payment ids", async () => {
+    await completeZeroChargeOrder("sqorder_1", "idem-1");
+    expect(ordersPay).toHaveBeenCalledWith({
+      orderId: "sqorder_1",
+      idempotencyKey: "idem-1",
+      paymentIds: [],
+    });
+  });
+
+  it("swallows a thrown error and never rejects", async () => {
+    ordersPay.mockRejectedValue(new Error("Square is down"));
+    await expect(completeZeroChargeOrder("sqorder_1", "idem-1")).resolves.toBeUndefined();
+  });
+});

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -1,6 +1,13 @@
 /**
  * Store Checkout API
- * POST: Charges Square, saves the Order to MongoDB, and sends the confirmation email.
+ * POST: Creates a Square Order, charges Square, saves the Order to MongoDB, and
+ * sends the confirmation email.
+ *
+ * SQUARE ORDER LINKING: every charge is linked to a real Square Order whose line
+ * items reference the actual catalog objects being sold (lib/square/storeOrders.ts),
+ * mirroring the pattern in lib/square/gift-cards.ts. This is what makes Square's own
+ * per-item inventory count decrement on a sale — a bare payments.create() with no
+ * orderId/catalogObjectId does NOT touch inventory at all.
  *
  * PRICE INTEGRITY: client-supplied money is NOT trusted. The subtotal is recomputed
  * from the Square catalog and shipping from a fresh Shippo re-quote (lib/checkout/
@@ -36,6 +43,11 @@ import { squareCustomerService } from "@/lib/square/customers";
 import { squareCardService } from "@/lib/square/cards";
 import { resolveUserSquareCustomerId } from "@/lib/square/userCustomer";
 import { giftCardService } from "@/lib/square/gift-cards";
+import {
+  createSquareOrderForCart,
+  cancelSquareOrderBestEffort,
+  completeZeroChargeOrder,
+} from "@/lib/square/storeOrders";
 import {
   priceCartFromCatalog,
   resolveShippingRate,
@@ -233,19 +245,39 @@ export async function POST(request: Request): Promise<Response> {
       }
     }
 
+    // Build the idempotency key ONCE and reuse it for both the Square order and
+    // the payment/pay-order call below — Square scopes idempotency per endpoint,
+    // so this is safe, and it keeps a client retry (lost response) from ever
+    // creating a second, orphaned order while the payment call dedupes to the
+    // original.
+    const squareIdempotencyKey = normalizeIdempotencyKey(body.idempotencyKey);
+
+    // Create the real Square Order FIRST, with catalog-linked line items, so a
+    // completed sale decrements Square's own inventory (lib/square/storeOrders.ts).
+    // FAIL CLOSED: if this throws, the outer catch returns an error and no charge
+    // is ever attempted — never fall back to a bare, catalog-less payment.
+    const shippingAndTaxCents = serverRate.rateCents + taxCents;
+    const squareOrder = await createSquareOrderForCart({
+      pricedItems: pricedCart.items,
+      shippingAndTaxCents,
+      giftCardAppliedCents,
+      idempotencyKey: squareIdempotencyKey,
+    });
+
     // Step 1: Charge the card portion (skipped when a gift card covers the full total).
     let squarePaymentId: string | undefined;
     let squareReceiptUrl: string | undefined;
     if (chargeCents > 0) {
       const usingSavedCard = Boolean(body.savedCardId);
       if (!usingSavedCard && !paymentToken) {
+        await cancelSquareOrderBestEffort(squareOrder.orderId, squareOrder.version);
         return NextResponse.json(
           { error: "Payment information is required" },
           { status: 400 }
         );
       }
       const paymentResult = await squareClient.payments.create({
-        idempotencyKey: normalizeIdempotencyKey(body.idempotencyKey),
+        idempotencyKey: squareIdempotencyKey,
         // A saved card charges by its card id; a new card by the one-time nonce.
         sourceId: body.savedCardId ?? (paymentToken as string),
         ...(accountCustomerId ? { customerId: accountCustomerId } : {}),
@@ -256,6 +288,8 @@ export async function POST(request: Request): Promise<Response> {
           amount: BigInt(chargeCents),
           currency: "USD",
         },
+        orderId: squareOrder.orderId,
+        locationId: squareOrder.locationId,
         buyerEmailAddress: customer.email,
         shippingAddress: {
           addressLine1: shippingAddress.addressLine1,
@@ -275,6 +309,7 @@ export async function POST(request: Request): Promise<Response> {
       const payment = paymentResult.payment;
       if (payment?.status !== "COMPLETED") {
         console.error("[API-STORE-CHECKOUT-POST] Square payment not completed:", payment?.status);
+        await cancelSquareOrderBestEffort(squareOrder.orderId, squareOrder.version);
         return NextResponse.json(
           { error: "Payment was not completed", status: payment?.status },
           { status: 400 }
@@ -315,12 +350,21 @@ export async function POST(request: Request): Promise<Response> {
       } catch (giftCardError) {
         console.error("[API-STORE-CHECKOUT-POST] Gift card redemption failed:", giftCardError);
         if (chargeCents === 0) {
+          await cancelSquareOrderBestEffort(squareOrder.orderId, squareOrder.version);
           return NextResponse.json(
             { error: "Gift card could not be redeemed. No charge was made." },
             { status: 400 }
           );
         }
       }
+    }
+
+    // When a gift card covers the entire total, there's no payment to link the
+    // order to — complete it directly so Square's inventory decrement still
+    // fires. Runs AFTER gift-card redemption (and its failure/cancel path above)
+    // so the order is only ever finalized once the free order is actually real.
+    if (chargeCents === 0) {
+      await completeZeroChargeOrder(squareOrder.orderId, squareIdempotencyKey);
     }
 
     // Step 2: Save Order to MongoDB — with SERVER-derived prices and the FRESH
@@ -353,6 +397,7 @@ export async function POST(request: Request): Promise<Response> {
       shippingAddress,
       square: {
         paymentId: squarePaymentId,
+        orderId: squareOrder.orderId,
         receiptUrl: squareReceiptUrl,
       },
       giftCard:

--- a/lib/square/storeOrders.ts
+++ b/lib/square/storeOrders.ts
@@ -1,0 +1,174 @@
+/**
+ * Square Order building for the store checkout.
+ *
+ * Wires cart line items to real Square catalog objects (via catalogObjectId)
+ * so a store sale decrements Square's own per-item inventory count — mirroring
+ * the order-then-payment pattern already proven in lib/square/gift-cards.ts.
+ * Every dollar amount here comes from numbers this app already computed and
+ * trusts (lib/checkout/storePricing.ts, lib/utils/salesTax.ts) — never
+ * recomputed by Square's own tax/discount engine, so the order total always
+ * equals the amount actually charged.
+ */
+import { getSquareClient } from "@/lib/square/client";
+import type { PricedItem } from "@/lib/checkout/storePricing";
+
+const client = getSquareClient();
+
+function getSquareLocationId(): string {
+  return (
+    process.env.NEXT_PUBLIC_SQUARE_LOCATION_ID ||
+    process.env.SQUARE_LOCATION_ID ||
+    ""
+  );
+}
+
+interface StoreOrderLineItem {
+  catalogObjectId?: string;
+  name?: string;
+  quantity: string;
+  basePriceMoney: { amount: bigint; currency: "USD" };
+}
+
+/**
+ * Pure mapping: priced cart items -> Square Order line items, plus one plain
+ * (non-catalog) line for shipping+tax combined when non-zero. No I/O.
+ */
+export function buildStoreOrderLineItems(
+  pricedItems: PricedItem[],
+  shippingAndTaxCents: number
+): StoreOrderLineItem[] {
+  const lineItems: StoreOrderLineItem[] = pricedItems.map((item) => ({
+    catalogObjectId: item.squareVariationId,
+    quantity: String(item.quantity),
+    basePriceMoney: { amount: BigInt(item.unitPriceCents), currency: "USD" },
+  }));
+
+  if (shippingAndTaxCents > 0) {
+    lineItems.push({
+      name: "Shipping & Tax",
+      quantity: "1",
+      basePriceMoney: { amount: BigInt(shippingAndTaxCents), currency: "USD" },
+    });
+  }
+
+  return lineItems;
+}
+
+/**
+ * Creates the real Square Order for a cart, BEFORE any charge is attempted.
+ * Callers must fail closed if this throws — never fall back to a bare
+ * payments.create() call, which would silently reintroduce the catalog-less
+ * charge this module exists to fix.
+ */
+export async function createSquareOrderForCart(input: {
+  pricedItems: PricedItem[];
+  shippingAndTaxCents: number;
+  giftCardAppliedCents: number;
+  idempotencyKey: string;
+}): Promise<{ orderId: string; version: number; locationId: string }> {
+  const locationId = getSquareLocationId();
+  if (!locationId) {
+    throw new Error("Square location ID is not configured");
+  }
+
+  const orderResponse = await client.orders.create({
+    idempotencyKey: input.idempotencyKey,
+    order: {
+      locationId,
+      lineItems: buildStoreOrderLineItems(
+        input.pricedItems,
+        input.shippingAndTaxCents
+      ),
+      ...(input.giftCardAppliedCents > 0
+        ? {
+            discounts: [
+              {
+                name: "Gift Card Applied",
+                type: "FIXED_AMOUNT",
+                scope: "ORDER",
+                amountMoney: {
+                  amount: BigInt(input.giftCardAppliedCents),
+                  currency: "USD",
+                },
+              },
+            ],
+          }
+        : {}),
+    },
+  });
+
+  const order = orderResponse.order;
+  if (!order?.id || order.version == null) {
+    console.error(
+      "[SQUARE-STORE-ORDERS-createSquareOrderForCart] Unexpected order response shape"
+    );
+    throw new Error("Failed to create Square order for cart");
+  }
+
+  console.log(
+    "[SQUARE-STORE-ORDERS-createSquareOrderForCart] Order created:",
+    order.id
+  );
+  return { orderId: order.id, version: order.version, locationId };
+}
+
+/**
+ * Best-effort cancel of an unpaid Square order (e.g. the payment meant to
+ * complete it failed, or a validation error surfaced after the order was
+ * created). Never throws — an unpaid OPEN order is harmless (Square never
+ * decrements inventory for it), so a failed cancel must not change the
+ * customer-facing response. Merchant-visible cleanliness only.
+ */
+export async function cancelSquareOrderBestEffort(
+  orderId: string,
+  version: number
+): Promise<void> {
+  try {
+    const locationId = getSquareLocationId();
+    await client.orders.update({
+      orderId,
+      order: { locationId, version, state: "CANCELED" },
+    });
+    console.log(
+      "[SQUARE-STORE-ORDERS-cancelSquareOrderBestEffort] Canceled unpaid order:",
+      orderId
+    );
+  } catch (error) {
+    console.error(
+      "[SQUARE-STORE-ORDERS-cancelSquareOrderBestEffort] Best-effort cancel failed (non-fatal):",
+      orderId,
+      error
+    );
+  }
+}
+
+/**
+ * Completes a Square order that a gift card covered in full (chargeCents ===
+ * 0, so there's no payment to link it to) — the order still needs to reach
+ * COMPLETED for Square's inventory decrement to fire. Non-fatal on failure:
+ * this path is rare enough that a Square hiccup here shouldn't block an
+ * otherwise-legitimate free order that already succeeded on the app's side
+ * (card charge skipped, gift card already redeemed).
+ */
+export async function completeZeroChargeOrder(
+  orderId: string,
+  idempotencyKey: string
+): Promise<void> {
+  try {
+    await client.orders.pay({
+      orderId,
+      idempotencyKey,
+      paymentIds: [],
+    });
+    console.log(
+      "[SQUARE-STORE-ORDERS-completeZeroChargeOrder] Order completed with no linked payment:",
+      orderId
+    );
+  } catch (error) {
+    console.error(
+      "[SQUARE-STORE-ORDERS-completeZeroChargeOrder] Failed (non-fatal):",
+      orderId,
+      error
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Store checkout charged Square with a bare `payments.create()` call (flat `amountMoney`, generic note) and never referenced a real catalog item — so a sale never decremented Square's own per-item inventory count, for any product, in either environment. Two historical in-person/POS sales proved Square's own inventory tracking works fine; the gap was specifically in this app's checkout never wiring into it.
- Adds `lib/square/storeOrders.ts`, mirroring the order-then-payment pattern already proven for gift cards (`lib/square/gift-cards.ts`): creates a real Square Order with catalog-linked line items (`catalogObjectId` per cart line, a plain shipping+tax line, and an `ORDER`-scoped `FIXED_AMOUNT` gift-card discount — all driven by numbers this app already computes and trusts, never Square's own tax/discount engine) **before** any charge, then links the payment to it via `orderId`.
- **Fails closed**: if Square order creation fails, no charge is attempted and no fallback to the old catalog-less path exists.
- Best-effort cancels the Square order if the payment then fails or a validation error surfaces after order creation (non-fatal — an unpaid `OPEN` order never touches inventory).
- Handles the gift-card-covers-everything ($0 charge) edge case by completing the order directly via `orders.pay({ paymentIds: [] })`, ordered *after* gift-card redemption succeeds so a redemption failure never leaves an already-completed (inventory-decremented) order with no payment and no saved record.
- Populates the long-reserved, never-used `Order.square.orderId` Mongo field.

## What changed
- `lib/square/storeOrders.ts` (new) — `buildStoreOrderLineItems`, `createSquareOrderForCart`, `cancelSquareOrderBestEffort`, `completeZeroChargeOrder`.
- `app/api/store/checkout/route.ts` — creates the Square Order before charging, threads `orderId`/`locationId` into `payments.create`, cancels on failure, completes zero-charge orders, stamps `square.orderId`.
- `__tests__/checkout/storeCheckoutRoute.test.ts` — extended Square mock (`orders.create/update/pay`), new coverage for the line-item shape, multi-item carts, the gift-card discount, the \$0-charge path, fail-closed order-creation failure, and non-fatal cancel-on-payment-failure.
- `__tests__/square/storeOrders.test.ts` (new) — pure line-item-building logic + the thin Square-call wrappers.

## Test plan
- [x] `npx vitest run` — full suite, 405/405 passing (47 test files)
- [x] `pnpm run build` — compiles clean, no type errors
- [x] `npx eslint` on all changed/new files — clean
- [ ] Manual sandbox purchase on `stg.coastalcreationsstudio.com/shop` for a tracked item — confirm the Square order reaches `COMPLETED` with `catalogObjectId` line items, inventory decrements by the purchased quantity, and the Mongo order's `square.orderId` populates
- [ ] Manual sandbox test of the gift-card-covered path (discount line + reduced order total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)