### PR TITLE
fix(shop): list each variation as its own card on the grid

### DIFF
--- a/__tests__/utils/catalogHelpers.test.ts
+++ b/__tests__/utils/catalogHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   isInOnlineSalesCategory,
   deriveAvailability,
   toStoreProductSummary,
+  toStoreProductSummaries,
 } from "@/lib/utils/catalogHelpers";
 import type { RawCatalogItem, RawVariation } from "@/lib/square/catalog";
 import type { IStoreProductSettings } from "@/lib/models/StoreProductSettings";
@@ -16,6 +17,7 @@ const baseVariation: RawVariation = {
   priceCents: 2000,
   variablePricing: false,
   trackInventory: false,
+  imageUrls: [],
 };
 
 const baseItem: RawCatalogItem = {
@@ -254,5 +256,93 @@ describe("toStoreProductSummary", () => {
     const summary = toStoreProductSummary(item, baseSettings, stock);
     expect(summary.defaultVariation?.id).toBe("V2");
     expect(summary.availabilityLabel).toBe("Only 1 remaining");
+  });
+});
+
+describe("toStoreProductSummaries", () => {
+  it("returns a single summary, unchanged, for a single-variation item", () => {
+    const summaries = toStoreProductSummaries(baseItem, baseSettings, new Map());
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toEqual(toStoreProductSummary(baseItem, baseSettings, new Map()));
+  });
+
+  it("returns one card per variation for a multi-variation item, each independently sellable", () => {
+    // Mirrors the real "Mini Travel Art Kits" prod bug: 9 flavors, only a few
+    // in stock. The old single-card-with-a-hidden-default behavior meant a
+    // shopper could only ever see/buy whichever flavor happened to be picked
+    // as the default — the others were invisible on the grid.
+    const item: RawCatalogItem = {
+      ...baseItem,
+      name: "Mini Travel Art Kits",
+      variations: [
+        { ...baseVariation, id: "UNICORN", name: "Mini Unicorn Art Kit", ordinal: 0, trackInventory: true }, // sold out
+        { ...baseVariation, id: "LIZARD", name: "Mini Lizard Art Kit", ordinal: 4, trackInventory: true, priceCents: 2500 },
+        { ...baseVariation, id: "BEACH", name: "Mini Beach Art Kit", ordinal: 5, trackInventory: true, priceCents: 2500 },
+        { ...baseVariation, id: "GIRAFFE", name: "Mini Giraffe Art Kit", ordinal: 7, trackInventory: true, priceCents: 2500 },
+      ],
+    };
+    const stock = new Map([
+      ["LIZARD", 1],
+      ["BEACH", 1],
+      ["GIRAFFE", 1],
+    ]); // UNICORN absent -> sold_out
+
+    const summaries = toStoreProductSummaries(item, baseSettings, stock);
+
+    expect(summaries).toHaveLength(4);
+    // Sorted by ordinal, not input order.
+    expect(summaries.map((s) => s.name)).toEqual([
+      "Mini Unicorn Art Kit",
+      "Mini Lizard Art Kit",
+      "Mini Beach Art Kit",
+      "Mini Giraffe Art Kit",
+    ]);
+    // Every flavor is its own independently-addable single-variation card —
+    // not a rolled-up multi-variation item hiding the others.
+    for (const s of summaries) {
+      expect(s.hasMultipleVariations).toBe(false);
+      expect(s.squareItemId).toBe(item.id);
+      expect(s.defaultVariation?.name).toBe(s.name);
+    }
+    const lizard = summaries.find((s) => s.name === "Mini Lizard Art Kit");
+    const unicorn = summaries.find((s) => s.name === "Mini Unicorn Art Kit");
+    // 1 unit is within LOW_STOCK_THRESHOLD (5) -> "low_stock", not "sold_out".
+    expect(lizard?.availability).toBe("low_stock");
+    expect(lizard?.availabilityLabel).toBe("Only 1 remaining");
+    expect(lizard?.priceRange).toEqual({ minCents: 2500, maxCents: 2500 });
+    expect(unicorn?.availability).toBe("sold_out");
+  });
+
+  it("produces a unique, correctly-decodable slug per flavor", () => {
+    const item: RawCatalogItem = {
+      ...baseItem,
+      id: "ITEM123",
+      variations: [
+        { ...baseVariation, id: "V1", name: "Mini Unicorn Art Kit", ordinal: 0 },
+        { ...baseVariation, id: "V2", name: "Mini Dino Art Kit", ordinal: 1 },
+      ],
+    };
+    const summaries = toStoreProductSummaries(item, undefined, new Map());
+    const slugs = summaries.map((s) => s.slug);
+    expect(new Set(slugs).size).toBe(2);
+    expect(slugs).toEqual(["mini-unicorn-art-kit-ITEM123", "mini-dino-art-kit-ITEM123"]);
+  });
+
+  it("prefers the variation's own image, falling back to the item's image", () => {
+    const item: RawCatalogItem = {
+      ...baseItem,
+      imageUrls: ["https://example.com/item-fallback.jpg"],
+      variations: [
+        { ...baseVariation, id: "V1", name: "Has Own Image", imageUrls: ["https://example.com/v1.jpg"] },
+        { ...baseVariation, id: "V2", name: "No Own Image", imageUrls: [] },
+      ],
+    };
+    const summaries = toStoreProductSummaries(item, undefined, new Map());
+    expect(summaries.find((s) => s.name === "Has Own Image")?.primaryImage?.url).toBe(
+      "https://example.com/v1.jpg"
+    );
+    expect(summaries.find((s) => s.name === "No Own Image")?.primaryImage?.url).toBe(
+      "https://example.com/item-fallback.jpg"
+    );
   });
 });

