### PR TITLE
copy(shop): simplify gift card banner headline

### DIFF
--- a/components/store/ShopGiftCardCTA.tsx
+++ b/components/store/ShopGiftCardCTA.tsx
@@ -37,12 +37,11 @@ export default function ShopGiftCardCTA(): ReactElement {
           {/* Copy + CTA */}
           <div className="flex flex-col items-center gap-4 md:items-start">
             <h2 className="text-2xl font-bold text-[var(--color-primary)] md:text-3xl">
-              Tough to buy for? Let them choose.
+              Coastal Creations Gift Cards
             </h2>
             <p className="max-w-xl text-base leading-relaxed text-[var(--color-text-muted)] md:text-lg">
-              A Coastal Creations gift card is always the right fit — use it here
-              in the shop, or for classes, camps, workshops, and walk-in studio
-              time.
+              Use it here in the shop, or for classes, camps, workshops, and
+              walk-in studio time.
             </p>
             <Link
               href="/gift-cards"


### PR DESCRIPTION
## Summary
- The gift-card CTA beneath the shop grid read "Tough to buy for? Let them choose." / "A Coastal Creations gift card is always the right fit — use it here in the shop, or for classes, camps, workshops, and walk-in studio time." — replaced with a plain headline ("Coastal Creations Gift Cards") and trimmed the body to just the factual part (where it can be used).
- Scoped to `components/store/ShopGiftCardCTA.tsx` only — the homepage gift-card banner (`components/landing/GiftCardBanner.tsx`, "Give the gift of creativity.") uses different copy and wasn't touched.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Verified live on `/shop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)