### PR TITLE
feat(calendar): one popover for preview + sign-up, no duplicate modal

### DIFF
--- a/__tests__/calendar/EventPopover.test.ts
+++ b/__tests__/calendar/EventPopover.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { calculatePopoverPosition } from "@/components/calendar/EventPopover";
+
+function rect(partial: Partial<DOMRect>): DOMRect {
+  const left = partial.left ?? 0;
+  const top = partial.top ?? 0;
+  const width = partial.width ?? 0;
+  const height = partial.height ?? 0;
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: partial.right ?? left + width,
+    bottom: partial.bottom ?? top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
+  Object.defineProperty(window, "innerHeight", { writable: true, configurable: true, value: height });
+}
+
+describe("calculatePopoverPosition", () => {
+  beforeEach(() => {
+    setViewport(1024, 768);
+  });
+
+  it("centers above the anchor when there's room above", () => {
+    const anchor = rect({ left: 400, top: 300, width: 100, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformY).toBe("-100%");
+    expect(result.transformX).toBe("-50%");
+    expect(result.top).toBe(anchor.top - 10);
+    expect(result.left).toBe(anchor.left + anchor.width / 2);
+  });
+
+  it("flips below the anchor when there's no room above but room below", () => {
+    const anchor = rect({ left: 400, top: 20, width: 100, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformY).toBe("0%");
+    expect(result.top).toBe(anchor.bottom + 10);
+  });
+
+  it("clamps to the left edge instead of running off-screen", () => {
+    const anchor = rect({ left: 10, top: 300, width: 50, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformX).toBe("0%");
+    expect(result.left).toBe(16); // margin
+  });
+
+  it("clamps to the right edge instead of running off-screen", () => {
+    const anchor = rect({ left: 990, top: 300, width: 30, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformX).toBe("-100%");
+    expect(result.left).toBe(1024 - 16); // viewportWidth - margin
+  });
+
+  it("centers vertically when there's no room above or below", () => {
+    setViewport(1024, 220);
+    const anchor = rect({ left: 400, top: 100, width: 100, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformY).toBe("-50%");
+    expect(result.top).toBe(110); // viewportHeight / 2
+  });
+});

--- a/components/calendar/EventPopover.tsx
+++ b/components/calendar/EventPopover.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactElement } from "react";
+import { createPortal } from "react-dom";
+
+export interface PopoverEvent {
+  title: string;
+  eventType: string;
+  timeDisplay: string;
+  price?: number;
+  isFree?: boolean;
+  description?: string;
+  currentSignups: number;
+  isRecurring?: boolean;
+  recurringPattern?: string;
+  recurringEndDate?: string | Date;
+  _id: string;
+  isSoldOut: boolean;
+}
+
+export type PopoverMode = "hover" | "pinned";
+
+const COMPACT_QUERY = "(hover: none), (pointer: coarse), (max-width: 640px)";
+
+interface EventPopoverProps {
+  event: PopoverEvent;
+  anchorRect: DOMRect;
+  mode: PopoverMode;
+  eventColor: string;
+  onRequestClose: () => void;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+  onSignUp: () => void;
+  onViewDetails: () => void;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  artist: "Live Demo",
+  camp: "Art Camp",
+  workshop: "Workshop",
+  event: "Workshop",
+};
+
+function typeLabel(eventType: string): string {
+  return TYPE_LABELS[eventType] ?? "Class";
+}
+
+/** Anchor the popover near the event chip, flipping above/below and clamping
+ * horizontally so it never runs off-screen. Positioned once on open — the
+ * caller closes the popover on scroll/resize/navigation rather than trying
+ * to keep a live position in sync with a moving anchor. */
+export function calculatePopoverPosition(
+  anchorRect: DOMRect,
+  popoverRect: DOMRect
+): { left: number; top: number; transformX: string; transformY: string } {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const margin = 16;
+
+  let left = anchorRect.left + anchorRect.width / 2;
+  let top = anchorRect.top - 10;
+  let transformX = "-50%";
+  let transformY = "-100%";
+
+  const halfWidth = popoverRect.width / 2;
+  if (left - halfWidth < margin) {
+    left = margin;
+    transformX = "0%";
+  } else if (left + halfWidth > viewportWidth - margin) {
+    left = viewportWidth - margin;
+    transformX = "-100%";
+  }
+
+  const spaceAbove = anchorRect.top;
+  const spaceBelow = viewportHeight - anchorRect.bottom;
+  const height = popoverRect.height;
+
+  if (spaceAbove < height + margin && spaceBelow > height + margin) {
+    top = anchorRect.bottom + 10;
+    transformY = "0%";
+  } else if (spaceAbove < height + margin && spaceBelow < height + margin) {
+    top = viewportHeight / 2;
+    transformY = "-50%";
+    if (left < viewportWidth / 2) {
+      left = Math.max(margin, anchorRect.right + 10);
+      transformX = "0%";
+    } else {
+      left = Math.min(viewportWidth - margin, anchorRect.left - 10);
+      transformX = "-100%";
+    }
+  }
+
+  return { left, top, transformX, transformY };
+}
+
+export default function EventPopover({
+  event,
+  anchorRect,
+  mode,
+  eventColor,
+  onRequestClose,
+  onPointerEnter,
+  onPointerLeave,
+  onSignUp,
+  onViewDetails,
+}: EventPopoverProps): ReactElement | null {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [style, setStyle] = useState<CSSProperties>({ visibility: "hidden" });
+  // Compact (fixed bottom sheet) below the same breakpoint the rest of the
+  // calendar already treats as mobile — matches calendar.css's 640px/768px cuts.
+  const [isCompact, setIsCompact] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(COMPACT_QUERY).matches
+  );
+
+  useEffect(() => {
+    const query = window.matchMedia(COMPACT_QUERY);
+    const listener = (e: MediaQueryListEvent): void => setIsCompact(e.matches);
+    query.addEventListener("change", listener);
+    return () => query.removeEventListener("change", listener);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isCompact || !popoverRef.current) {
+      setStyle({});
+      return;
+    }
+    const rect = popoverRef.current.getBoundingClientRect();
+    const { left, top, transformX, transformY } = calculatePopoverPosition(
+      anchorRect,
+      rect
+    );
+    setStyle({
+      position: "fixed",
+      left,
+      top,
+      transform: `translate(${transformX}, ${transformY})`,
+    });
+  }, [anchorRect, isCompact]);
+
+  // Escape always closes. Outside click only closes a pinned popover — a
+  // hover popover is already dismissed by the pointer-leave timer.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") onRequestClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onRequestClose]);
+
+  useEffect(() => {
+    if (mode !== "pinned") return;
+    const onPointerDown = (e: PointerEvent): void => {
+      if (!popoverRef.current?.contains(e.target as Node)) {
+        onRequestClose();
+      }
+    };
+    // Delay one tick so the click that opened this popover doesn't also close it.
+    const id = window.setTimeout(
+      () => document.addEventListener("pointerdown", onPointerDown),
+      0
+    );
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [mode, onRequestClose]);
+
+  useEffect(() => {
+    if (mode === "pinned") closeButtonRef.current?.focus();
+  }, [mode]);
+
+  const currentSignups = event.currentSignups;
+  const showParticipants = currentSignups > 5 && event.eventType !== "artist";
+
+  const content = (
+    <>
+      {mode === "pinned" && isCompact && (
+        <div
+          className="event-popover-backdrop"
+          onClick={onRequestClose}
+          aria-hidden="true"
+        />
+      )}
+      <div
+        ref={popoverRef}
+        role="dialog"
+        aria-label={event.title}
+        className={`event-popover ${mode === "hover" ? "event-popover--hover" : "event-popover--pinned"} ${isCompact ? "event-popover--compact" : ""}`}
+        style={style}
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {mode === "pinned" && (
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="event-popover-close"
+            onClick={onRequestClose}
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        )}
+
+        <span
+          className="event-popover-type"
+          style={{ backgroundColor: eventColor }}
+        >
+          {typeLabel(event.eventType)}
+        </span>
+
+        <div className="event-popover-title">{event.title}</div>
+
+        {event.timeDisplay && (
+          <div className="event-popover-time">{event.timeDisplay}</div>
+        )}
+
+        <div className="event-popover-body">
+          {typeof event.price === "number" && event.price > 0 && (
+            <div className="event-popover-price">Price: ${event.price}</div>
+          )}
+          {(event.isFree || event.price === 0) && (
+            <div className="event-popover-price">Free</div>
+          )}
+
+          {showParticipants && (
+            <div className="event-popover-participants">
+              {currentSignups} / 20 signed up
+            </div>
+          )}
+
+          {event.isRecurring && (
+            <div className="event-popover-recurring">
+              Recurring {event.recurringPattern}
+              {event.recurringEndDate
+                ? ` until ${new Date(event.recurringEndDate).toLocaleDateString()}`
+                : ""}
+            </div>
+          )}
+
+          {event.description && (
+            <div className="event-popover-description">
+              {event.description}
+            </div>
+          )}
+        </div>
+
+        <div className="event-popover-actions">
+          {event.eventType === "artist" ? (
+            <button
+              type="button"
+              className="event-popover-cta"
+              onClick={onViewDetails}
+            >
+              View Details
+            </button>
+          ) : event.isSoldOut ? (
+            <div className="event-popover-soldout">Sold Out</div>
+          ) : (
+            <button
+              type="button"
+              className="event-popover-cta"
+              onClick={onSignUp}
+            >
+              Sign Up
+            </button>
+          )}
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/components/calendar/NewCalendar.tsx
+++ b/components/calendar/NewCalendar.tsx
@@ -9,6 +9,15 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import "./calendar.css";
 import { useRouter } from "next/navigation";
 import { CalendarEvent, ApiEvent } from "@/types/interfaces";
+import type { EventClickArg, EventHoveringArg } from "@fullcalendar/core";
+import EventPopover, { type PopoverEvent, type PopoverMode } from "./EventPopover";
+
+// Hover-intent delay: only open a preview once the pointer rests on an event,
+// so sweeping across stacked events doesn't spawn/flicker popovers.
+const HOVER_OPEN_DELAY_MS = 220;
+// Grace period before closing on pointer-leave, so crossing the gap between
+// the event chip and the popover (the "hover bridge") doesn't kill it early.
+const HOVER_CLOSE_DELAY_MS = 180;
 
 export default function NewCalendar() {
   const [calendarView, setCalendarView] = useState("dayGridMonth");
@@ -19,23 +28,82 @@ export default function NewCalendar() {
 
   const router = useRouter();
 
-  // Use refs for tooltip tracking so event listeners always see current values
-  const activeTooltipRef = useRef<HTMLElement | null>(null);
-  const tooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  // Hover-intent delay: only show a preview once the pointer rests on an event,
-  // so sweeping across stacked events doesn't spawn/flicker tooltips.
-  const tooltipShowTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const TOOLTIP_SHOW_DELAY_MS = 220;
-  const [selectedEvent, setSelectedEvent] = useState<{
-    title: string;
-    eventType: string;
-    timeDisplay: string;
-    price?: number;
-    isFree?: boolean;
-    description?: string;
-    _id: string;
-    isSoldOut: boolean;
+  const [popover, setPopover] = useState<{
+    event: PopoverEvent;
+    anchorRect: DOMRect;
+    mode: PopoverMode;
   } | null>(null);
+
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearOpenTimer = useCallback(() => {
+    if (openTimerRef.current) {
+      clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+  }, []);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const closePopover = useCallback(() => {
+    clearOpenTimer();
+    clearCloseTimer();
+    setPopover(null);
+  }, [clearOpenTimer, clearCloseTimer]);
+
+  // Cancel a pending close — called when the pointer (re)enters either the
+  // event chip or the popover itself, so moving between them never drops it.
+  const cancelClose = useCallback(() => {
+    clearCloseTimer();
+  }, [clearCloseTimer]);
+
+  const scheduleClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null;
+      setPopover(null);
+    }, HOVER_CLOSE_DELAY_MS);
+  }, [clearCloseTimer]);
+
+  const scheduleOpen = useCallback(
+    (event: PopoverEvent, anchorRect: DOMRect) => {
+      clearOpenTimer();
+      clearCloseTimer();
+      openTimerRef.current = setTimeout(() => {
+        openTimerRef.current = null;
+        setPopover({ event, anchorRect, mode: "hover" });
+      }, HOVER_OPEN_DELAY_MS);
+    },
+    [clearOpenTimer, clearCloseTimer]
+  );
+
+  useEffect(() => {
+    return () => {
+      clearOpenTimer();
+      clearCloseTimer();
+    };
+  }, [clearOpenTimer, clearCloseTimer]);
+
+  // Any popover (hover or pinned) is anchored to a specific chip's on-screen
+  // position captured at open time — scrolling, resizing, or paging the
+  // calendar to a new month all invalidate that position, so close rather
+  // than risk a stale, misplaced card.
+  useEffect(() => {
+    if (!popover) return;
+    const dismiss = (): void => closePopover();
+    window.addEventListener("scroll", dismiss, true);
+    window.addEventListener("resize", dismiss);
+    return () => {
+      window.removeEventListener("scroll", dismiss, true);
+      window.removeEventListener("resize", dismiss);
+    };
+  }, [popover, closePopover]);
 
   const resources = [
     { id: "class", title: "Classes", eventColor: "#0c4a6e" },
@@ -414,20 +482,35 @@ export default function NewCalendar() {
     router.push(`/payments?${params.toString()}`);
   };
 
-  useEffect(() => {
-    return () => {
-      // Remove any tooltips when component unmounts
-      if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
-        document.body.removeChild(activeTooltipRef.current);
-      }
-      if (tooltipTimeoutRef.current) {
-        clearTimeout(tooltipTimeoutRef.current);
-      }
-      if (tooltipShowTimeoutRef.current) {
-        clearTimeout(tooltipShowTimeoutRef.current);
-      }
-    };
-  }, []);
+  // Shared by both the hover preview and the click/tap popover — previously
+  // duplicated between eventMouseEnter and eventClick, which is how they'd
+  // drifted into showing two different views of the same event.
+  const toPopoverEvent = useCallback(
+    (event: EventClickArg["event"] | EventHoveringArg["event"]): PopoverEvent => {
+      const props = event.extendedProps as Record<string, unknown>;
+      const eventType = (props?.eventType as string) || "";
+      const eventId = (props?._id as string) || "";
+      const currentSignups = eventId
+        ? eventParticipantCounts[eventId] || 0
+        : 0;
+      const maxParticipants = 20;
+      return {
+        title: event.title,
+        eventType,
+        timeDisplay: (props?.timeDisplay as string) || "",
+        price: props?.price as number | undefined,
+        isFree: props?.isFree as boolean | undefined,
+        description: props?.description as string | undefined,
+        currentSignups,
+        isRecurring: props?.isRecurring as boolean | undefined,
+        recurringPattern: props?.recurringPattern as string | undefined,
+        recurringEndDate: props?.recurringEndDate as string | Date | undefined,
+        _id: eventId,
+        isSoldOut: eventType !== "artist" && currentSignups >= maxParticipants,
+      };
+    },
+    [eventParticipantCounts]
+  );
 
   return (
     <div className="calendar-container">
@@ -452,6 +535,8 @@ export default function NewCalendar() {
         resources={calendarView.includes("resource") ? resources : undefined}
         datesSet={(dateInfo) => {
           setCalendarView(dateInfo.view.type);
+          // Paging to a new month invalidates any open popover's anchor position.
+          closePopover();
         }}
         height="auto"
         eventClassNames={(arg) => {
@@ -468,219 +553,38 @@ export default function NewCalendar() {
         }}
         eventClick={(info) => {
           info.jsEvent.preventDefault();
-          // Dismiss any active tooltip
-          if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
-            document.body.removeChild(activeTooltipRef.current);
-            activeTooltipRef.current = null;
-          }
-          if (tooltipTimeoutRef.current) {
-            clearTimeout(tooltipTimeoutRef.current);
-            tooltipTimeoutRef.current = null;
-          }
-          if (tooltipShowTimeoutRef.current) {
-            clearTimeout(tooltipShowTimeoutRef.current);
-            tooltipShowTimeoutRef.current = null;
-          }
-          const props = info.event.extendedProps;
-          const eventId = props?._id || "";
-          const currentSignups = eventId
-            ? eventParticipantCounts[eventId] || 0
-            : 0;
-          const isSoldOut =
-            props?.eventType !== "artist" && currentSignups >= 20;
-          setSelectedEvent({
-            title: info.event.title,
-            eventType: props?.eventType || "",
-            timeDisplay: props?.timeDisplay || "",
-            price: props?.price,
-            isFree: props?.isFree,
-            description: props?.description,
-            _id: eventId,
-            isSoldOut,
+          clearOpenTimer();
+          clearCloseTimer();
+          setPopover({
+            event: toPopoverEvent(info.event),
+            anchorRect: info.el.getBoundingClientRect(),
+            mode: "pinned",
           });
         }}
         eventMouseEnter={(info) => {
-          // Only show hover previews on devices with a true hover-capable
-          // pointer (mouse). Touch devices use tap -> detail sheet, so a
-          // synthetic hover must never leave a stuck tooltip behind.
+          // A pinned (clicked/tapped) popover is only dismissed explicitly —
+          // hovering a different chip must not silently steal it away.
+          if (popover?.mode === "pinned") return;
+          // Only open hover previews on devices with a true hover-capable,
+          // fine pointer (mouse). Touch/coarse pointers rely on eventClick's
+          // pinned popover instead — a synthetic hover must never leave a
+          // stuck popover behind on a device that can't "leave" it.
           if (
             typeof window !== "undefined" &&
-            window.matchMedia("(hover: none)").matches
+            !window.matchMedia("(hover: hover) and (pointer: fine)").matches
           ) {
             return;
           }
-
-          // Remove any existing tooltip DOM element
-          if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
-            document.body.removeChild(activeTooltipRef.current);
-            activeTooltipRef.current = null;
-          }
-
-          // Clear any pending hide timeout for a previous tooltip, as we are showing a new one.
-          if (tooltipTimeoutRef.current) {
-            clearTimeout(tooltipTimeoutRef.current);
-            tooltipTimeoutRef.current = null;
-          }
-
-          // Cancel a pending show from a previously-hovered event.
-          if (tooltipShowTimeoutRef.current) {
-            clearTimeout(tooltipShowTimeoutRef.current);
-            tooltipShowTimeoutRef.current = null;
-          }
-
-          // Hover-intent: only build + show the preview once the pointer has
-          // rested on this event for a beat. Quickly passing over neighbouring
-          // events is cancelled by eventMouseLeave before this fires.
-          tooltipShowTimeoutRef.current = setTimeout(() => {
-            tooltipShowTimeoutRef.current = null;
-
-          // Create new tooltip
-          const tooltip = document.createElement("div");
-          tooltip.className = "event-tooltip";
-
-          // Build tooltip content
-          let tooltipContent = `<div class="tooltip-title">${info.event.title}</div>`;
-
-          // Get event type early for use in multiple places
-          const eventType = info.event.extendedProps?.eventType;
-
-          if (info.event.extendedProps?.timeDisplay) {
-            tooltipContent += `<div class="tooltip-time">${info.event.extendedProps.timeDisplay}</div>`;
-          }
-
-          // if (info.event.extendedProps?.eventType) {
-          //   tooltipContent += `<div class="tooltip-type">Type: ${info.event.extendedProps.eventType}</div>`;
-          // }
-
-          if (info.event.extendedProps?.price) {
-            tooltipContent += `<div class="tooltip-price">Price: $${info.event.extendedProps.price}</div>`;
-          }
-
-          // Show participant count only if signups > 5 and not artist event
-          const eventId = info.event.extendedProps?._id;
-          const currentSignups = eventId
-            ? eventParticipantCounts[eventId] || 0
-            : 0;
-          if (currentSignups > 5 && eventType !== "artist") {
-            // We need to get the numberOfParticipants from the event data
-            // For now, we'll use the default of 20 if not available
-            tooltipContent += `<div class="tooltip-participants">${currentSignups} / 20 signed up</div>`;
-          }
-
-          if (info.event.extendedProps?.isRecurring) {
-            tooltipContent += `<div class="tooltip-recurring">
-              Recurring ${info.event.extendedProps.recurringPattern} 
-              ${info.event.extendedProps.recurringEndDate ? `until ${new Date(info.event.extendedProps.recurringEndDate).toLocaleDateString()}` : ""}
-            </div>`;
-          }
-
-          if (info.event.extendedProps?.description) {
-            tooltipContent += `<div class="tooltip-description">${info.event.extendedProps.description}</div>`;
-          }
-
-          // The hover tooltip is a non-interactive PREVIEW only. The actual
-          // sign-up / sold-out CTA lives in the click-to-open detail sheet, so
-          // there is no fragile "move the mouse onto a hovering button" path.
-          const maxParticipants = 20; // Default capacity
-          const isSoldOut =
-            eventType !== "artist" && currentSignups >= maxParticipants;
-          tooltipContent += `<div class="tooltip-hint">${
-            isSoldOut ? "Sold out" : "Click the calendar event for details"
-          }</div>`;
-
-          tooltip.innerHTML = tooltipContent;
-
-          // Add to body first to get accurate dimensions
-          document.body.appendChild(tooltip);
-
-          // Position the tooltip with smart boundary checking
-          const rect = info.el.getBoundingClientRect();
-          const tooltipRect = tooltip.getBoundingClientRect();
-          const viewportWidth = window.innerWidth;
-          const viewportHeight = window.innerHeight;
-
-          // Calculate initial centered position
-          let left = rect.left + rect.width / 2;
-          let top = rect.top - 10;
-          let transformX = "-50%";
-          let transformY = "-100%";
-
-          // Check horizontal boundaries
-          const tooltipHalfWidth = tooltipRect.width / 2;
-          const margin = 16; // Minimum margin from screen edge
-
-          if (left - tooltipHalfWidth < margin) {
-            // Too far left - align to left edge with margin
-            left = margin;
-            transformX = "0%";
-          } else if (left + tooltipHalfWidth > viewportWidth - margin) {
-            // Too far right - align to right edge with margin
-            left = viewportWidth - margin;
-            transformX = "-100%";
-          }
-
-          // Check vertical boundaries
-          const tooltipHeight = tooltipRect.height;
-          const spaceAbove = rect.top;
-          const spaceBelow = viewportHeight - rect.bottom;
-
-          if (
-            spaceAbove < tooltipHeight + margin &&
-            spaceBelow > tooltipHeight + margin
-          ) {
-            // Not enough space above, position below
-            top = rect.bottom + 10;
-            transformY = "0%";
-          } else if (
-            spaceAbove < tooltipHeight + margin &&
-            spaceBelow < tooltipHeight + margin
-          ) {
-            // Not enough space above or below, center vertically
-            top = viewportHeight / 2;
-            transformY = "-50%";
-
-            // If centering vertically, also ensure we're not too close to edges horizontally
-            if (left < viewportWidth / 2) {
-              left = Math.max(margin, rect.right + 10);
-              transformX = "0%";
-            } else {
-              left = Math.min(viewportWidth - margin, rect.left - 10);
-              transformX = "-100%";
-            }
-          }
-
-          // Apply positioning. pointer-events:none keeps the preview from ever
-          // intercepting the mouse, so moving toward / clicking the event below
-          // always works — no hover-bridge flicker.
-          tooltip.style.position = "fixed";
-          tooltip.style.left = left + "px";
-          tooltip.style.top = top + "px";
-          tooltip.style.transform = `translate(${transformX}, ${transformY})`;
-          tooltip.style.zIndex = "99999";
-          tooltip.style.display = "block";
-          tooltip.style.pointerEvents = "none";
-
-          activeTooltipRef.current = tooltip;
-          }, TOOLTIP_SHOW_DELAY_MS);
+          scheduleOpen(toPopoverEvent(info.event), info.el.getBoundingClientRect());
         }}
         eventMouseLeave={() => {
-          // Cancel a not-yet-shown preview (the pointer was just passing over).
-          if (tooltipShowTimeoutRef.current) {
-            clearTimeout(tooltipShowTimeoutRef.current);
-            tooltipShowTimeoutRef.current = null;
-          }
-          // Pure preview — remove it as soon as the pointer leaves the event.
-          if (tooltipTimeoutRef.current) {
-            clearTimeout(tooltipTimeoutRef.current);
-            tooltipTimeoutRef.current = null;
-          }
-          if (
-            activeTooltipRef.current &&
-            document.body.contains(activeTooltipRef.current)
-          ) {
-            document.body.removeChild(activeTooltipRef.current);
-          }
-          activeTooltipRef.current = null;
+          // Never let hover tracking close a pinned popover — see eventMouseEnter.
+          if (popover?.mode === "pinned") return;
+          clearOpenTimer();
+          // Grace period, not immediate removal — gives the pointer time to
+          // cross the gap onto the popover itself (the "hover bridge") without
+          // the popover disappearing out from under it.
+          scheduleClose();
         }}
         eventDidMount={(info) => {
           // Set event color based on event type
@@ -696,85 +600,29 @@ export default function NewCalendar() {
         }}
       />
 
-      {selectedEvent && (
-        <div
-          className="event-sheet-overlay"
-          onClick={() => setSelectedEvent(null)}
-        >
-          <div
-            className="event-sheet"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              className="event-sheet-close"
-              onClick={() => setSelectedEvent(null)}
-              type="button"
-              aria-label="Close"
-            >
-              &times;
-            </button>
-            <span
-              className="event-sheet-type"
-              style={{
-                backgroundColor: getEventColor(selectedEvent.eventType),
-              }}
-            >
-              {selectedEvent.eventType === "artist"
-                ? "Live Demo"
-                : selectedEvent.eventType === "camp"
-                  ? "Art Camp"
-                  : "Workshop"}
-            </span>
-            <h3 className="event-sheet-title">{selectedEvent.title}</h3>
-            {selectedEvent.timeDisplay && (
-              <p className="event-sheet-time">{selectedEvent.timeDisplay}</p>
-            )}
-            {(selectedEvent.price || selectedEvent.isFree) && (
-              <p className="event-sheet-price">
-                {selectedEvent.isFree || selectedEvent.price === 0
-                  ? "Free"
-                  : `$${selectedEvent.price}`}
-              </p>
-            )}
-            {selectedEvent.description && (
-              <p className="event-sheet-description">
-                {selectedEvent.description}
-              </p>
-            )}
-            {selectedEvent.eventType === "artist" ? (
-              <button
-                className="event-sheet-signup"
-                type="button"
-                onClick={() => {
-                  setSelectedEvent(null);
-                  router.push(
-                    `/events/live-artist/${selectedEvent._id}`
-                  );
-                }}
-              >
-                View Details
-              </button>
-            ) : selectedEvent.isSoldOut ? (
-              <div className="event-sheet-soldout">Sold Out</div>
-            ) : (
-              <button
-                className="event-sheet-signup"
-                type="button"
-                onClick={() => {
-                  setSelectedEvent(null);
-                  navigateToPayment(
-                    selectedEvent._id,
-                    selectedEvent.title,
-                    selectedEvent.price,
-                    selectedEvent.isFree
-                  );
-                }}
-              >
-                Sign Up
-              </button>
-            )}
-          </div>
-        </div>
+      {popover && (
+        <EventPopover
+          event={popover.event}
+          anchorRect={popover.anchorRect}
+          mode={popover.mode}
+          eventColor={getEventColor(popover.event.eventType)}
+          onRequestClose={closePopover}
+          // Bridge-safe dismissal only applies to a hover preview — a pinned
+          // (clicked/tapped) popover stays open regardless of pointer
+          // position until explicitly dismissed.
+          onPointerEnter={popover.mode === "hover" ? cancelClose : () => {}}
+          onPointerLeave={popover.mode === "hover" ? scheduleClose : () => {}}
+          onSignUp={() => {
+            const { _id, title, price, isFree } = popover.event;
+            closePopover();
+            navigateToPayment(_id, title, price, isFree);
+          }}
+          onViewDetails={() => {
+            const { _id } = popover.event;
+            closePopover();
+            router.push(`/events/live-artist/${_id}`);
+          }}
+        />
       )}
     </div>
   );

--- a/components/calendar/NewCalendar.tsx
+++ b/components/calendar/NewCalendar.tsx
@@ -585,7 +585,7 @@ export default function NewCalendar() {
           const isSoldOut =
             eventType !== "artist" && currentSignups >= maxParticipants;
           tooltipContent += `<div class="tooltip-hint">${
-            isSoldOut ? "Sold out" : "Click for details"
+            isSoldOut ? "Sold out" : "Click the calendar event for details"
           }</div>`;
 
           tooltip.innerHTML = tooltipContent;

--- a/components/calendar/calendar.css
+++ b/components/calendar/calendar.css
@@ -188,6 +188,20 @@
   overflow: visible !important;
   position: relative;
   cursor: pointer;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+/* The event chip is the real click target (the hover tooltip above it is a
+   non-interactive preview) — reinforce that visually on hover/keyboard focus
+   so it's obvious what to click, since the tooltip's own text can't do it. */
+.fc-event:hover {
+  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.35);
+  transform: translateY(-1px);
+}
+
+.fc-event:focus-visible {
+  outline: 2px solid var(--color-primary, #0c4a6e);
+  outline-offset: 2px;
 }
 
 .fc-event-title {

--- a/components/calendar/calendar.css
+++ b/components/calendar/calendar.css
@@ -191,9 +191,8 @@
   transition: box-shadow 0.15s ease, transform 0.15s ease;
 }
 
-/* The event chip is the real click target (the hover tooltip above it is a
-   non-interactive preview) — reinforce that visually on hover/keyboard focus
-   so it's obvious what to click, since the tooltip's own text can't do it. */
+/* Reinforce the chip as the interactive origin of the popover on hover and
+   keyboard focus, independent of whether the popover itself is open yet. */
 .fc-event:hover {
   box-shadow: 0 2px 8px rgba(12, 74, 110, 0.35);
   transform: translateY(-1px);
@@ -264,55 +263,82 @@
 }
 
 /* ============================================
-   Tooltip -- clean, brand-aligned
+   Event Popover -- single surface for preview + sign-up
+   (replaces the old non-interactive tooltip + separate event-sheet modal)
    ============================================ */
-.event-tooltip {
+.event-popover {
   position: fixed;
   background: white;
   border: 1px solid #e5e7eb;
   border-radius: 12px;
   padding: 16px 18px;
-  width: 280px;
+  width: 300px;
   max-width: 90vw;
+  max-height: 80vh;
   box-shadow: 0 8px 24px rgba(12, 74, 110, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
   font-size: 0.9em;
-  z-index: 99999 !important;
-  pointer-events: none;
+  z-index: 99999;
+  pointer-events: auto;
   white-space: normal;
   color: var(--color-text-primary, #111827);
   text-align: left;
   line-height: 1.5;
+  display: flex;
+  flex-direction: column;
 }
 
-/* Tooltip title */
-.tooltip-title {
+.event-popover-type {
+  align-self: flex-start;
+  display: inline-block;
+  color: white;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 3px 10px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.event-popover-title {
   font-weight: 700;
   font-size: 1.15em;
-  margin-bottom: 10px;
-  border-bottom: 2px solid #e5e7eb;
-  padding-bottom: 8px;
+  margin-bottom: 6px;
   color: var(--color-primary, #0c4a6e);
   letter-spacing: -0.01em;
 }
 
-/* Tooltip time */
-.tooltip-time {
-  margin-bottom: 6px;
+.event-popover-time {
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e5e7eb;
   color: var(--color-text-muted, #374151);
   font-weight: 600;
   font-size: 0.95em;
 }
 
-/* Tooltip type */
-.tooltip-type {
-  margin-bottom: 6px;
-  color: var(--color-text-subtle, #4b5563);
-  font-weight: 500;
-  text-transform: capitalize;
+.event-popover-body {
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: #cbd5e1 #f3f4f6;
 }
 
-/* Tooltip price */
-.tooltip-price {
+.event-popover-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.event-popover-body::-webkit-scrollbar-track {
+  background: #f3f4f6;
+  border-radius: 3px;
+}
+
+.event-popover-body::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 3px;
+}
+
+.event-popover-price {
   margin-bottom: 8px;
   color: var(--color-primary, #0c4a6e);
   font-weight: 700;
@@ -321,18 +347,17 @@
   padding: 5px 10px;
   border-radius: 6px;
   border: 1px solid #e0f2fe;
+  display: inline-block;
 }
 
-/* Tooltip participants */
-.tooltip-participants {
+.event-popover-participants {
   margin-bottom: 6px;
   color: var(--color-text-subtle, #4b5563);
   font-weight: 500;
   font-size: 0.9em;
 }
 
-/* Tooltip recurring */
-.tooltip-recurring {
+.event-popover-recurring {
   margin-bottom: 8px;
   color: var(--color-secondary, #0369a1);
   font-weight: 600;
@@ -343,10 +368,8 @@
   border: 1px solid #e0f2fe;
 }
 
-/* Tooltip description */
-.tooltip-description {
+.event-popover-description {
   margin-top: 10px;
-  margin-bottom: 10px;
   color: var(--color-text-subtle, #4b5563);
   line-height: 1.6;
   font-size: 0.9em;
@@ -354,179 +377,128 @@
   padding: 10px 12px;
   border-radius: 8px;
   border: 1px solid #f3f4f6;
-  max-height: 100px;
-  overflow-y: auto;
   word-wrap: break-word;
-  scrollbar-width: thin;
-  scrollbar-color: #cbd5e1 #f3f4f6;
 }
 
-.tooltip-description::-webkit-scrollbar {
-  width: 6px;
+.event-popover-actions {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  padding-top: 12px;
+  margin-top: 8px;
 }
 
-.tooltip-description::-webkit-scrollbar-track {
-  background: #f3f4f6;
-  border-radius: 3px;
-}
-
-.tooltip-description::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 3px;
-}
-
-.tooltip-description::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
-}
-
-/* Hint footer -- nudges the user to click for the full detail sheet */
-.tooltip-hint {
-  margin-top: 12px;
-  padding-top: 10px;
-  border-top: 1px solid #f1f5f9;
-  color: var(--color-text-subtle, #64748b);
-  font-weight: 600;
-  font-size: 0.82em;
-  text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-/* Sold out badge */
-.tooltip-soldout {
-  margin-top: 12px;
-}
-
-/* Signup button -- brand primary */
-.tooltip-signup {
-  margin-top: 12px;
-  text-align: center;
-}
-
-.tooltip-signup button {
+.event-popover-cta {
+  display: block;
+  width: 100%;
   background: var(--color-primary, #0c4a6e);
   color: white;
   border: none;
-  padding: 9px 20px;
+  padding: 10px 20px;
   border-radius: 8px;
   cursor: pointer;
-  font-weight: 600;
-  transition: background 0.2s ease, box-shadow 0.2s ease;
+  font-weight: 700;
   font-size: 0.9em;
-  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.2);
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.2);
 }
 
-.tooltip-signup button:hover {
+.event-popover-cta:hover {
   background: var(--color-primary-dark, #073a58);
   box-shadow: 0 4px 14px rgba(12, 74, 110, 0.3);
 }
 
-.tooltip-signup button:active {
+.event-popover-cta:active {
   box-shadow: 0 2px 6px rgba(12, 74, 110, 0.2);
 }
 
-/* ============================================
-   Responsive Tooltip
-   ============================================ */
-@media (max-width: 1024px) {
-  .event-tooltip {
-    width: 260px;
-    max-width: 85vw;
+.event-popover-soldout {
+  display: block;
+  width: 100%;
+  padding: 10px 20px;
+  text-align: center;
+  background: linear-gradient(135deg, #d32f2f, #f44336);
+  color: white;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 0.9em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.event-popover-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  color: #94a3b8;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+.event-popover-close:hover {
+  color: #475569;
+}
+
+/* Pinned popover (click/tap) reserves space for the close button. */
+.event-popover--pinned {
+  padding-right: 32px;
+}
+
+/* Compact = touch or narrow viewport: fixed bottom card instead of an
+   anchored floating popover (an anchored position is unreliable once there's
+   no precise hover point, and small screens don't have room beside a chip). */
+.event-popover--compact {
+  position: fixed !important;
+  left: 12px;
+  right: 12px;
+  bottom: max(12px, env(safe-area-inset-bottom));
+  top: auto;
+  width: auto;
+  max-width: none;
+  max-height: min(75dvh, 560px);
+  border-radius: 16px;
+  padding: 20px 20px 16px;
+  animation: popoverSlideUp 0.25s ease;
+}
+
+.event-popover--compact.event-popover--pinned {
+  padding-right: 20px;
+}
+
+.event-popover--compact .event-popover-close {
+  top: 12px;
+  right: 14px;
+}
+
+.event-popover-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 99998;
+  animation: popoverFadeIn 0.2s ease;
+}
+
+@keyframes popoverFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes popoverSlideUp {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
+@media (max-width: 1024px) and (min-width: 641px) {
+  .event-popover:not(.event-popover--compact) {
+    width: 270px;
     padding: 14px 16px;
     font-size: 0.85em;
-  }
-
-  .tooltip-title {
-    font-size: 1.1em;
-    margin-bottom: 8px;
-  }
-
-  .tooltip-description {
-    padding: 8px 10px;
-    font-size: 0.85em;
-  }
-}
-
-@media (max-width: 768px) {
-  .event-tooltip {
-    width: 240px;
-    max-width: 80vw;
-    padding: 12px 14px;
-    font-size: 0.8em;
-    border-radius: 10px;
-  }
-
-  .tooltip-title {
-    font-size: 1.05em;
-    margin-bottom: 6px;
-    padding-bottom: 6px;
-  }
-
-  .tooltip-time,
-  .tooltip-price,
-  .tooltip-recurring {
-    font-size: 0.9em;
-    margin-bottom: 5px;
-    padding: 4px 8px;
-  }
-
-  .tooltip-description {
-    padding: 6px 8px;
-    font-size: 0.8em;
-    margin-top: 8px;
-    margin-bottom: 8px;
-  }
-
-  .tooltip-signup {
-    margin-top: 10px;
-  }
-
-  .tooltip-signup button {
-    padding: 8px 16px;
-    font-size: 0.8em;
-  }
-}
-
-@media (max-width: 480px) {
-  .event-tooltip {
-    width: 220px;
-    max-width: 75vw;
-    padding: 10px 12px;
-    font-size: 0.75em;
-    border-radius: 8px;
-  }
-
-  .tooltip-title {
-    font-size: 1em;
-    margin-bottom: 5px;
-    padding-bottom: 4px;
-  }
-
-  .tooltip-time,
-  .tooltip-price,
-  .tooltip-recurring {
-    font-size: 0.85em;
-    margin-bottom: 4px;
-    padding: 3px 6px;
-  }
-
-  .tooltip-description {
-    padding: 5px 6px;
-    font-size: 0.75em;
-    margin-top: 6px;
-    margin-bottom: 6px;
-  }
-
-  .tooltip-signup {
-    margin-top: 8px;
-  }
-
-  .tooltip-signup button {
-    padding: 6px 12px;
-    font-size: 0.75em;
-    border-radius: 6px;
   }
 }
 
@@ -548,151 +520,3 @@
   }
 }
 
-/* ============================================
-   Event Detail Sheet (tap-to-view)
-   ============================================ */
-.event-sheet-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 100000;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  animation: sheetFadeIn 0.2s ease;
-}
-
-.event-sheet {
-  background: white;
-  width: 100%;
-  max-width: 500px;
-  max-height: 85vh;
-  overflow-y: auto;
-  border-radius: 20px 20px 0 0;
-  padding: 24px 20px 32px;
-  position: relative;
-  animation: sheetSlideUp 0.3s ease;
-}
-
-@media (min-width: 769px) {
-  .event-sheet-overlay {
-    align-items: center;
-  }
-
-  .event-sheet {
-    border-radius: 16px;
-    max-width: 420px;
-    animation: sheetFadeIn 0.2s ease;
-  }
-}
-
-.event-sheet-close {
-  position: absolute;
-  top: 12px;
-  right: 16px;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: #94a3b8;
-  cursor: pointer;
-  padding: 4px 8px;
-  line-height: 1;
-}
-
-.event-sheet-close:hover {
-  color: #475569;
-}
-
-.event-sheet-type {
-  display: inline-block;
-  color: white;
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 3px 10px;
-  border-radius: 4px;
-  margin-bottom: 8px;
-}
-
-.event-sheet-title {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--color-primary, #0c4a6e);
-  margin: 0 0 8px;
-  line-height: 1.3;
-  font-family: var(--font-eb-garamond);
-}
-
-.event-sheet-time {
-  color: #374151;
-  font-weight: 600;
-  font-size: 0.95rem;
-  margin: 0 0 6px;
-}
-
-.event-sheet-price {
-  color: var(--color-primary, #0c4a6e);
-  font-weight: 700;
-  font-size: 1.1rem;
-  margin: 0 0 12px;
-  background: var(--color-light, #f0f9ff);
-  display: inline-block;
-  padding: 4px 12px;
-  border-radius: 6px;
-  border: 1px solid #e0f2fe;
-}
-
-.event-sheet-description {
-  color: #4b5563;
-  font-size: 0.9rem;
-  line-height: 1.6;
-  margin: 0 0 16px;
-  max-height: 120px;
-  overflow-y: auto;
-}
-
-.event-sheet-signup {
-  display: block;
-  width: 100%;
-  background: var(--color-primary, #0c4a6e);
-  color: white;
-  border: none;
-  padding: 12px 24px;
-  border-radius: 10px;
-  cursor: pointer;
-  font-weight: 700;
-  font-size: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  transition: background 0.2s ease;
-  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.2);
-}
-
-.event-sheet-signup:hover {
-  background: var(--color-primary-dark, #073a58);
-}
-
-.event-sheet-soldout {
-  display: block;
-  width: 100%;
-  padding: 12px 24px;
-  text-align: center;
-  background: linear-gradient(135deg, #d32f2f, #f44336);
-  color: white;
-  border-radius: 10px;
-  font-weight: 700;
-  font-size: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-@keyframes sheetFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes sheetSlideUp {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
-}


### PR DESCRIPTION
## Summary

Two iterations on the calendar interaction, per live feedback:

1. First pass: the hover tooltip said "Click for details" but was deliberately non-interactive (`pointer-events: none`) to avoid a hover-bridge flicker bug, so the actual click target was a separate small chip underneath. Fixed the misleading copy and added a hover/focus affordance on the chip. Consulted Codex for a second opinion on this fix.
2. Rejected in review: "I don't like that, I just want sign up in the tooltip, no expanded modal, it's the same information twice!" — the hover preview and the click-triggered event-sheet modal both showed title/time/price/description, just to open a near-duplicate on click.

Final design (Codex-consulted architecture, since making the popover interactive reintroduces the exact hover-bridge problem the old code was dodging):

- **One `EventPopover` component**, portal-rendered React (replacing raw `document.createElement`/`innerHTML` DOM manipulation — also closes an innerHTML-with-dynamic-content injection surface).
- **Bridge-safe hover**: 220ms open-intent delay (unchanged) + a new 180ms close-grace-period that only elapses once the pointer has left both the chip and the popover, so crossing the gap to click Sign Up doesn't kill it first.
- **Click/tap pins the same popover** (close button, Escape, outside-click dismiss). Compact viewports (touch/coarse pointer/≤640px) render it as a fixed bottom card instead of an anchored floater.
- Dismissed on scroll/resize/month-navigation (position is anchored once at open time, not tracked live).
- **Deleted the entire event-sheet modal** (~230 lines of JSX + CSS) and the old tooltip CSS.
- `toPopoverEvent()` centralizes what was previously duplicated (and already drifting) between the hover and click code paths.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (one pre-existing, unrelated warning on `generateRecurringEvents`)
- [x] Full test suite (410 tests) passing
- [x] New `__tests__/calendar/EventPopover.test.ts` covering the pure position-calculation helper (edge-clamping, above/below flip, vertical-centering fallback)
- [x] Verified live: hover → popover → moving pointer onto the popover and clicking Sign Up navigates correctly to `/payments` with the right event/price prefilled (the hover-bridge case); click/tap opens pinned with working close button; Escape and outside-click dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)