--- a/app/api/store/products/route.ts
+++ b/app/api/store/products/route.ts
@@ -5,7 +5,7 @@ import { listCatalogItems, getInventoryCounts } from "@/lib/square/catalog";
 import {
   isSellablePhysicalGood,
   isInOnlineSalesCategory,
-  toStoreProductSummary,
+  toStoreProductSummaries,
 } from "@/lib/utils/catalogHelpers";
 import type { StoreProductSummary } from "@/lib/types/storeTypes";
 import type { IStoreProductSettings } from "@/lib/models/StoreProductSettings";
@@ -35,7 +35,10 @@ export async function GET(): Promise<Response> {
     const stock = await getInventoryCounts(variationIds);
 
     const products: StoreProductSummary[] = items
-      .map((item) => toStoreProductSummary(item, byId.get(item.id), stock))
+      // Multi-variation items expand to one card per flavor (each a real,
+      // independently addable/sellable product) instead of one card that
+      // silently quick-adds a single flavor while the others go unseen.
+      .flatMap((item) => toStoreProductSummaries(item, byId.get(item.id), stock))
       // Sold-out items still display, but always sink to the end of the grid —
       // available/low-stock items sort first; displayOrder only breaks ties
       // within each group.

--- a/components/store/ProductDetail.tsx
+++ b/components/store/ProductDetail.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactElement } from "react";
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { useProduct } from "@/hooks/queries/use-products";
 import { useCart } from "@/components/store/CartProvider";
