### PR TITLE
release: checkout/UI fixes, calendar popover redesign, Square order linking

### DIFF
--- a/__tests__/calendar/EventPopover.test.ts
+++ b/__tests__/calendar/EventPopover.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { calculatePopoverPosition } from "@/components/calendar/EventPopover";
+
+function rect(partial: Partial<DOMRect>): DOMRect {
+  const left = partial.left ?? 0;
+  const top = partial.top ?? 0;
+  const width = partial.width ?? 0;
+  const height = partial.height ?? 0;
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: partial.right ?? left + width,
+    bottom: partial.bottom ?? top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
+  Object.defineProperty(window, "innerHeight", { writable: true, configurable: true, value: height });
+}
+
+describe("calculatePopoverPosition", () => {
+  beforeEach(() => {
+    setViewport(1024, 768);
+  });
+
+  it("centers above the anchor when there's room above", () => {
+    const anchor = rect({ left: 400, top: 300, width: 100, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformY).toBe("-100%");
+    expect(result.transformX).toBe("-50%");
+    expect(result.top).toBe(anchor.top - 10);
+    expect(result.left).toBe(anchor.left + anchor.width / 2);
+  });
+
+  it("flips below the anchor when there's no room above but room below", () => {
+    const anchor = rect({ left: 400, top: 20, width: 100, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformY).toBe("0%");
+    expect(result.top).toBe(anchor.bottom + 10);
+  });
+
+  it("clamps to the left edge instead of running off-screen", () => {
+    const anchor = rect({ left: 10, top: 300, width: 50, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformX).toBe("0%");
+    expect(result.left).toBe(16); // margin
+  });
+
+  it("clamps to the right edge instead of running off-screen", () => {
+    const anchor = rect({ left: 990, top: 300, width: 30, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformX).toBe("-100%");
+    expect(result.left).toBe(1024 - 16); // viewportWidth - margin
+  });
+
+  it("centers vertically when there's no room above or below", () => {
+    setViewport(1024, 220);
+    const anchor = rect({ left: 400, top: 100, width: 100, height: 30 });
+    const popover = rect({ width: 300, height: 200 });
+    const result = calculatePopoverPosition(anchor, popover);
+    expect(result.transformY).toBe("-50%");
+    expect(result.top).toBe(110); // viewportHeight / 2
+  });
+});

--- a/__tests__/checkout/storeCheckoutRoute.test.ts
+++ b/__tests__/checkout/storeCheckoutRoute.test.ts
@@ -11,8 +11,18 @@ vi.mock("@/lib/checkout/storePricing", () => ({
 }));
 
 const paymentsCreate = vi.fn();
+const ordersCreate = vi.fn();
+const ordersUpdate = vi.fn();
+const ordersPay = vi.fn();
 vi.mock("@/lib/square/client", () => ({
-  getSquareClient: () => ({ payments: { create: (...a: unknown[]) => paymentsCreate(...a) } }),
+  getSquareClient: () => ({
+    payments: { create: (...a: unknown[]) => paymentsCreate(...a) },
+    orders: {
+      create: (...a: unknown[]) => ordersCreate(...a),
+      update: (...a: unknown[]) => ordersUpdate(...a),
+      pay: (...a: unknown[]) => ordersPay(...a),
+    },
+  }),
 }));
 
 const findOrCreateCustomer = vi.fn();
@@ -141,6 +151,7 @@ beforeEach(() => {
   // Launch gate: the route 503s unless the shop is enabled (lib/constants/
   // featureFlags.ts). Every test here exercises the route past that gate.
   vi.stubEnv("NEXT_PUBLIC_SHOP_ENABLED", "true");
+  vi.stubEnv("SQUARE_LOCATION_ID", "loc_test_1");
   priceCartFromCatalog.mockResolvedValue({
     items: [
       { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
@@ -148,6 +159,9 @@ beforeEach(() => {
     subtotalCents: 8800,
   });
   resolveShippingRate.mockResolvedValue(RATE);
+  ordersCreate.mockResolvedValue({ order: { id: "sqorder_1", version: 1 } });
+  ordersUpdate.mockResolvedValue({ order: { id: "sqorder_1", version: 2, state: "CANCELED" } });
+  ordersPay.mockResolvedValue({ order: { id: "sqorder_1", state: "COMPLETED" } });
   paymentsCreate.mockResolvedValue({
     payment: { id: "pay_1", status: "COMPLETED", receiptUrl: "https://squareup.com/receipt/pay_1" },
   });
@@ -183,6 +197,30 @@ describe("POST /api/store/checkout", () => {
     expect(paymentsCreate).toHaveBeenCalledTimes(1);
     expect(paymentsCreate.mock.calls[0][0].amountMoney.amount).toBe(BigInt(9991));
 
+    // A real Square Order is created BEFORE the charge, with catalog-linked line
+    // items — this is the inventory-decrement fix. One line per cart item, plus a
+    // plain shipping+tax line, no gift-card discount on this order.
+    expect(ordersCreate).toHaveBeenCalledTimes(1);
+    const orderRequest = ordersCreate.mock.calls[0][0];
+    expect(orderRequest.order.locationId).toBe("loc_test_1");
+    expect(orderRequest.order.lineItems).toEqual([
+      {
+        catalogObjectId: "var_1",
+        quantity: "1",
+        basePriceMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+      {
+        name: "Shipping & Tax",
+        quantity: "1",
+        basePriceMoney: { amount: BigInt(1191), currency: "USD" },
+      },
+    ]);
+    expect(orderRequest.order.discounts).toBeUndefined();
+
+    // The payment is linked to that order.
+    expect(paymentsCreate.mock.calls[0][0].orderId).toBe("sqorder_1");
+    expect(paymentsCreate.mock.calls[0][0].locationId).toBe("loc_test_1");
+
     expect(orderCreate).toHaveBeenCalledTimes(1);
     const order = orderCreate.mock.calls[0][0];
     expect(order.totalCents).toBe(9991);
@@ -192,9 +230,63 @@ describe("POST /api/store/checkout", () => {
     expect(order.status).toBe("paid");
     expect(purchaseLabelForOrder).toHaveBeenCalledWith("order_1");
 
-    // Square receipt captured on the order + returned for the confirmation page.
+    // Square receipt + order id captured on the order + receipt returned for the
+    // confirmation page.
     expect(order.square.receiptUrl).toBe("https://squareup.com/receipt/pay_1");
+    expect(order.square.orderId).toBe("sqorder_1");
     expect(data.receiptUrl).toBe("https://squareup.com/receipt/pay_1");
+  });
+
+  it("reuses the same idempotency key for the Square order and the payment", async () => {
+    await POST(req(baseBody({ idempotencyKey: "idem-shared" })));
+    expect(ordersCreate.mock.calls[0][0].idempotencyKey).toBe("idem-shared");
+    expect(paymentsCreate.mock.calls[0][0].idempotencyKey).toBe("idem-shared");
+  });
+
+  it("maps a multi-item cart to one Square order line item per line", async () => {
+    priceCartFromCatalog.mockResolvedValue({
+      items: [
+        { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 2, unitPriceCents: 8800 },
+        { squareCatalogItemId: "item_2", squareVariationId: "var_2", name: "Mushroom Kit", variationName: "Regular", quantity: 1, unitPriceCents: 1500 },
+      ],
+      subtotalCents: 19100,
+    });
+    const res = await POST(req(baseBody()));
+    expect(res.status).toBe(200);
+
+    const lineItems = ordersCreate.mock.calls[0][0].order.lineItems;
+    expect(lineItems[0]).toEqual({
+      catalogObjectId: "var_1",
+      quantity: "2",
+      basePriceMoney: { amount: BigInt(8800), currency: "USD" },
+    });
+    expect(lineItems[1]).toEqual({
+      catalogObjectId: "var_2",
+      quantity: "1",
+      basePriceMoney: { amount: BigInt(1500), currency: "USD" },
+    });
+  });
+
+  it("fails closed (no charge, no order saved) when Square order creation fails", async () => {
+    ordersCreate.mockRejectedValue(new Error("Square Orders API down"));
+    const res = await POST(req(baseBody()));
+
+    expect(res.status).toBe(500);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(orderCreate).not.toHaveBeenCalled();
+  });
+
+  it("best-effort cancels the Square order when the payment is not COMPLETED (non-fatal on cancel failure)", async () => {
+    paymentsCreate.mockResolvedValue({ payment: { id: "pay_x", status: "FAILED" } });
+    ordersUpdate.mockRejectedValue(new Error("cancel also failed"));
+
+    const res = await POST(req(baseBody()));
+
+    expect(res.status).toBe(400);
+    expect(orderCreate).not.toHaveBeenCalled();
+    expect(ordersUpdate).toHaveBeenCalledTimes(1);
+    expect(ordersUpdate.mock.calls[0][0].orderId).toBe("sqorder_1");
+    expect(ordersUpdate.mock.calls[0][0].order.state).toBe("CANCELED");
   });
 
   it("ships to the RECIPIENT on a gift order while charging the BUYER (A1)", async () => {
@@ -233,6 +325,80 @@ describe("POST /api/store/checkout", () => {
     expect(giftCardRedeem).toHaveBeenCalledWith("gc_1", 8800, "buyer@example.com");
     const order = orderCreate.mock.calls[0][0];
     expect(order.giftCard).toEqual({ giftCardId: "gc_1", amountCents: 8800 });
+
+    // The Square order carries an ORDER-scoped FIXED_AMOUNT discount for the
+    // applied gift card, so numbers (never Square's own tax/discount engine)
+    // stay the single source of truth for what's charged.
+    const orderRequest = ordersCreate.mock.calls[0][0];
+    expect(orderRequest.order.discounts).toEqual([
+      {
+        name: "Gift Card Applied",
+        type: "FIXED_AMOUNT",
+        scope: "ORDER",
+        amountMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+    ]);
+  });
+
+  it("completes the Square order with no linked payment when a gift card covers the entire total ($0 charge)", async () => {
+    // Free shipping + $0 tax + a gift card covering the full subtotal exactly.
+    resolveShippingRate.mockResolvedValue({ ...RATE, rateCents: 0 });
+    priceCartFromCatalog.mockResolvedValue({
+      items: [
+        { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
+      ],
+      subtotalCents: 8800,
+    });
+    giftCardGetById.mockResolvedValue({ state: "ACTIVE", balanceMoney: { amount: 8800 } });
+    giftCardRedeem.mockResolvedValue({});
+
+    const res = await POST(
+      req({
+        ...baseBody({ giftCard: { giftCardId: "gc_1", amountCents: 8800 } }),
+        shippingAddress: { ...SELF_ADDRESS, stateProvince: "NY" }, // no NJ tax
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(ordersPay).toHaveBeenCalledTimes(1);
+    expect(ordersPay.mock.calls[0][0]).toEqual({
+      orderId: "sqorder_1",
+      idempotencyKey: "idem-1",
+      paymentIds: [],
+    });
+
+    const order = orderCreate.mock.calls[0][0];
+    expect(order.status).toBe("paid");
+    expect(order.square.orderId).toBe("sqorder_1");
+    expect(order.square.paymentId).toBeUndefined();
+  });
+
+  it("cancels the Square order and never saves it when gift card redemption fails on a $0-charge order", async () => {
+    resolveShippingRate.mockResolvedValue({ ...RATE, rateCents: 0 });
+    priceCartFromCatalog.mockResolvedValue({
+      items: [
+        { squareCatalogItemId: "item_1", squareVariationId: "var_1", name: "Garden Art Kit", variationName: "Regular", quantity: 1, unitPriceCents: 8800 },
+      ],
+      subtotalCents: 8800,
+    });
+    giftCardGetById.mockResolvedValue({ state: "ACTIVE", balanceMoney: { amount: 8800 } });
+    giftCardRedeem.mockRejectedValue(new Error("redemption failed"));
+
+    const res = await POST(
+      req({
+        ...baseBody({ giftCard: { giftCardId: "gc_1", amountCents: 8800 } }),
+        shippingAddress: { ...SELF_ADDRESS, stateProvince: "NY" },
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(ordersPay).not.toHaveBeenCalled();
+    expect(ordersUpdate).toHaveBeenCalledTimes(1);
+    expect(ordersUpdate.mock.calls[0][0].order.state).toBe("CANCELED");
+    expect(orderCreate).not.toHaveBeenCalled();
   });
 
   it("rejects (400) and never charges when the cart fails price integrity", async () => {
@@ -242,6 +408,7 @@ describe("POST /api/store/checkout", () => {
 
     expect(res.status).toBe(400);
     expect(data.error).toBe("Item unavailable");
+    expect(ordersCreate).not.toHaveBeenCalled();
     expect(paymentsCreate).not.toHaveBeenCalled();
     expect(orderCreate).not.toHaveBeenCalled();
   });
@@ -250,6 +417,7 @@ describe("POST /api/store/checkout", () => {
     resolveShippingRate.mockRejectedValue(new PriceIntegrityError("Shipping rate unavailable"));
     const res = await POST(req(baseBody()));
     expect(res.status).toBe(400);
+    expect(ordersCreate).not.toHaveBeenCalled();
     expect(paymentsCreate).not.toHaveBeenCalled();
     expect(orderCreate).not.toHaveBeenCalled();
   });

--- a/__tests__/square/storeOrders.test.ts
+++ b/__tests__/square/storeOrders.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PricedItem } from "@/lib/checkout/storePricing";
+
+const ordersCreate = vi.fn();
+const ordersUpdate = vi.fn();
+const ordersPay = vi.fn();
+vi.mock("@/lib/square/client", () => ({
+  getSquareClient: () => ({
+    orders: {
+      create: (...a: unknown[]) => ordersCreate(...a),
+      update: (...a: unknown[]) => ordersUpdate(...a),
+      pay: (...a: unknown[]) => ordersPay(...a),
+    },
+  }),
+}));
+
+import {
+  buildStoreOrderLineItems,
+  createSquareOrderForCart,
+  cancelSquareOrderBestEffort,
+  completeZeroChargeOrder,
+} from "@/lib/square/storeOrders";
+
+const ITEM: PricedItem = {
+  squareCatalogItemId: "item_1",
+  squareVariationId: "var_1",
+  name: "Garden Art Kit",
+  variationName: "Regular",
+  quantity: 2,
+  unitPriceCents: 8800,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("SQUARE_LOCATION_ID", "loc_test_1");
+  ordersCreate.mockResolvedValue({ order: { id: "sqorder_1", version: 1 } });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("buildStoreOrderLineItems", () => {
+  it("maps a priced item to a catalog-linked line item with a string quantity", () => {
+    const lineItems = buildStoreOrderLineItems([ITEM], 0);
+    expect(lineItems).toEqual([
+      {
+        catalogObjectId: "var_1",
+        quantity: "2",
+        basePriceMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+    ]);
+  });
+
+  it("appends a plain shipping+tax line only when non-zero", () => {
+    expect(buildStoreOrderLineItems([ITEM], 0)).toHaveLength(1);
+
+    const withShipping = buildStoreOrderLineItems([ITEM], 1191);
+    expect(withShipping).toHaveLength(2);
+    expect(withShipping[1]).toEqual({
+      name: "Shipping & Tax",
+      quantity: "1",
+      basePriceMoney: { amount: BigInt(1191), currency: "USD" },
+    });
+    expect(withShipping[1].catalogObjectId).toBeUndefined();
+  });
+
+  it("maps multiple items 1:1, preserving order", () => {
+    const second: PricedItem = { ...ITEM, squareCatalogItemId: "item_2", squareVariationId: "var_2", quantity: 1, unitPriceCents: 1500 };
+    const lineItems = buildStoreOrderLineItems([ITEM, second], 0);
+    expect(lineItems).toHaveLength(2);
+    expect(lineItems[0].catalogObjectId).toBe("var_1");
+    expect(lineItems[1].catalogObjectId).toBe("var_2");
+  });
+});
+
+describe("createSquareOrderForCart", () => {
+  it("creates an order with the location id, line items, and no discount by default", async () => {
+    const result = await createSquareOrderForCart({
+      pricedItems: [ITEM],
+      shippingAndTaxCents: 1191,
+      giftCardAppliedCents: 0,
+      idempotencyKey: "idem-1",
+    });
+
+    expect(result).toEqual({ orderId: "sqorder_1", version: 1, locationId: "loc_test_1" });
+    const request = ordersCreate.mock.calls[0][0];
+    expect(request.idempotencyKey).toBe("idem-1");
+    expect(request.order.locationId).toBe("loc_test_1");
+    expect(request.order.lineItems).toHaveLength(2);
+    expect(request.order.discounts).toBeUndefined();
+  });
+
+  it("adds an ORDER-scoped FIXED_AMOUNT discount when a gift card was applied", async () => {
+    await createSquareOrderForCart({
+      pricedItems: [ITEM],
+      shippingAndTaxCents: 0,
+      giftCardAppliedCents: 8800,
+      idempotencyKey: "idem-1",
+    });
+
+    const request = ordersCreate.mock.calls[0][0];
+    expect(request.order.discounts).toEqual([
+      {
+        name: "Gift Card Applied",
+        type: "FIXED_AMOUNT",
+        scope: "ORDER",
+        amountMoney: { amount: BigInt(8800), currency: "USD" },
+      },
+    ]);
+  });
+
+  it("throws (fail closed) when SQUARE_LOCATION_ID is not configured", async () => {
+    vi.stubEnv("SQUARE_LOCATION_ID", "");
+    await expect(
+      createSquareOrderForCart({
+        pricedItems: [ITEM],
+        shippingAndTaxCents: 0,
+        giftCardAppliedCents: 0,
+        idempotencyKey: "idem-1",
+      })
+    ).rejects.toThrow("Square location ID is not configured");
+    expect(ordersCreate).not.toHaveBeenCalled();
+  });
+
+  it("throws (fail closed) when Square returns an order with no id or version", async () => {
+    ordersCreate.mockResolvedValue({ order: {} });
+    await expect(
+      createSquareOrderForCart({
+        pricedItems: [ITEM],
+        shippingAndTaxCents: 0,
+        giftCardAppliedCents: 0,
+        idempotencyKey: "idem-1",
+      })
+    ).rejects.toThrow("Failed to create Square order for cart");
+  });
+});
+
+describe("cancelSquareOrderBestEffort", () => {
+  it("cancels the order with its current version and CANCELED state", async () => {
+    ordersUpdate.mockResolvedValue({ order: { id: "sqorder_1", state: "CANCELED" } });
+    await cancelSquareOrderBestEffort("sqorder_1", 1);
+
+    expect(ordersUpdate).toHaveBeenCalledWith({
+      orderId: "sqorder_1",
+      order: { locationId: "loc_test_1", version: 1, state: "CANCELED" },
+    });
+  });
+
+  it("swallows a thrown error and never rejects", async () => {
+    ordersUpdate.mockRejectedValue(new Error("Square is down"));
+    await expect(cancelSquareOrderBestEffort("sqorder_1", 1)).resolves.toBeUndefined();
+  });
+});
+
+describe("completeZeroChargeOrder", () => {
+  it("pays the order with no linked payment ids", async () => {
+    await completeZeroChargeOrder("sqorder_1", "idem-1");
+    expect(ordersPay).toHaveBeenCalledWith({
+      orderId: "sqorder_1",
+      idempotencyKey: "idem-1",
+      paymentIds: [],
+    });
+  });
+
+  it("swallows a thrown error and never rejects", async () => {
+    ordersPay.mockRejectedValue(new Error("Square is down"));
+    await expect(completeZeroChargeOrder("sqorder_1", "idem-1")).resolves.toBeUndefined();
+  });
+});

--- a/app/api/store/checkout/route.ts
+++ b/app/api/store/checkout/route.ts
@@ -1,6 +1,13 @@
 /**
  * Store Checkout API
- * POST: Charges Square, saves the Order to MongoDB, and sends the confirmation email.
+ * POST: Creates a Square Order, charges Square, saves the Order to MongoDB, and
+ * sends the confirmation email.
+ *
+ * SQUARE ORDER LINKING: every charge is linked to a real Square Order whose line
+ * items reference the actual catalog objects being sold (lib/square/storeOrders.ts),
+ * mirroring the pattern in lib/square/gift-cards.ts. This is what makes Square's own
+ * per-item inventory count decrement on a sale — a bare payments.create() with no
+ * orderId/catalogObjectId does NOT touch inventory at all.
  *
  * PRICE INTEGRITY: client-supplied money is NOT trusted. The subtotal is recomputed
  * from the Square catalog and shipping from a fresh Shippo re-quote (lib/checkout/
@@ -36,6 +43,11 @@ import { squareCustomerService } from "@/lib/square/customers";
 import { squareCardService } from "@/lib/square/cards";
 import { resolveUserSquareCustomerId } from "@/lib/square/userCustomer";
 import { giftCardService } from "@/lib/square/gift-cards";
+import {
+  createSquareOrderForCart,
+  cancelSquareOrderBestEffort,
+  completeZeroChargeOrder,
+} from "@/lib/square/storeOrders";
 import {
   priceCartFromCatalog,
   resolveShippingRate,
@@ -233,19 +245,39 @@ export async function POST(request: Request): Promise<Response> {
       }
     }
 
+    // Build the idempotency key ONCE and reuse it for both the Square order and
+    // the payment/pay-order call below — Square scopes idempotency per endpoint,
+    // so this is safe, and it keeps a client retry (lost response) from ever
+    // creating a second, orphaned order while the payment call dedupes to the
+    // original.
+    const squareIdempotencyKey = normalizeIdempotencyKey(body.idempotencyKey);
+
+    // Create the real Square Order FIRST, with catalog-linked line items, so a
+    // completed sale decrements Square's own inventory (lib/square/storeOrders.ts).
+    // FAIL CLOSED: if this throws, the outer catch returns an error and no charge
+    // is ever attempted — never fall back to a bare, catalog-less payment.
+    const shippingAndTaxCents = serverRate.rateCents + taxCents;
+    const squareOrder = await createSquareOrderForCart({
+      pricedItems: pricedCart.items,
+      shippingAndTaxCents,
+      giftCardAppliedCents,
+      idempotencyKey: squareIdempotencyKey,
+    });
+
     // Step 1: Charge the card portion (skipped when a gift card covers the full total).
     let squarePaymentId: string | undefined;
     let squareReceiptUrl: string | undefined;
     if (chargeCents > 0) {
       const usingSavedCard = Boolean(body.savedCardId);
       if (!usingSavedCard && !paymentToken) {
+        await cancelSquareOrderBestEffort(squareOrder.orderId, squareOrder.version);
         return NextResponse.json(
           { error: "Payment information is required" },
           { status: 400 }
         );
       }
       const paymentResult = await squareClient.payments.create({
-        idempotencyKey: normalizeIdempotencyKey(body.idempotencyKey),
+        idempotencyKey: squareIdempotencyKey,
         // A saved card charges by its card id; a new card by the one-time nonce.
         sourceId: body.savedCardId ?? (paymentToken as string),
         ...(accountCustomerId ? { customerId: accountCustomerId } : {}),
@@ -256,6 +288,8 @@ export async function POST(request: Request): Promise<Response> {
           amount: BigInt(chargeCents),
           currency: "USD",
         },
+        orderId: squareOrder.orderId,
+        locationId: squareOrder.locationId,
         buyerEmailAddress: customer.email,
         shippingAddress: {
           addressLine1: shippingAddress.addressLine1,
@@ -275,6 +309,7 @@ export async function POST(request: Request): Promise<Response> {
       const payment = paymentResult.payment;
       if (payment?.status !== "COMPLETED") {
         console.error("[API-STORE-CHECKOUT-POST] Square payment not completed:", payment?.status);
+        await cancelSquareOrderBestEffort(squareOrder.orderId, squareOrder.version);
         return NextResponse.json(
           { error: "Payment was not completed", status: payment?.status },
           { status: 400 }
@@ -315,12 +350,21 @@ export async function POST(request: Request): Promise<Response> {
       } catch (giftCardError) {
         console.error("[API-STORE-CHECKOUT-POST] Gift card redemption failed:", giftCardError);
         if (chargeCents === 0) {
+          await cancelSquareOrderBestEffort(squareOrder.orderId, squareOrder.version);
           return NextResponse.json(
             { error: "Gift card could not be redeemed. No charge was made." },
             { status: 400 }
           );
         }
       }
+    }
+
+    // When a gift card covers the entire total, there's no payment to link the
+    // order to — complete it directly so Square's inventory decrement still
+    // fires. Runs AFTER gift-card redemption (and its failure/cancel path above)
+    // so the order is only ever finalized once the free order is actually real.
+    if (chargeCents === 0) {
+      await completeZeroChargeOrder(squareOrder.orderId, squareIdempotencyKey);
     }
 
     // Step 2: Save Order to MongoDB — with SERVER-derived prices and the FRESH
@@ -353,6 +397,7 @@ export async function POST(request: Request): Promise<Response> {
       shippingAddress,
       square: {
         paymentId: squarePaymentId,
+        orderId: squareOrder.orderId,
         receiptUrl: squareReceiptUrl,
       },
       giftCard:

--- a/app/globals.css
+++ b/app/globals.css
@@ -165,6 +165,22 @@
   }
 }
 
+/* Browsers default <button> to cursor: default, not pointer (unlike <a> —
+   that's a common assumption, but it's wrong). Tailwind doesn't correct this
+   in Preflight either, so every button needs cursor-pointer added by hand or
+   it silently falls back to the arrow cursor — which is how this app ended
+   up with the inconsistency (some buttons styled it, most didn't, e.g. the
+   cart icon and several account-page buttons had no pointer at all). Set the
+   sane default here instead of chasing every instance; components in the
+   utilities layer (e.g. Button.tsx's disabled:cursor-not-allowed) still win
+   over this since utilities are declared after base in Tailwind's layer order. */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 /* Cart "item added" feedback — badge / button pop. */
 @keyframes cartBump {
   0% {

--- a/components/calendar/EventPopover.tsx
+++ b/components/calendar/EventPopover.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactElement } from "react";
+import { createPortal } from "react-dom";
+
+export interface PopoverEvent {
+  title: string;
+  eventType: string;
+  timeDisplay: string;
+  price?: number;
+  isFree?: boolean;
+  description?: string;
+  currentSignups: number;
+  isRecurring?: boolean;
+  recurringPattern?: string;
+  recurringEndDate?: string | Date;
+  _id: string;
+  isSoldOut: boolean;
+}
+
+export type PopoverMode = "hover" | "pinned";
+
+const COMPACT_QUERY = "(hover: none), (pointer: coarse), (max-width: 640px)";
+
+interface EventPopoverProps {
+  event: PopoverEvent;
+  anchorRect: DOMRect;
+  mode: PopoverMode;
+  eventColor: string;
+  onRequestClose: () => void;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+  onSignUp: () => void;
+  onViewDetails: () => void;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  artist: "Live Demo",
+  camp: "Art Camp",
+  workshop: "Workshop",
+  event: "Workshop",
+};
+
+function typeLabel(eventType: string): string {
+  return TYPE_LABELS[eventType] ?? "Class";
+}
+
+/** Anchor the popover near the event chip, flipping above/below and clamping
+ * horizontally so it never runs off-screen. Positioned once on open — the
+ * caller closes the popover on scroll/resize/navigation rather than trying
+ * to keep a live position in sync with a moving anchor. */
+export function calculatePopoverPosition(
+  anchorRect: DOMRect,
+  popoverRect: DOMRect
+): { left: number; top: number; transformX: string; transformY: string } {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const margin = 16;
+
+  let left = anchorRect.left + anchorRect.width / 2;
+  let top = anchorRect.top - 10;
+  let transformX = "-50%";
+  let transformY = "-100%";
+
+  const halfWidth = popoverRect.width / 2;
+  if (left - halfWidth < margin) {
+    left = margin;
+    transformX = "0%";
+  } else if (left + halfWidth > viewportWidth - margin) {
+    left = viewportWidth - margin;
+    transformX = "-100%";
+  }
+
+  const spaceAbove = anchorRect.top;
+  const spaceBelow = viewportHeight - anchorRect.bottom;
+  const height = popoverRect.height;
+
+  if (spaceAbove < height + margin && spaceBelow > height + margin) {
+    top = anchorRect.bottom + 10;
+    transformY = "0%";
+  } else if (spaceAbove < height + margin && spaceBelow < height + margin) {
+    top = viewportHeight / 2;
+    transformY = "-50%";
+    if (left < viewportWidth / 2) {
+      left = Math.max(margin, anchorRect.right + 10);
+      transformX = "0%";
+    } else {
+      left = Math.min(viewportWidth - margin, anchorRect.left - 10);
+      transformX = "-100%";
+    }
+  }
+
+  return { left, top, transformX, transformY };
+}
+
+export default function EventPopover({
+  event,
+  anchorRect,
+  mode,
+  eventColor,
+  onRequestClose,
+  onPointerEnter,
+  onPointerLeave,
+  onSignUp,
+  onViewDetails,
+}: EventPopoverProps): ReactElement | null {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [style, setStyle] = useState<CSSProperties>({ visibility: "hidden" });
+  // Compact (fixed bottom sheet) below the same breakpoint the rest of the
+  // calendar already treats as mobile — matches calendar.css's 640px/768px cuts.
+  const [isCompact, setIsCompact] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(COMPACT_QUERY).matches
+  );
+
+  useEffect(() => {
+    const query = window.matchMedia(COMPACT_QUERY);
+    const listener = (e: MediaQueryListEvent): void => setIsCompact(e.matches);
+    query.addEventListener("change", listener);
+    return () => query.removeEventListener("change", listener);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isCompact || !popoverRef.current) {
+      setStyle({});
+      return;
+    }
+    const rect = popoverRef.current.getBoundingClientRect();
+    const { left, top, transformX, transformY } = calculatePopoverPosition(
+      anchorRect,
+      rect
+    );
+    setStyle({
+      position: "fixed",
+      left,
+      top,
+      transform: `translate(${transformX}, ${transformY})`,
+    });
+  }, [anchorRect, isCompact]);
+
+  // Escape always closes. Outside click only closes a pinned popover — a
+  // hover popover is already dismissed by the pointer-leave timer.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") onRequestClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onRequestClose]);
+
+  useEffect(() => {
+    if (mode !== "pinned") return;
+    const onPointerDown = (e: PointerEvent): void => {
+      if (!popoverRef.current?.contains(e.target as Node)) {
+        onRequestClose();
+      }
+    };
+    // Delay one tick so the click that opened this popover doesn't also close it.
+    const id = window.setTimeout(
+      () => document.addEventListener("pointerdown", onPointerDown),
+      0
+    );
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [mode, onRequestClose]);
+
+  useEffect(() => {
+    if (mode === "pinned") closeButtonRef.current?.focus();
+  }, [mode]);
+
+  const currentSignups = event.currentSignups;
+  const showParticipants = currentSignups > 5 && event.eventType !== "artist";
+
+  const content = (
+    <>
+      {mode === "pinned" && isCompact && (
+        <div
+          className="event-popover-backdrop"
+          onClick={onRequestClose}
+          aria-hidden="true"
+        />
+      )}
+      <div
+        ref={popoverRef}
+        role="dialog"
+        aria-label={event.title}
+        className={`event-popover ${mode === "hover" ? "event-popover--hover" : "event-popover--pinned"} ${isCompact ? "event-popover--compact" : ""}`}
+        style={style}
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {mode === "pinned" && (
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="event-popover-close"
+            onClick={onRequestClose}
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        )}
+
+        <span
+          className="event-popover-type"
+          style={{ backgroundColor: eventColor }}
+        >
+          {typeLabel(event.eventType)}
+        </span>
+
+        <div className="event-popover-title">{event.title}</div>
+
+        {event.timeDisplay && (
+          <div className="event-popover-time">{event.timeDisplay}</div>
+        )}
+
+        <div className="event-popover-body">
+          {typeof event.price === "number" && event.price > 0 && (
+            <div className="event-popover-price">Price: ${event.price}</div>
+          )}
+          {(event.isFree || event.price === 0) && (
+            <div className="event-popover-price">Free</div>
+          )}
+
+          {showParticipants && (
+            <div className="event-popover-participants">
+              {currentSignups} / 20 signed up
+            </div>
+          )}
+
+          {event.isRecurring && (
+            <div className="event-popover-recurring">
+              Recurring {event.recurringPattern}
+              {event.recurringEndDate
+                ? ` until ${new Date(event.recurringEndDate).toLocaleDateString()}`
+                : ""}
+            </div>
+          )}
+
+          {event.description && (
+            <div className="event-popover-description">
+              {event.description}
+            </div>
+          )}
+        </div>
+
+        <div className="event-popover-actions">
+          {event.eventType === "artist" ? (
+            <button
+              type="button"
+              className="event-popover-cta"
+              onClick={onViewDetails}
+            >
+              View Details
+            </button>
+          ) : event.isSoldOut ? (
+            <div className="event-popover-soldout">Sold Out</div>
+          ) : (
+            <button
+              type="button"
+              className="event-popover-cta"
+              onClick={onSignUp}
+            >
+              Sign Up
+            </button>
+          )}
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/components/calendar/NewCalendar.tsx
+++ b/components/calendar/NewCalendar.tsx
@@ -9,6 +9,15 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import "./calendar.css";
 import { useRouter } from "next/navigation";
 import { CalendarEvent, ApiEvent } from "@/types/interfaces";
+import type { EventClickArg, EventHoveringArg } from "@fullcalendar/core";
+import EventPopover, { type PopoverEvent, type PopoverMode } from "./EventPopover";
+
+// Hover-intent delay: only open a preview once the pointer rests on an event,
+// so sweeping across stacked events doesn't spawn/flicker popovers.
+const HOVER_OPEN_DELAY_MS = 220;
+// Grace period before closing on pointer-leave, so crossing the gap between
+// the event chip and the popover (the "hover bridge") doesn't kill it early.
+const HOVER_CLOSE_DELAY_MS = 180;
 
 export default function NewCalendar() {
   const [calendarView, setCalendarView] = useState("dayGridMonth");
@@ -19,23 +28,82 @@ export default function NewCalendar() {
 
   const router = useRouter();
 
-  // Use refs for tooltip tracking so event listeners always see current values
-  const activeTooltipRef = useRef<HTMLElement | null>(null);
-  const tooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  // Hover-intent delay: only show a preview once the pointer rests on an event,
-  // so sweeping across stacked events doesn't spawn/flicker tooltips.
-  const tooltipShowTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const TOOLTIP_SHOW_DELAY_MS = 220;
-  const [selectedEvent, setSelectedEvent] = useState<{
-    title: string;
-    eventType: string;
-    timeDisplay: string;
-    price?: number;
-    isFree?: boolean;
-    description?: string;
-    _id: string;
-    isSoldOut: boolean;
+  const [popover, setPopover] = useState<{
+    event: PopoverEvent;
+    anchorRect: DOMRect;
+    mode: PopoverMode;
   } | null>(null);
+
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearOpenTimer = useCallback(() => {
+    if (openTimerRef.current) {
+      clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+  }, []);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const closePopover = useCallback(() => {
+    clearOpenTimer();
+    clearCloseTimer();
+    setPopover(null);
+  }, [clearOpenTimer, clearCloseTimer]);
+
+  // Cancel a pending close — called when the pointer (re)enters either the
+  // event chip or the popover itself, so moving between them never drops it.
+  const cancelClose = useCallback(() => {
+    clearCloseTimer();
+  }, [clearCloseTimer]);
+
+  const scheduleClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null;
+      setPopover(null);
+    }, HOVER_CLOSE_DELAY_MS);
+  }, [clearCloseTimer]);
+
+  const scheduleOpen = useCallback(
+    (event: PopoverEvent, anchorRect: DOMRect) => {
+      clearOpenTimer();
+      clearCloseTimer();
+      openTimerRef.current = setTimeout(() => {
+        openTimerRef.current = null;
+        setPopover({ event, anchorRect, mode: "hover" });
+      }, HOVER_OPEN_DELAY_MS);
+    },
+    [clearOpenTimer, clearCloseTimer]
+  );
+
+  useEffect(() => {
+    return () => {
+      clearOpenTimer();
+      clearCloseTimer();
+    };
+  }, [clearOpenTimer, clearCloseTimer]);
+
+  // Any popover (hover or pinned) is anchored to a specific chip's on-screen
+  // position captured at open time — scrolling, resizing, or paging the
+  // calendar to a new month all invalidate that position, so close rather
+  // than risk a stale, misplaced card.
+  useEffect(() => {
+    if (!popover) return;
+    const dismiss = (): void => closePopover();
+    window.addEventListener("scroll", dismiss, true);
+    window.addEventListener("resize", dismiss);
+    return () => {
+      window.removeEventListener("scroll", dismiss, true);
+      window.removeEventListener("resize", dismiss);
+    };
+  }, [popover, closePopover]);
 
   const resources = [
     { id: "class", title: "Classes", eventColor: "#0c4a6e" },
@@ -414,20 +482,35 @@ export default function NewCalendar() {
     router.push(`/payments?${params.toString()}`);
   };
 
-  useEffect(() => {
-    return () => {
-      // Remove any tooltips when component unmounts
-      if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
-        document.body.removeChild(activeTooltipRef.current);
-      }
-      if (tooltipTimeoutRef.current) {
-        clearTimeout(tooltipTimeoutRef.current);
-      }
-      if (tooltipShowTimeoutRef.current) {
-        clearTimeout(tooltipShowTimeoutRef.current);
-      }
-    };
-  }, []);
+  // Shared by both the hover preview and the click/tap popover — previously
+  // duplicated between eventMouseEnter and eventClick, which is how they'd
+  // drifted into showing two different views of the same event.
+  const toPopoverEvent = useCallback(
+    (event: EventClickArg["event"] | EventHoveringArg["event"]): PopoverEvent => {
+      const props = event.extendedProps as Record<string, unknown>;
+      const eventType = (props?.eventType as string) || "";
+      const eventId = (props?._id as string) || "";
+      const currentSignups = eventId
+        ? eventParticipantCounts[eventId] || 0
+        : 0;
+      const maxParticipants = 20;
+      return {
+        title: event.title,
+        eventType,
+        timeDisplay: (props?.timeDisplay as string) || "",
+        price: props?.price as number | undefined,
+        isFree: props?.isFree as boolean | undefined,
+        description: props?.description as string | undefined,
+        currentSignups,
+        isRecurring: props?.isRecurring as boolean | undefined,
+        recurringPattern: props?.recurringPattern as string | undefined,
+        recurringEndDate: props?.recurringEndDate as string | Date | undefined,
+        _id: eventId,
+        isSoldOut: eventType !== "artist" && currentSignups >= maxParticipants,
+      };
+    },
+    [eventParticipantCounts]
+  );
 
   return (
     <div className="calendar-container">
@@ -452,6 +535,8 @@ export default function NewCalendar() {
         resources={calendarView.includes("resource") ? resources : undefined}
         datesSet={(dateInfo) => {
           setCalendarView(dateInfo.view.type);
+          // Paging to a new month invalidates any open popover's anchor position.
+          closePopover();
         }}
         height="auto"
         eventClassNames={(arg) => {
@@ -468,219 +553,38 @@ export default function NewCalendar() {
         }}
         eventClick={(info) => {
           info.jsEvent.preventDefault();
-          // Dismiss any active tooltip
-          if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
-            document.body.removeChild(activeTooltipRef.current);
-            activeTooltipRef.current = null;
-          }
-          if (tooltipTimeoutRef.current) {
-            clearTimeout(tooltipTimeoutRef.current);
-            tooltipTimeoutRef.current = null;
-          }
-          if (tooltipShowTimeoutRef.current) {
-            clearTimeout(tooltipShowTimeoutRef.current);
-            tooltipShowTimeoutRef.current = null;
-          }
-          const props = info.event.extendedProps;
-          const eventId = props?._id || "";
-          const currentSignups = eventId
-            ? eventParticipantCounts[eventId] || 0
-            : 0;
-          const isSoldOut =
-            props?.eventType !== "artist" && currentSignups >= 20;
-          setSelectedEvent({
-            title: info.event.title,
-            eventType: props?.eventType || "",
-            timeDisplay: props?.timeDisplay || "",
-            price: props?.price,
-            isFree: props?.isFree,
-            description: props?.description,
-            _id: eventId,
-            isSoldOut,
+          clearOpenTimer();
+          clearCloseTimer();
+          setPopover({
+            event: toPopoverEvent(info.event),
+            anchorRect: info.el.getBoundingClientRect(),
+            mode: "pinned",
           });
         }}
         eventMouseEnter={(info) => {
-          // Only show hover previews on devices with a true hover-capable
-          // pointer (mouse). Touch devices use tap -> detail sheet, so a
-          // synthetic hover must never leave a stuck tooltip behind.
+          // A pinned (clicked/tapped) popover is only dismissed explicitly —
+          // hovering a different chip must not silently steal it away.
+          if (popover?.mode === "pinned") return;
+          // Only open hover previews on devices with a true hover-capable,
+          // fine pointer (mouse). Touch/coarse pointers rely on eventClick's
+          // pinned popover instead — a synthetic hover must never leave a
+          // stuck popover behind on a device that can't "leave" it.
           if (
             typeof window !== "undefined" &&
-            window.matchMedia("(hover: none)").matches
+            !window.matchMedia("(hover: hover) and (pointer: fine)").matches
           ) {
             return;
           }
-
-          // Remove any existing tooltip DOM element
-          if (activeTooltipRef.current && document.body.contains(activeTooltipRef.current)) {
-            document.body.removeChild(activeTooltipRef.current);
-            activeTooltipRef.current = null;
-          }
-
-          // Clear any pending hide timeout for a previous tooltip, as we are showing a new one.
-          if (tooltipTimeoutRef.current) {
-            clearTimeout(tooltipTimeoutRef.current);
-            tooltipTimeoutRef.current = null;
-          }
-
-          // Cancel a pending show from a previously-hovered event.
-          if (tooltipShowTimeoutRef.current) {
-            clearTimeout(tooltipShowTimeoutRef.current);
-            tooltipShowTimeoutRef.current = null;
-          }
-
-          // Hover-intent: only build + show the preview once the pointer has
-          // rested on this event for a beat. Quickly passing over neighbouring
-          // events is cancelled by eventMouseLeave before this fires.
-          tooltipShowTimeoutRef.current = setTimeout(() => {
-            tooltipShowTimeoutRef.current = null;
-
-          // Create new tooltip
-          const tooltip = document.createElement("div");
-          tooltip.className = "event-tooltip";
-
-          // Build tooltip content
-          let tooltipContent = `<div class="tooltip-title">${info.event.title}</div>`;
-
-          // Get event type early for use in multiple places
-          const eventType = info.event.extendedProps?.eventType;
-
-          if (info.event.extendedProps?.timeDisplay) {
-            tooltipContent += `<div class="tooltip-time">${info.event.extendedProps.timeDisplay}</div>`;
-          }
-
-          // if (info.event.extendedProps?.eventType) {
-          //   tooltipContent += `<div class="tooltip-type">Type: ${info.event.extendedProps.eventType}</div>`;
-          // }
-
-          if (info.event.extendedProps?.price) {
-            tooltipContent += `<div class="tooltip-price">Price: $${info.event.extendedProps.price}</div>`;
-          }
-
-          // Show participant count only if signups > 5 and not artist event
-          const eventId = info.event.extendedProps?._id;
-          const currentSignups = eventId
-            ? eventParticipantCounts[eventId] || 0
-            : 0;
-          if (currentSignups > 5 && eventType !== "artist") {
-            // We need to get the numberOfParticipants from the event data
-            // For now, we'll use the default of 20 if not available
-            tooltipContent += `<div class="tooltip-participants">${currentSignups} / 20 signed up</div>`;
-          }
-
-          if (info.event.extendedProps?.isRecurring) {
-            tooltipContent += `<div class="tooltip-recurring">
-              Recurring ${info.event.extendedProps.recurringPattern} 
-              ${info.event.extendedProps.recurringEndDate ? `until ${new Date(info.event.extendedProps.recurringEndDate).toLocaleDateString()}` : ""}
-            </div>`;
-          }
-
-          if (info.event.extendedProps?.description) {
-            tooltipContent += `<div class="tooltip-description">${info.event.extendedProps.description}</div>`;
-          }
-
-          // The hover tooltip is a non-interactive PREVIEW only. The actual
-          // sign-up / sold-out CTA lives in the click-to-open detail sheet, so
-          // there is no fragile "move the mouse onto a hovering button" path.
-          const maxParticipants = 20; // Default capacity
-          const isSoldOut =
-            eventType !== "artist" && currentSignups >= maxParticipants;
-          tooltipContent += `<div class="tooltip-hint">${
-            isSoldOut ? "Sold out" : "Click the calendar event for details"
-          }</div>`;
-
-          tooltip.innerHTML = tooltipContent;
-
-          // Add to body first to get accurate dimensions
-          document.body.appendChild(tooltip);
-
-          // Position the tooltip with smart boundary checking
-          const rect = info.el.getBoundingClientRect();
-          const tooltipRect = tooltip.getBoundingClientRect();
-          const viewportWidth = window.innerWidth;
-          const viewportHeight = window.innerHeight;
-
-          // Calculate initial centered position
-          let left = rect.left + rect.width / 2;
-          let top = rect.top - 10;
-          let transformX = "-50%";
-          let transformY = "-100%";
-
-          // Check horizontal boundaries
-          const tooltipHalfWidth = tooltipRect.width / 2;
-          const margin = 16; // Minimum margin from screen edge
-
-          if (left - tooltipHalfWidth < margin) {
-            // Too far left - align to left edge with margin
-            left = margin;
-            transformX = "0%";
-          } else if (left + tooltipHalfWidth > viewportWidth - margin) {
-            // Too far right - align to right edge with margin
-            left = viewportWidth - margin;
-            transformX = "-100%";
-          }
-
-          // Check vertical boundaries
-          const tooltipHeight = tooltipRect.height;
-          const spaceAbove = rect.top;
-          const spaceBelow = viewportHeight - rect.bottom;
-
-          if (
-            spaceAbove < tooltipHeight + margin &&
-            spaceBelow > tooltipHeight + margin
-          ) {
-            // Not enough space above, position below
-            top = rect.bottom + 10;
-            transformY = "0%";
-          } else if (
-            spaceAbove < tooltipHeight + margin &&
-            spaceBelow < tooltipHeight + margin
-          ) {
-            // Not enough space above or below, center vertically
-            top = viewportHeight / 2;
-            transformY = "-50%";
-
-            // If centering vertically, also ensure we're not too close to edges horizontally
-            if (left < viewportWidth / 2) {
-              left = Math.max(margin, rect.right + 10);
-              transformX = "0%";
-            } else {
-              left = Math.min(viewportWidth - margin, rect.left - 10);
-              transformX = "-100%";
-            }
-          }
-
-          // Apply positioning. pointer-events:none keeps the preview from ever
-          // intercepting the mouse, so moving toward / clicking the event below
-          // always works — no hover-bridge flicker.
-          tooltip.style.position = "fixed";
-          tooltip.style.left = left + "px";
-          tooltip.style.top = top + "px";
-          tooltip.style.transform = `translate(${transformX}, ${transformY})`;
-          tooltip.style.zIndex = "99999";
-          tooltip.style.display = "block";
-          tooltip.style.pointerEvents = "none";
-
-          activeTooltipRef.current = tooltip;
-          }, TOOLTIP_SHOW_DELAY_MS);
+          scheduleOpen(toPopoverEvent(info.event), info.el.getBoundingClientRect());
         }}
         eventMouseLeave={() => {
-          // Cancel a not-yet-shown preview (the pointer was just passing over).
-          if (tooltipShowTimeoutRef.current) {
-            clearTimeout(tooltipShowTimeoutRef.current);
-            tooltipShowTimeoutRef.current = null;
-          }
-          // Pure preview — remove it as soon as the pointer leaves the event.
-          if (tooltipTimeoutRef.current) {
-            clearTimeout(tooltipTimeoutRef.current);
-            tooltipTimeoutRef.current = null;
-          }
-          if (
-            activeTooltipRef.current &&
-            document.body.contains(activeTooltipRef.current)
-          ) {
-            document.body.removeChild(activeTooltipRef.current);
-          }
-          activeTooltipRef.current = null;
+          // Never let hover tracking close a pinned popover — see eventMouseEnter.
+          if (popover?.mode === "pinned") return;
+          clearOpenTimer();
+          // Grace period, not immediate removal — gives the pointer time to
+          // cross the gap onto the popover itself (the "hover bridge") without
+          // the popover disappearing out from under it.
+          scheduleClose();
         }}
         eventDidMount={(info) => {
           // Set event color based on event type
@@ -696,85 +600,29 @@ export default function NewCalendar() {
         }}
       />
 
-      {selectedEvent && (
-        <div
-          className="event-sheet-overlay"
-          onClick={() => setSelectedEvent(null)}
-        >
-          <div
-            className="event-sheet"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              className="event-sheet-close"
-              onClick={() => setSelectedEvent(null)}
-              type="button"
-              aria-label="Close"
-            >
-              &times;
-            </button>
-            <span
-              className="event-sheet-type"
-              style={{
-                backgroundColor: getEventColor(selectedEvent.eventType),
-              }}
-            >
-              {selectedEvent.eventType === "artist"
-                ? "Live Demo"
-                : selectedEvent.eventType === "camp"
-                  ? "Art Camp"
-                  : "Workshop"}
-            </span>
-            <h3 className="event-sheet-title">{selectedEvent.title}</h3>
-            {selectedEvent.timeDisplay && (
-              <p className="event-sheet-time">{selectedEvent.timeDisplay}</p>
-            )}
-            {(selectedEvent.price || selectedEvent.isFree) && (
-              <p className="event-sheet-price">
-                {selectedEvent.isFree || selectedEvent.price === 0
-                  ? "Free"
-                  : `$${selectedEvent.price}`}
-              </p>
-            )}
-            {selectedEvent.description && (
-              <p className="event-sheet-description">
-                {selectedEvent.description}
-              </p>
-            )}
-            {selectedEvent.eventType === "artist" ? (
-              <button
-                className="event-sheet-signup"
-                type="button"
-                onClick={() => {
-                  setSelectedEvent(null);
-                  router.push(
-                    `/events/live-artist/${selectedEvent._id}`
-                  );
-                }}
-              >
-                View Details
-              </button>
-            ) : selectedEvent.isSoldOut ? (
-              <div className="event-sheet-soldout">Sold Out</div>
-            ) : (
-              <button
-                className="event-sheet-signup"
-                type="button"
-                onClick={() => {
-                  setSelectedEvent(null);
-                  navigateToPayment(
-                    selectedEvent._id,
-                    selectedEvent.title,
-                    selectedEvent.price,
-                    selectedEvent.isFree
-                  );
-                }}
-              >
-                Sign Up
-              </button>
-            )}
-          </div>
-        </div>
+      {popover && (
+        <EventPopover
+          event={popover.event}
+          anchorRect={popover.anchorRect}
+          mode={popover.mode}
+          eventColor={getEventColor(popover.event.eventType)}
+          onRequestClose={closePopover}
+          // Bridge-safe dismissal only applies to a hover preview — a pinned
+          // (clicked/tapped) popover stays open regardless of pointer
+          // position until explicitly dismissed.
+          onPointerEnter={popover.mode === "hover" ? cancelClose : () => {}}
+          onPointerLeave={popover.mode === "hover" ? scheduleClose : () => {}}
+          onSignUp={() => {
+            const { _id, title, price, isFree } = popover.event;
+            closePopover();
+            navigateToPayment(_id, title, price, isFree);
+          }}
+          onViewDetails={() => {
+            const { _id } = popover.event;
+            closePopover();
+            router.push(`/events/live-artist/${_id}`);
+          }}
+        />
       )}
     </div>
   );

--- a/components/calendar/NewCalendar.tsx
+++ b/components/calendar/NewCalendar.tsx
@@ -585,7 +585,7 @@ export default function NewCalendar() {
           const isSoldOut =
             eventType !== "artist" && currentSignups >= maxParticipants;
           tooltipContent += `<div class="tooltip-hint">${
-            isSoldOut ? "Sold out" : "Click for details"
+            isSoldOut ? "Sold out" : "Click the calendar event for details"
           }</div>`;
 
           tooltip.innerHTML = tooltipContent;

--- a/components/calendar/calendar.css
+++ b/components/calendar/calendar.css
@@ -188,6 +188,20 @@
   overflow: visible !important;
   position: relative;
   cursor: pointer;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+/* The event chip is the real click target (the hover tooltip above it is a
+   non-interactive preview) — reinforce that visually on hover/keyboard focus
+   so it's obvious what to click, since the tooltip's own text can't do it. */
+.fc-event:hover {
+  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.35);
+  transform: translateY(-1px);
+}
+
+.fc-event:focus-visible {
+  outline: 2px solid var(--color-primary, #0c4a6e);
+  outline-offset: 2px;
 }
 
 .fc-event-title {

--- a/components/calendar/calendar.css
+++ b/components/calendar/calendar.css
@@ -191,9 +191,8 @@
   transition: box-shadow 0.15s ease, transform 0.15s ease;
 }
 
-/* The event chip is the real click target (the hover tooltip above it is a
-   non-interactive preview) — reinforce that visually on hover/keyboard focus
-   so it's obvious what to click, since the tooltip's own text can't do it. */
+/* Reinforce the chip as the interactive origin of the popover on hover and
+   keyboard focus, independent of whether the popover itself is open yet. */
 .fc-event:hover {
   box-shadow: 0 2px 8px rgba(12, 74, 110, 0.35);
   transform: translateY(-1px);
@@ -264,55 +263,82 @@
 }
 
 /* ============================================
-   Tooltip -- clean, brand-aligned
+   Event Popover -- single surface for preview + sign-up
+   (replaces the old non-interactive tooltip + separate event-sheet modal)
    ============================================ */
-.event-tooltip {
+.event-popover {
   position: fixed;
   background: white;
   border: 1px solid #e5e7eb;
   border-radius: 12px;
   padding: 16px 18px;
-  width: 280px;
+  width: 300px;
   max-width: 90vw;
+  max-height: 80vh;
   box-shadow: 0 8px 24px rgba(12, 74, 110, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
   font-size: 0.9em;
-  z-index: 99999 !important;
-  pointer-events: none;
+  z-index: 99999;
+  pointer-events: auto;
   white-space: normal;
   color: var(--color-text-primary, #111827);
   text-align: left;
   line-height: 1.5;
+  display: flex;
+  flex-direction: column;
 }
 
-/* Tooltip title */
-.tooltip-title {
+.event-popover-type {
+  align-self: flex-start;
+  display: inline-block;
+  color: white;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 3px 10px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.event-popover-title {
   font-weight: 700;
   font-size: 1.15em;
-  margin-bottom: 10px;
-  border-bottom: 2px solid #e5e7eb;
-  padding-bottom: 8px;
+  margin-bottom: 6px;
   color: var(--color-primary, #0c4a6e);
   letter-spacing: -0.01em;
 }
 
-/* Tooltip time */
-.tooltip-time {
-  margin-bottom: 6px;
+.event-popover-time {
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e5e7eb;
   color: var(--color-text-muted, #374151);
   font-weight: 600;
   font-size: 0.95em;
 }
 
-/* Tooltip type */
-.tooltip-type {
-  margin-bottom: 6px;
-  color: var(--color-text-subtle, #4b5563);
-  font-weight: 500;
-  text-transform: capitalize;
+.event-popover-body {
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: #cbd5e1 #f3f4f6;
 }
 
-/* Tooltip price */
-.tooltip-price {
+.event-popover-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.event-popover-body::-webkit-scrollbar-track {
+  background: #f3f4f6;
+  border-radius: 3px;
+}
+
+.event-popover-body::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 3px;
+}
+
+.event-popover-price {
   margin-bottom: 8px;
   color: var(--color-primary, #0c4a6e);
   font-weight: 700;
@@ -321,18 +347,17 @@
   padding: 5px 10px;
   border-radius: 6px;
   border: 1px solid #e0f2fe;
+  display: inline-block;
 }
 
-/* Tooltip participants */
-.tooltip-participants {
+.event-popover-participants {
   margin-bottom: 6px;
   color: var(--color-text-subtle, #4b5563);
   font-weight: 500;
   font-size: 0.9em;
 }
 
-/* Tooltip recurring */
-.tooltip-recurring {
+.event-popover-recurring {
   margin-bottom: 8px;
   color: var(--color-secondary, #0369a1);
   font-weight: 600;
@@ -343,10 +368,8 @@
   border: 1px solid #e0f2fe;
 }
 
-/* Tooltip description */
-.tooltip-description {
+.event-popover-description {
   margin-top: 10px;
-  margin-bottom: 10px;
   color: var(--color-text-subtle, #4b5563);
   line-height: 1.6;
   font-size: 0.9em;
@@ -354,179 +377,128 @@
   padding: 10px 12px;
   border-radius: 8px;
   border: 1px solid #f3f4f6;
-  max-height: 100px;
-  overflow-y: auto;
   word-wrap: break-word;
-  scrollbar-width: thin;
-  scrollbar-color: #cbd5e1 #f3f4f6;
 }
 
-.tooltip-description::-webkit-scrollbar {
-  width: 6px;
+.event-popover-actions {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  padding-top: 12px;
+  margin-top: 8px;
 }
 
-.tooltip-description::-webkit-scrollbar-track {
-  background: #f3f4f6;
-  border-radius: 3px;
-}
-
-.tooltip-description::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 3px;
-}
-
-.tooltip-description::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
-}
-
-/* Hint footer -- nudges the user to click for the full detail sheet */
-.tooltip-hint {
-  margin-top: 12px;
-  padding-top: 10px;
-  border-top: 1px solid #f1f5f9;
-  color: var(--color-text-subtle, #64748b);
-  font-weight: 600;
-  font-size: 0.82em;
-  text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-/* Sold out badge */
-.tooltip-soldout {
-  margin-top: 12px;
-}
-
-/* Signup button -- brand primary */
-.tooltip-signup {
-  margin-top: 12px;
-  text-align: center;
-}
-
-.tooltip-signup button {
+.event-popover-cta {
+  display: block;
+  width: 100%;
   background: var(--color-primary, #0c4a6e);
   color: white;
   border: none;
-  padding: 9px 20px;
+  padding: 10px 20px;
   border-radius: 8px;
   cursor: pointer;
-  font-weight: 600;
-  transition: background 0.2s ease, box-shadow 0.2s ease;
+  font-weight: 700;
   font-size: 0.9em;
-  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.2);
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.2);
 }
 
-.tooltip-signup button:hover {
+.event-popover-cta:hover {
   background: var(--color-primary-dark, #073a58);
   box-shadow: 0 4px 14px rgba(12, 74, 110, 0.3);
 }
 
-.tooltip-signup button:active {
+.event-popover-cta:active {
   box-shadow: 0 2px 6px rgba(12, 74, 110, 0.2);
 }
 
-/* ============================================
-   Responsive Tooltip
-   ============================================ */
-@media (max-width: 1024px) {
-  .event-tooltip {
-    width: 260px;
-    max-width: 85vw;
+.event-popover-soldout {
+  display: block;
+  width: 100%;
+  padding: 10px 20px;
+  text-align: center;
+  background: linear-gradient(135deg, #d32f2f, #f44336);
+  color: white;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 0.9em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.event-popover-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  color: #94a3b8;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+.event-popover-close:hover {
+  color: #475569;
+}
+
+/* Pinned popover (click/tap) reserves space for the close button. */
+.event-popover--pinned {
+  padding-right: 32px;
+}
+
+/* Compact = touch or narrow viewport: fixed bottom card instead of an
+   anchored floating popover (an anchored position is unreliable once there's
+   no precise hover point, and small screens don't have room beside a chip). */
+.event-popover--compact {
+  position: fixed !important;
+  left: 12px;
+  right: 12px;
+  bottom: max(12px, env(safe-area-inset-bottom));
+  top: auto;
+  width: auto;
+  max-width: none;
+  max-height: min(75dvh, 560px);
+  border-radius: 16px;
+  padding: 20px 20px 16px;
+  animation: popoverSlideUp 0.25s ease;
+}
+
+.event-popover--compact.event-popover--pinned {
+  padding-right: 20px;
+}
+
+.event-popover--compact .event-popover-close {
+  top: 12px;
+  right: 14px;
+}
+
+.event-popover-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 99998;
+  animation: popoverFadeIn 0.2s ease;
+}
+
+@keyframes popoverFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes popoverSlideUp {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
+@media (max-width: 1024px) and (min-width: 641px) {
+  .event-popover:not(.event-popover--compact) {
+    width: 270px;
     padding: 14px 16px;
     font-size: 0.85em;
-  }
-
-  .tooltip-title {
-    font-size: 1.1em;
-    margin-bottom: 8px;
-  }
-
-  .tooltip-description {
-    padding: 8px 10px;
-    font-size: 0.85em;
-  }
-}
-
-@media (max-width: 768px) {
-  .event-tooltip {
-    width: 240px;
-    max-width: 80vw;
-    padding: 12px 14px;
-    font-size: 0.8em;
-    border-radius: 10px;
-  }
-
-  .tooltip-title {
-    font-size: 1.05em;
-    margin-bottom: 6px;
-    padding-bottom: 6px;
-  }
-
-  .tooltip-time,
-  .tooltip-price,
-  .tooltip-recurring {
-    font-size: 0.9em;
-    margin-bottom: 5px;
-    padding: 4px 8px;
-  }
-
-  .tooltip-description {
-    padding: 6px 8px;
-    font-size: 0.8em;
-    margin-top: 8px;
-    margin-bottom: 8px;
-  }
-
-  .tooltip-signup {
-    margin-top: 10px;
-  }
-
-  .tooltip-signup button {
-    padding: 8px 16px;
-    font-size: 0.8em;
-  }
-}
-
-@media (max-width: 480px) {
-  .event-tooltip {
-    width: 220px;
-    max-width: 75vw;
-    padding: 10px 12px;
-    font-size: 0.75em;
-    border-radius: 8px;
-  }
-
-  .tooltip-title {
-    font-size: 1em;
-    margin-bottom: 5px;
-    padding-bottom: 4px;
-  }
-
-  .tooltip-time,
-  .tooltip-price,
-  .tooltip-recurring {
-    font-size: 0.85em;
-    margin-bottom: 4px;
-    padding: 3px 6px;
-  }
-
-  .tooltip-description {
-    padding: 5px 6px;
-    font-size: 0.75em;
-    margin-top: 6px;
-    margin-bottom: 6px;
-  }
-
-  .tooltip-signup {
-    margin-top: 8px;
-  }
-
-  .tooltip-signup button {
-    padding: 6px 12px;
-    font-size: 0.75em;
-    border-radius: 6px;
   }
 }
 
@@ -548,151 +520,3 @@
   }
 }
 
-/* ============================================
-   Event Detail Sheet (tap-to-view)
-   ============================================ */
-.event-sheet-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 100000;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  animation: sheetFadeIn 0.2s ease;
-}
-
-.event-sheet {
-  background: white;
-  width: 100%;
-  max-width: 500px;
-  max-height: 85vh;
-  overflow-y: auto;
-  border-radius: 20px 20px 0 0;
-  padding: 24px 20px 32px;
-  position: relative;
-  animation: sheetSlideUp 0.3s ease;
-}
-
-@media (min-width: 769px) {
-  .event-sheet-overlay {
-    align-items: center;
-  }
-
-  .event-sheet {
-    border-radius: 16px;
-    max-width: 420px;
-    animation: sheetFadeIn 0.2s ease;
-  }
-}
-
-.event-sheet-close {
-  position: absolute;
-  top: 12px;
-  right: 16px;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: #94a3b8;
-  cursor: pointer;
-  padding: 4px 8px;
-  line-height: 1;
-}
-
-.event-sheet-close:hover {
-  color: #475569;
-}
-
-.event-sheet-type {
-  display: inline-block;
-  color: white;
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 3px 10px;
-  border-radius: 4px;
-  margin-bottom: 8px;
-}
-
-.event-sheet-title {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--color-primary, #0c4a6e);
-  margin: 0 0 8px;
-  line-height: 1.3;
-  font-family: var(--font-eb-garamond);
-}
-
-.event-sheet-time {
-  color: #374151;
-  font-weight: 600;
-  font-size: 0.95rem;
-  margin: 0 0 6px;
-}
-
-.event-sheet-price {
-  color: var(--color-primary, #0c4a6e);
-  font-weight: 700;
-  font-size: 1.1rem;
-  margin: 0 0 12px;
-  background: var(--color-light, #f0f9ff);
-  display: inline-block;
-  padding: 4px 12px;
-  border-radius: 6px;
-  border: 1px solid #e0f2fe;
-}
-
-.event-sheet-description {
-  color: #4b5563;
-  font-size: 0.9rem;
-  line-height: 1.6;
-  margin: 0 0 16px;
-  max-height: 120px;
-  overflow-y: auto;
-}
-
-.event-sheet-signup {
-  display: block;
-  width: 100%;
-  background: var(--color-primary, #0c4a6e);
-  color: white;
-  border: none;
-  padding: 12px 24px;
-  border-radius: 10px;
-  cursor: pointer;
-  font-weight: 700;
-  font-size: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  transition: background 0.2s ease;
-  box-shadow: 0 2px 8px rgba(12, 74, 110, 0.2);
-}
-
-.event-sheet-signup:hover {
-  background: var(--color-primary-dark, #073a58);
-}
-
-.event-sheet-soldout {
-  display: block;
-  width: 100%;
-  padding: 12px 24px;
-  text-align: center;
-  background: linear-gradient(135deg, #d32f2f, #f44336);
-  color: white;
-  border-radius: 10px;
-  font-weight: 700;
-  font-size: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-@keyframes sheetFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes sheetSlideUp {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
-}

--- a/components/store/CheckoutField.tsx
+++ b/components/store/CheckoutField.tsx
@@ -7,34 +7,24 @@ interface FieldWrapperProps {
   required?: boolean;
   touched: boolean;
   error: string | null;
-  value?: string;
   children: ReactElement;
 }
 
-/** Label + input shell with a valid ✓ and a touched-only error message. */
+/** Label + input shell with a touched-only error message. */
 export function FieldWrapper({
   id,
   label,
   required,
   touched,
   error,
-  value,
   children,
 }: FieldWrapperProps): ReactElement {
-  const isValid = !!value && !error;
   return (
     <div>
       <Label htmlFor={id} required={required}>
         {label}
       </Label>
-      <div className="relative">
-        {children}
-        {isValid && (
-          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-green-500 text-sm pointer-events-none">
-            ✓
-          </span>
-        )}
-      </div>
+      {children}
       {touched && error && (
         <p className="text-[var(--color-error)] text-xs mt-1">{error}</p>
       )}

--- a/components/store/ContactFields.tsx
+++ b/components/store/ContactFields.tsx
@@ -47,7 +47,6 @@ export default function ContactFields({
           required
           touched={!!touched.email}
           error={contactError("email", values.email)}
-          value={values.email}
         >
           <Input
             id="contact-email"
@@ -65,7 +64,6 @@ export default function ContactFields({
           required
           touched={!!touched.phone}
           error={contactError("phone", values.phone)}
-          value={values.phone}
         >
           <Input
             id="contact-phone"
@@ -87,7 +85,6 @@ export default function ContactFields({
           required
           touched={!!touched.firstName}
           error={contactError("firstName", values.firstName)}
-          value={values.firstName}
         >
           <Input
             id="contact-firstName"
@@ -104,7 +101,6 @@ export default function ContactFields({
           required
           touched={!!touched.lastName}
           error={contactError("lastName", values.lastName)}
-          value={values.lastName}
         >
           <Input
             id="contact-lastName"

--- a/components/store/ShippingAddressStep.tsx
+++ b/components/store/ShippingAddressStep.tsx
@@ -72,7 +72,6 @@ export default function ShippingAddressStep({
             required
             touched={!!touched.firstName}
             error={validateField("firstName", values.firstName)}
-            value={values.firstName}
           >
             <Input id="ship-firstName" autoComplete="off" {...fieldProps("firstName")} />
           </FieldWrapper>
@@ -83,7 +82,6 @@ export default function ShippingAddressStep({
             required
             touched={!!touched.lastName}
             error={validateField("lastName", values.lastName)}
-            value={values.lastName}
           >
             <Input id="ship-lastName" autoComplete="off" {...fieldProps("lastName")} />
           </FieldWrapper>
@@ -96,7 +94,6 @@ export default function ShippingAddressStep({
         required
         touched={!!touched.addressLine1}
         error={validateField("addressLine1", values.addressLine1)}
-        value={values.addressLine1}
       >
         <Input id="addressLine1" autoComplete="address-line1" {...fieldProps("addressLine1")} />
       </FieldWrapper>
@@ -118,35 +115,29 @@ export default function ShippingAddressStep({
           required
           touched={!!touched.city}
           error={validateField("city", values.city)}
-          value={values.city}
         >
           <Input id="city" autoComplete="address-level2" {...fieldProps("city")} />
         </FieldWrapper>
 
         <div>
           <Label htmlFor="state" required>State</Label>
-          <div className="relative">
-            <select
-              id="state"
-              value={values.state}
-              onChange={(e) => {
-                onChange("state", e.target.value);
-                touch("state");
-              }}
-              onBlur={() => touch("state")}
-              className="w-full h-[50px] px-4 bg-[var(--color-light)] border border-[var(--color-border)] rounded-[var(--radius-default)] text-[var(--color-text-primary)] focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none transition-colors text-sm appearance-none"
-            >
-              <option value="">State</option>
-              {US_STATES.map((s) => (
-                <option key={s} value={s}>{s}</option>
-              ))}
-            </select>
-            {values.state && (
-              <span className="absolute right-7 top-1/2 -translate-y-1/2 text-green-500 text-sm pointer-events-none">
-                ✓
-              </span>
-            )}
-          </div>
+          <select
+            id="state"
+            name="state"
+            autoComplete="off"
+            value={values.state}
+            onChange={(e) => {
+              onChange("state", e.target.value);
+              touch("state");
+            }}
+            onBlur={() => touch("state")}
+            className="w-full h-[50px] px-4 bg-[var(--color-light)] border border-[var(--color-border)] rounded-[var(--radius-default)] text-[var(--color-text-primary)] focus:border-[var(--color-primary)] focus:ring-2 focus:ring-[var(--color-primary)]/20 focus:outline-none transition-colors text-sm appearance-none"
+          >
+            <option value="">State</option>
+            {US_STATES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
           {touched.state && !values.state && (
             <p className="text-[var(--color-error)] text-xs mt-1">Required</p>
           )}
@@ -158,7 +149,6 @@ export default function ShippingAddressStep({
           required
           touched={!!touched.zip}
           error={validateField("zip", values.zip)}
-          value={values.zip}
         >
           <Input id="zip" autoComplete="postal-code" maxLength={10} {...fieldProps("zip")} />
         </FieldWrapper>

--- a/components/store/ShopGiftCardCTA.tsx
+++ b/components/store/ShopGiftCardCTA.tsx
@@ -37,12 +37,11 @@ export default function ShopGiftCardCTA(): ReactElement {
           {/* Copy + CTA */}
           <div className="flex flex-col items-center gap-4 md:items-start">
             <h2 className="text-2xl font-bold text-[var(--color-primary)] md:text-3xl">
-              Tough to buy for? Let them choose.
+              Coastal Creations Gift Cards
             </h2>
             <p className="max-w-xl text-base leading-relaxed text-[var(--color-text-muted)] md:text-lg">
-              A Coastal Creations gift card is always the right fit — use it here
-              in the shop, or for classes, camps, workshops, and walk-in studio
-              time.
+              Use it here in the shop, or for classes, camps, workshops, and
+              walk-in studio time.
             </p>
             <Link
               href="/gift-cards"

--- a/lib/square/storeOrders.ts
+++ b/lib/square/storeOrders.ts
@@ -1,0 +1,174 @@
+/**
+ * Square Order building for the store checkout.
+ *
+ * Wires cart line items to real Square catalog objects (via catalogObjectId)
+ * so a store sale decrements Square's own per-item inventory count — mirroring
+ * the order-then-payment pattern already proven in lib/square/gift-cards.ts.
+ * Every dollar amount here comes from numbers this app already computed and
+ * trusts (lib/checkout/storePricing.ts, lib/utils/salesTax.ts) — never
+ * recomputed by Square's own tax/discount engine, so the order total always
+ * equals the amount actually charged.
+ */
+import { getSquareClient } from "@/lib/square/client";
+import type { PricedItem } from "@/lib/checkout/storePricing";
+
+const client = getSquareClient();
+
+function getSquareLocationId(): string {
+  return (
+    process.env.NEXT_PUBLIC_SQUARE_LOCATION_ID ||
+    process.env.SQUARE_LOCATION_ID ||
+    ""
+  );
+}
+
+interface StoreOrderLineItem {
+  catalogObjectId?: string;
+  name?: string;
+  quantity: string;
+  basePriceMoney: { amount: bigint; currency: "USD" };
+}
+
+/**
+ * Pure mapping: priced cart items -> Square Order line items, plus one plain
+ * (non-catalog) line for shipping+tax combined when non-zero. No I/O.
+ */
+export function buildStoreOrderLineItems(
+  pricedItems: PricedItem[],
+  shippingAndTaxCents: number
+): StoreOrderLineItem[] {
+  const lineItems: StoreOrderLineItem[] = pricedItems.map((item) => ({
+    catalogObjectId: item.squareVariationId,
+    quantity: String(item.quantity),
+    basePriceMoney: { amount: BigInt(item.unitPriceCents), currency: "USD" },
+  }));
+
+  if (shippingAndTaxCents > 0) {
+    lineItems.push({
+      name: "Shipping & Tax",
+      quantity: "1",
+      basePriceMoney: { amount: BigInt(shippingAndTaxCents), currency: "USD" },
+    });
+  }
+
+  return lineItems;
+}
+
+/**
+ * Creates the real Square Order for a cart, BEFORE any charge is attempted.
+ * Callers must fail closed if this throws — never fall back to a bare
+ * payments.create() call, which would silently reintroduce the catalog-less
+ * charge this module exists to fix.
+ */
+export async function createSquareOrderForCart(input: {
+  pricedItems: PricedItem[];
+  shippingAndTaxCents: number;
+  giftCardAppliedCents: number;
+  idempotencyKey: string;
+}): Promise<{ orderId: string; version: number; locationId: string }> {
+  const locationId = getSquareLocationId();
+  if (!locationId) {
+    throw new Error("Square location ID is not configured");
+  }
+
+  const orderResponse = await client.orders.create({
+    idempotencyKey: input.idempotencyKey,
+    order: {
+      locationId,
+      lineItems: buildStoreOrderLineItems(
+        input.pricedItems,
+        input.shippingAndTaxCents
+      ),
+      ...(input.giftCardAppliedCents > 0
+        ? {
+            discounts: [
+              {
+                name: "Gift Card Applied",
+                type: "FIXED_AMOUNT",
+                scope: "ORDER",
+                amountMoney: {
+                  amount: BigInt(input.giftCardAppliedCents),
+                  currency: "USD",
+                },
+              },
+            ],
+          }
+        : {}),
+    },
+  });
+
+  const order = orderResponse.order;
+  if (!order?.id || order.version == null) {
+    console.error(
+      "[SQUARE-STORE-ORDERS-createSquareOrderForCart] Unexpected order response shape"
+    );
+    throw new Error("Failed to create Square order for cart");
+  }
+
+  console.log(
+    "[SQUARE-STORE-ORDERS-createSquareOrderForCart] Order created:",
+    order.id
+  );
+  return { orderId: order.id, version: order.version, locationId };
+}
+
+/**
+ * Best-effort cancel of an unpaid Square order (e.g. the payment meant to
+ * complete it failed, or a validation error surfaced after the order was
+ * created). Never throws — an unpaid OPEN order is harmless (Square never
+ * decrements inventory for it), so a failed cancel must not change the
+ * customer-facing response. Merchant-visible cleanliness only.
+ */
+export async function cancelSquareOrderBestEffort(
+  orderId: string,
+  version: number
+): Promise<void> {
+  try {
+    const locationId = getSquareLocationId();
+    await client.orders.update({
+      orderId,
+      order: { locationId, version, state: "CANCELED" },
+    });
+    console.log(
+      "[SQUARE-STORE-ORDERS-cancelSquareOrderBestEffort] Canceled unpaid order:",
+      orderId
+    );
+  } catch (error) {
+    console.error(
+      "[SQUARE-STORE-ORDERS-cancelSquareOrderBestEffort] Best-effort cancel failed (non-fatal):",
+      orderId,
+      error
+    );
+  }
+}
+
+/**
+ * Completes a Square order that a gift card covered in full (chargeCents ===
+ * 0, so there's no payment to link it to) — the order still needs to reach
+ * COMPLETED for Square's inventory decrement to fire. Non-fatal on failure:
+ * this path is rare enough that a Square hiccup here shouldn't block an
+ * otherwise-legitimate free order that already succeeded on the app's side
+ * (card charge skipped, gift card already redeemed).
+ */
+export async function completeZeroChargeOrder(
+  orderId: string,
+  idempotencyKey: string
+): Promise<void> {
+  try {
+    await client.orders.pay({
+      orderId,
+      idempotencyKey,
+      paymentIds: [],
+    });
+    console.log(
+      "[SQUARE-STORE-ORDERS-completeZeroChargeOrder] Order completed with no linked payment:",
+      orderId
+    );
+  } catch (error) {
+    console.error(
+      "[SQUARE-STORE-ORDERS-completeZeroChargeOrder] Failed (non-fatal):",
+      orderId,
+      error
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- **Square order linking** (#191): checkout now creates a real Square Order per sale so Square's own inventory count decrements — a bare payment charge never touched inventory.
- **Checkout hardening** (#192): state field can no longer be silently autofilled with a mismatched value (blocks autofill outright — `autocomplete="off"` — rather than normalizing after the fact, which also protects NJ sales tax's exact "NJ" match); removed the green checkmarks that appeared on every filled field; every button app-wide now gets `cursor: pointer` by default instead of the browser's `default` arrow.
- **Gift card banner copy** (#193): replaced "Tough to buy for? Let them choose." with a plain "Coastal Creations Gift Cards" headline.
- **Calendar popover redesign** (#194): merged the hover-preview tooltip and the click-triggered detail modal into one interactive popover with the Sign Up button embedded — no more duplicate surfaces showing the same event info. Bridge-safe hover (open/close timers) so moving the pointer from the event chip onto the popover to click Sign Up works reliably.

## Test plan
- [x] All of the above verified live on the `develop` Vercel deployment (https://coastal-creations-app-git-develop-benjamin-corbetts-projects.vercel.app) post-merge: no checkmarks, state autofill blocked, cursor-pointer on every button, gift card copy live, calendar popover opens/signs-up/navigates to `/payments` correctly end-to-end
- [x] `tsc --noEmit` / `eslint` / full test suite (410 tests) clean on each PR
- [ ] Full checkout smoke test in prod after merge (cart → Square payment → Shippo label → confirmation email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)