### PR TITLE
fix(shop): detail page shows the variation's name, not the item's

### DIFF
--- a/app/shop/[slug]/page.tsx
+++ b/app/shop/[slug]/page.tsx
@@ -8,23 +8,40 @@ import { retrieveCatalogItem } from "@/lib/square/catalog";
 
 interface Props {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ variation?: string }>;
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: Props): Promise<Metadata> {
   if (!isShopEnabled()) {
     return { title: "Shop | Coastal Creations Studio" };
   }
   const { slug } = await params;
+  const { variation: variationId } = await searchParams;
   const squareItemId = extractSquareItemIdFromSlug(slug);
 
   try {
     const item = await retrieveCatalogItem(squareItemId);
     if (item) {
+      // The grid always links here with ?variation=<id> for multi-variation
+      // items — use that flavor's own name so e.g. "Mini Beach Art Kit"
+      // doesn't show a browser tab / search-result title of the generic
+      // "Mini Travel Art Kits" item name it belongs to. Guarded to items
+      // with more than one variation: a single-SKU item's lone variation is
+      // often Square's generic internal placeholder name ("Regular"), which
+      // must never replace the item's real, customer-facing name.
+      const variationName =
+        variationId && item.variations.length > 1
+          ? item.variations.find((v) => v.id === variationId)?.name
+          : undefined;
+      const displayName = variationName ?? item.name;
       return {
-        title: `${item.name} | Shop | Coastal Creations Studio`,
+        title: `${displayName} | Shop | Coastal Creations Studio`,
         description: item.descriptionHtml
           ? item.descriptionHtml.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim()
-          : `${item.name} — available in the Coastal Creations Studio shop.`,
+          : `${displayName} — available in the Coastal Creations Studio shop.`,
       };
     }
   } catch {

--- a/components/store/ProductDetail.tsx
+++ b/components/store/ProductDetail.tsx
@@ -72,13 +72,22 @@ export default function ProductDetail({
   const displayPrice = activeVariation
     ? formatCents(activeVariation.priceCents)
     : null;
+  // Only prefer the variation's own name on a genuinely multi-variation item
+  // (e.g. "Mini Beach Art Kit") — Square defaults a single-variation item's
+  // one-and-only variation to a generic internal name like "Regular", which
+  // would replace a real product name ("Tiny Easel Painter Box") with
+  // meaningless placeholder text if shown unconditionally.
+  const displayName =
+    product.hasMultipleVariations && activeVariation
+      ? activeVariation.name
+      : product.name;
 
   // Default the hero to the active variation's OWN photo (e.g. the actual
   // lizard art kit, not item.images[0] — which may be a different flavor or
   // an unrelated promotional shot on multi-variation items). Once the
   // shopper picks a thumbnail, that choice takes over.
   const variationImage = activeVariation?.imageUrl
-    ? { id: `variation-${activeVariation.id}`, url: activeVariation.imageUrl, altText: activeVariation.name }
+    ? { id: `variation-${activeVariation.id}`, url: activeVariation.imageUrl, altText: displayName }
     : undefined;
   const activeImage =
     activeImageIndex === 0
@@ -94,7 +103,7 @@ export default function ProductDetail({
             {activeImage ? (
               <Image
                 src={activeImage.url}
-                alt={activeImage.altText ?? product.name}
+                alt={activeImage.altText ?? displayName}
                 fill
                 sizes="(max-width: 768px) 100vw, 50vw"
                 className="object-cover"
@@ -141,7 +150,7 @@ export default function ProductDetail({
           )}
 
           <h1 className="text-3xl font-bold text-[var(--color-primary)]">
-            {product.name}
+            {displayName}
           </h1>
 
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Caught doing the post-merge production check on #198/#199: visiting a flavor's page (e.g. `/shop/mini-beach-art-kit-...?variation=...`) correctly showed that flavor's price, stock badge, and photo — but the H1 and browser tab title still read "Mini Travel Art Kits", the generic parent item name. A shopper had no heading confirming which flavor they were actually looking at.

- `ProductDetail.tsx`: H1 and hero image alt text now prefer the active variation's own name — but **only** when the item genuinely has multiple variations. Caught this guard was necessary on the first preview build: a single-SKU item's lone variation is often Square's generic internal placeholder name ("Regular"), which showed up as the page title for "Tiny Easel Painter Box" before I added the `hasMultipleVariations` check.
- `app/shop/[slug]/page.tsx`: `generateMetadata` now reads the same `?variation=` the grid links with, applies the identical guard, and uses the variation's name for the page `<title>`/meta description instead of always falling back to the item's name.

## Test plan
- [x] `tsc --noEmit` / `eslint` clean
- [x] Full test suite (416 tests) passing
- [x] Verified on two preview builds: first caught the single-variation "Regular" regression live, second confirms the fix — "Tiny Easel Painter Box" now shows correctly (not "Regular") in both the H1 and browser tab title, no console errors, page still functions (price/availability/Add to Cart)
- [ ] Preview/dev environments don't have a multi-variation item in their test catalog — recommend confirming on a Mini Travel Art Kit product page in production that the title/H1 show the specific flavor name (e.g. "Mini Beach Art Kit")

🤖 Generated with [Claude Code](https://claude.com/claude-code)