@@ -34,6 +35,10 @@ export default function ProductDetail({
   const [selectedVariation, setSelectedVariation] =
     useState<StoreProductVariation | null>(null);
   const [activeImageIndex, setActiveImageIndex] = useState(0);
+  // A grid/list card links here with ?variation=<id> to pin the specific
+  // flavor it represents, e.g. clicking "Mini Beach Art Kit" shouldn't land
+  // you on whichever variation this page would otherwise default to.
+  const requestedVariationId = useSearchParams().get("variation");
 
   if (isLoading) {
     return (
@@ -55,7 +60,21 @@ export default function ProductDetail({
     );
   }
 
-  const activeVariation = selectedVariation ?? product.variations[0] ?? null;
+  // Priority: an explicit user pick, then the flavor the card was clicked
+  // from (?variation=), then the stock-aware default (never a sold-out
+  // variation just because it happens to be ordinal 0 — product.variations
+  // is ordinal-sorted, so variations[0] alone would silently land on a
+  // sold-out flavor whenever it's first, showing "Sold Out" on load even
+  // though other flavors are in stock).
+  const requestedVariation = requestedVariationId
+    ? product.variations.find((v) => v.id === requestedVariationId)
+    : undefined;
+  const activeVariation =
+    selectedVariation ??
+    requestedVariation ??
+    product.defaultVariation ??
+    product.variations[0] ??
+    null;
   const displayPrice = activeVariation
     ? formatCents(activeVariation.priceCents)
     : null;

--- a/components/store/ShopListRow.tsx
+++ b/components/store/ShopListRow.tsx
@@ -21,7 +21,12 @@ export default function ShopListRow({
   priority = false,
 }: ShopListRowProps): ReactElement {
   const tag = product.availabilityLabel;
-  const href = `/shop/${product.slug}`;
+  // The slug always resolves to the parent Square item; a variation id pins
+  // the detail page to the specific flavor this card represents (relevant
+  // for multi-variation items, harmless no-op for single-variation ones).
+  const href = product.defaultVariation
+    ? `/shop/${product.slug}?variation=${product.defaultVariation.id}`
+    : `/shop/${product.slug}`;
 
   return (
     <div className="group flex flex-col items-center gap-4 rounded-xl px-3 py-5 transition-colors duration-150 hover:bg-gray-50 sm:flex-row sm:items-center sm:gap-5 sm:text-left">
@@ -57,13 +62,6 @@ export default function ShopListRow({
               {product.name}
             </h3>
           </Link>
-          {/* Multi-variation items quick-add ONE specific flavor (defaultVariation) —
-              show which one, matching ShopProductCard's grid-view treatment. */}
-          {product.hasMultipleVariations && product.defaultVariation && (
-            <span className="text-xs font-medium text-[var(--color-text-subtle)]">
-              {product.defaultVariation.name}
-            </span>
-          )}
           {tag && (
             <span className="rounded-full bg-[var(--color-light)] px-2 py-0.5 text-xs font-medium text-[var(--color-primary)]">
               {tag}

--- a/components/store/ShopProductCard.tsx
+++ b/components/store/ShopProductCard.tsx
@@ -24,7 +24,12 @@ export default function ShopProductCard({
 }: ShopProductCardProps): ReactElement {
   const tag = product.availabilityLabel;
   const soldOut = product.availability === "sold_out";
-  const href = `/shop/${product.slug}`;
+  // The slug always resolves to the parent Square item; a variation id pins
+  // the detail page to the specific flavor this card represents (relevant
+  // for multi-variation items, harmless no-op for single-variation ones).
+  const href = product.defaultVariation
+    ? `/shop/${product.slug}?variation=${product.defaultVariation.id}`
+    : `/shop/${product.slug}`;
 
   return (
     <article className="group flex h-full flex-col rounded-2xl border border-[var(--color-border-light)] bg-white p-3 shadow-[0_2px_12px_rgba(12,74,110,0.06)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_12px_28px_rgba(12,74,110,0.14)]">
@@ -70,14 +75,6 @@ export default function ShopProductCard({
             {product.name}
           </h3>
         </Link>
-        {/* Multi-variation items (e.g. "Mini Travel Art Kits") quick-add ONE
-            specific flavor (defaultVariation) — show which one, so the customer
-            knows what they're actually getting without opening the product page. */}
-        {product.hasMultipleVariations && product.defaultVariation && (
-          <p className="mt-0.5 text-xs font-medium text-[var(--color-text-subtle)]">
-            {product.defaultVariation.name}
-          </p>
-        )}
         {product.description && (
           // Cap long descriptions at ~4 lines and let the overflow scroll inside
           // the card, so the whole blurb is readable without breaking the

--- a/components/store/Store.tsx
+++ b/components/store/Store.tsx
@@ -124,7 +124,7 @@ export default function Store(): ReactElement {
             <div className="grid grid-cols-2 items-stretch gap-5 sm:gap-6 md:grid-cols-3 xl:grid-cols-4">
               {items.map((product, i) => (
                 <ShopProductCard
-                  key={product.squareItemId}
+                  key={product.slug}
                   product={product}
                   priority={i < 4}
                 />
@@ -136,7 +136,7 @@ export default function Store(): ReactElement {
             <div className="flex flex-col divide-y divide-gray-100">
               {items.map((product, i) => (
                 <ShopListRow
-                  key={product.squareItemId}
+                  key={product.slug}
                   product={product}
                   priority={i < 6}
                 />

--- a/lib/square/catalog.ts
+++ b/lib/square/catalog.ts
@@ -23,6 +23,7 @@ export interface RawVariation {
   priceCents: number | null; // null = VARIABLE_PRICING
   variablePricing: boolean;
   trackInventory: boolean;
+  imageUrls: string[]; // the variation's OWN image(s), distinct from the item's
 }
 
 export interface RawCatalogItem {
@@ -141,10 +142,15 @@ function mapRawItem(
           priceMoney?: { amount?: bigint | null } | null;
         }> | null;
         trackInventory?: boolean | null;
+        imageIds?: (string | null)[] | null;
       } | null;
     };
     const vd = vObj.itemVariationData;
     const variablePricing = vd?.pricingType === "VARIABLE_PRICING";
+    const variationImageUrls = (vd?.imageIds ?? [])
+      .filter(Boolean)
+      .map((id) => imageById.get(id as string))
+      .filter(Boolean) as string[];
     return {
       id: vObj.id ?? "",
       name: vd?.name ?? "",
@@ -153,6 +159,7 @@ function mapRawItem(
       priceCents: variablePricing ? null : variationPriceCents(vd),
       variablePricing,
       trackInventory: vd?.trackInventory ?? false,
+      imageUrls: variationImageUrls,
     };
   });
 

--- a/lib/utils/catalogHelpers.ts
+++ b/lib/utils/catalogHelpers.ts
@@ -204,6 +204,67 @@ export function toStoreProductSummary(
 }
 
 /**
+ * Builds one StoreProductSummary PER VARIATION for a multi-variation item (e.g.
+ * "Mini Travel Art Kits" -> a separate grid card each for Unicorn, Dino, Lizard,
+ * ...), instead of one card that silently quick-adds a single flavor while the
+ * others go unseen. Single-variation items are returned unchanged, as a 1-item
+ * array, via toStoreProductSummary.
+ *
+ * Each flavor card is a self-contained single-variation summary: its own price,
+ * its own availability/label (not the item-level rollup), and its own image
+ * when Square has one for that variation (falling back to the item's image).
+ * The slug still encodes the parent item id (createProductSlug's id segment is
+ * always last, regardless of the variation-name prefix), so /shop/[slug]
+ * continues to resolve correctly — see extractSquareItemIdFromSlug.
+ */
+export function toStoreProductSummaries(
+  item: RawCatalogItem,
+  settings: IStoreProductSettings | undefined,
+  stock: Map<string, number>
+): StoreProductSummary[] {
+  if (item.variations.length <= 1) {
+    return [toStoreProductSummary(item, settings, stock)];
+  }
+
+  const itemPrimaryImage: StoreProductImage | undefined =
+    item.imageUrls.length > 0
+      ? { id: `img-${item.id}-0`, url: item.imageUrls[0], altText: item.name }
+      : undefined;
+  const description = item.descriptionHtml
+    ? stripHtml(item.descriptionHtml)
+    : undefined;
+  const displayOrder = (settings?.displayOrder as number | undefined) ?? 0;
+
+  return [...item.variations]
+    .sort((a, b) => a.ordinal - b.ordinal)
+    .map((raw) => {
+      const variation = toStoreProductVariation(raw, stock.get(raw.id));
+      const primaryImage: StoreProductImage | undefined =
+        raw.imageUrls.length > 0
+          ? { id: `img-${raw.id}-0`, url: raw.imageUrls[0], altText: raw.name }
+          : itemPrimaryImage;
+
+      return {
+        squareItemId: item.id,
+        name: raw.name,
+        slug: createProductSlug(raw.name, item.id),
+        primaryImage,
+        categoryName: item.categoryNames[0],
+        description,
+        priceRange: { minCents: variation.priceCents, maxCents: variation.priceCents },
+        hasMultipleVariations: false,
+        availability: variation.availability,
+        availabilityLabel: buildAvailabilityLabel(
+          variation.availability,
+          variation.inStockQuantity ?? 0
+        ),
+        displayOrder,
+        defaultVariation: variation,
+      };
+    });
+}
+
+/**
  * Builds the full StoreProduct (detail page shape) from a raw item + settings + stock map.
  */
 export function toStoreProduct(


### PR DESCRIPTION
## Summary

Found live in production via the Square MCP, following up on your screenshot: **"Mini Travel Art Kits" has 9 flavors; only 3 were actually in stock (Lizard, Beach, Giraffe), but the shop grid showed exactly ONE card, labeled "Mini Lizard Art Kit"** — Beach and Giraffe were real, purchasable variations with zero visibility anywhere. This was the `defaultVariation` design from #185/#186 (grid shows the flavor quick-add would actually add) — correct as far as it went, but it meant a shopper could only ever discover one flavor per multi-variation item.

Digging further turned up a related bug on the **product detail page**: it always defaulted to `product.variations[0]` (ordinal 0, "Mini Unicorn Art Kit" — sold out) regardless of which variations were actually in stock, so even clicking through could land on "Sold Out" on load with three other flavors sitting right there, unselected.

Per your direction — don't pick a default, list every variation as its own card (filters can group them later):

- **`toStoreProductSummaries()`** (new, in `catalogHelpers.ts`): for a multi-variation item, returns one `StoreProductSummary` per variation instead of one summary with a hidden default. Each is a self-contained, independently-addable card — own price, own availability/label (not the item-level rollup), own slug, and **prefers the variation's own Square image** over the item's shared image when Square has one (previously discarded entirely — `RawVariation` now carries `imageUrls`, so e.g. the Unicorn card shows the actual unicorn photo instead of a generic kit shot). Single-variation items are unaffected.
- API route (`/api/store/products`) now `flatMap`s through this instead of mapping 1:1.
- `Store.tsx`: card `key` changed from `squareItemId` to `slug` — flattened cards legitimately share a parent item id now, which would have collided as React keys.
- `ShopProductCard`/`ShopListRow`: link to `/shop/[slug]?variation=<id>` so clicking a specific flavor's card lands on that exact flavor on the detail page, not whichever one the page would otherwise default to. Removed the now-dead `hasMultipleVariations` subtitle branch (every grid card is single-variation now).
- `ProductDetail.tsx`: reads `?variation=`, falls back to the stock-aware `product.defaultVariation`, and only then to `variations[0]` — fixes the "defaults to a sold-out ordinal-0 variation" bug independent of the query param too.

## Test plan
- [x] `tsc --noEmit` / `eslint` clean
- [x] Full test suite (414 tests) passing, including 4 new tests on `toStoreProductSummaries` (per-flavor cards sorted by ordinal, unique/decodable slugs, variation-image-over-item-image fallback) mirroring the real Mini Travel Art Kits data
- [x] Cross-referenced against live Square production data (via MCP) to confirm the fix targets the actual current stock state (Lizard/Beach/Giraffe in stock, 6 others sold out)
- [x] Verified on a preview deployment: no console errors, single-variation items unaffected (detail page loads, `?variation=` param present and correct, Add to Cart works, cart badge increments)
- [ ] **Preview/dev environments use a smaller test Square catalog with no multi-variation items** — I could not visually exercise the actual "Mini Travel Art Kits" flattening (9 cards, correct images/stock) pre-merge. Recommend a quick manual check on `/shop` right after this merges to production, to confirm all 3 in-stock flavors (and the 6 sold-out ones) render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)