### PR TITLE
fix(store-checkout): block state autofill, drop checkmarks, cursor-pointer app-wide

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -165,6 +165,22 @@
   }
 }
 
+/* Browsers default <button> to cursor: default, not pointer (unlike <a> —
+   that's a common assumption, but it's wrong). Tailwind doesn't correct this
+   in Preflight either, so every button needs cursor-pointer added by hand or
+   it silently falls back to the arrow cursor — which is how this app ended
+   up with the inconsistency (some buttons styled it, most didn't, e.g. the
+   cart icon and several account-page buttons had no pointer at all). Set the
+   sane default here instead of chasing every instance; components in the
+   utilities layer (e.g. Button.tsx's disabled:cursor-not-allowed) still win
+   over this since utilities are declared after base in Tailwind's layer order. */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 /* Cart "item added" feedback — badge / button pop. */
 @keyframes cartBump {
   0% {

--- a/components/store/CheckoutField.tsx
+++ b/components/store/CheckoutField.tsx
@@ -7,34 +7,24 @@ interface FieldWrapperProps {
   required?: boolean;
   touched: boolean;
   error: string | null;
-  value?: string;
   children: ReactElement;
 }
 
-/** Label + input shell with a valid ✓ and a touched-only error message. */
+/** Label + input shell with a touched-only error message. */
 export function FieldWrapper({
   id,
   label,
   required,
   touched,
   error,
-  value,
   children,
 }: FieldWrapperProps): ReactElement {
-  const isValid = !!value && !error;
   return (
     <div>
       <Label htmlFor={id} required={required}>
         {label}
       </Label>
-      <div className="relative">
-        {children}
-        {isValid && (
-          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-green-500 text-sm pointer-events-none">
-            ✓
-          </span>
-        )}
-      </div>
+      {children}
       {touched && error && (
         <p className="text-[var(--color-error)] text-xs mt-1">{error}</p>
       )}

--- a/components/store/ContactFields.tsx
+++ b/components/store/ContactFields.tsx
@@ -47,7 +47,6 @@ export default function ContactFields({
           required
           touched={!!touched.email}
           error={contactError("email", values.email)}
-          value={values.email}
         >
           <Input
             id="contact-email"
@@ -65,7 +64,6 @@ export default function ContactFields({
           required
           touched={!!touched.phone}
           error={contactError("phone", values.phone)}
-          value={values.phone}
         >
           <Input
             id="contact-phone"
@@ -87,7 +85,6 @@ export default function ContactFields({
           required
           touched={!!touched.firstName}
           error={contactError("firstName", values.firstName)}
-          value={values.firstName}
         >
           <Input
             id="contact-firstName"
@@ -104,7 +101,6 @@ export default function ContactFields({
           required
           touched={!!touched.lastName}
           error={contactError("lastName", values.lastName)}
-          value={values.lastName}
         >
           <Input
             id="contact-lastName"

--- a/components/store/ShippingAddressStep.tsx
+++ b/components/store/ShippingAddressStep.tsx
@@ -72,7 +72,6 @@ export default function ShippingAddressStep({
             required
             touched={!!touched.firstName}
             error={validateField("firstName", values.firstName)}
-            value={values.firstName}
           >
             <Input id="ship-firstName" autoComplete="off" {...fieldProps("firstName")} />
           </FieldWrapper>
@@ -83,7 +82,6 @@ export default function ShippingAddressStep({
             required
             touched={!!touched.lastName}
             error={validateField("lastName", values.lastName)}
-            value={values.lastName}
           >
             <Input id="ship-lastName" autoComplete="off" {...fieldProps("lastName")} />
           </FieldWrapper>
@@ -96,7 +94,6 @@ export default function ShippingAddressStep({
         required
         touched={!!touched.addressLine1}
         error={validateField("addressLine1", values.addressLine1)}
-        value={values.addressLine1}
       >
         <Input id="addressLine1" autoComplete="address-line1" {...fieldProps("addressLine1")} />
       </FieldWrapper>
@@ -118,35 +115,29 @@ export default function ShippingAddressStep({
           required
           touched={!!touched.city}
           error={validateField("city", values.city)}
-          value={values.city}
         >
           <Input id="city" autoComplete="address-level2" {...fieldProps("city")} />
         </FieldWrapper>
 
         <div>
           <Label htmlFor="state" required>State</Label>
-          <div className="relative">
-            <select
-              id="state"
-              value={values.state}
-              onChange={(e) => {
-                onChange("state", e.target.value);
-                touch("state");
-              }}
-              onBlur={() => touch("state")}
-              className="w-full h-[50px] px-4 bg-[var(--color-light)] border border-[var(--color-border)] rounded-[var(--radius-default)] text-[var(--color-text-primary)] focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none transition-colors text-sm appearance-none"
-            >
-              <option value="">State</option>
-              {US_STATES.map((s) => (
-                <option key={s} value={s}>{s}</option>
-              ))}
-            </select>
-            {values.state && (
-              <span className="absolute right-7 top-1/2 -translate-y-1/2 text-green-500 text-sm pointer-events-none">
-                ✓
-              </span>
-            )}
-          </div>
+          <select
+            id="state"
+            name="state"
+            autoComplete="off"
+            value={values.state}
+            onChange={(e) => {
+              onChange("state", e.target.value);
+              touch("state");
+            }}
+            onBlur={() => touch("state")}
+            className="w-full h-[50px] px-4 bg-[var(--color-light)] border border-[var(--color-border)] rounded-[var(--radius-default)] text-[var(--color-text-primary)] focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none transition-colors text-sm appearance-none"
+          >
+            <option value="">State</option>
+            {US_STATES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
           {touched.state && !values.state && (
             <p className="text-[var(--color-error)] text-xs mt-1">Required</p>
           )}
@@ -158,7 +149,6 @@ export default function ShippingAddressStep({
           required
           touched={!!touched.zip}
           error={validateField("zip", values.zip)}
-          value={values.zip}
         >
           <Input id="zip" autoComplete="postal-code" maxLength={10} {...fieldProps("zip")} />
         </FieldWrapper>


### PR DESCRIPTION
## Summary
- **State autofill fix**: the checkout state `<select>` had no `name`/`autocomplete` hint, so some browsers' address autofill could set it to a value that didn't match any `<option>` (e.g. the full state name instead of the USPS code) — the dropdown looked unselected even though a real value had been submitted, and it risked silently skipping NJ sales tax (an exact `"NJ"` string match in `salesTax.ts`) on an autofilled full name. Fixed by blocking autofill outright (`name="state"` + `autocomplete="off"`) so the field is manual-select-only and can only ever hold one of the listed two-letter codes.
- **Removed the green checkmark** shown next to every filled contact/address field on checkout (email, phone, name, address, city, ZIP) plus the state select's own duplicate checkmark — visual clutter, not a validation signal.
- **App-wide cursor-pointer fix**: browsers default `<button>` to `cursor: default`, not `pointer` (a common wrong assumption — that's actually `<a>` behavior), and Tailwind's Preflight doesn't correct it. This left the app inconsistent — some buttons (e.g. `LogoutButton`) had `cursor-pointer` added by hand, most didn't (e.g. the cart icon, several account-page buttons). Set the default once in `globals.css`'s base layer instead of chasing every raw `<button>` across ~60 files. Explicit cursor utilities elsewhere (e.g. `Button.tsx`'s `disabled:cursor-not-allowed`) are unaffected since Tailwind's utilities layer always wins over base.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] Full checkout/salesTax test suite (92 tests) passing
- [x] Verified live: state select shows the picked code correctly, no checkmarks anywhere, cart icon + all header/homepage buttons report `cursor: pointer`, a synthetic disabled button confirms it correctly keeps `cursor: default`
- [ ] Spot-check account-page buttons in a real browser (signed-in flow not exercised in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)