### PR TITLE
release: product detail page shows the correct variation name

### DIFF
--- a/app/shop/[slug]/page.tsx
+++ b/app/shop/[slug]/page.tsx
@@ -8,23 +8,40 @@ import { retrieveCatalogItem } from "@/lib/square/catalog";
 
 interface Props {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ variation?: string }>;
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: Props): Promise<Metadata> {
   if (!isShopEnabled()) {
     return { title: "Shop | Coastal Creations Studio" };
   }
   const { slug } = await params;
+  const { variation: variationId } = await searchParams;
   const squareItemId = extractSquareItemIdFromSlug(slug);
 
   try {
     const item = await retrieveCatalogItem(squareItemId);
     if (item) {
+      // The grid always links here with ?variation=<id> for multi-variation
+      // items — use that flavor's own name so e.g. "Mini Beach Art Kit"
+      // doesn't show a browser tab / search-result title of the generic
+      // "Mini Travel Art Kits" item name it belongs to. Guarded to items
+      // with more than one variation: a single-SKU item's lone variation is
+      // often Square's generic internal placeholder name ("Regular"), which
+      // must never replace the item's real, customer-facing name.
+      const variationName =
+        variationId && item.variations.length > 1
+          ? item.variations.find((v) => v.id === variationId)?.name
+          : undefined;
+      const displayName = variationName ?? item.name;
       return {
-        title: `${item.name} | Shop | Coastal Creations Studio`,
+        title: `${displayName} | Shop | Coastal Creations Studio`,
         description: item.descriptionHtml
           ? item.descriptionHtml.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim()
-          : `${item.name} — available in the Coastal Creations Studio shop.`,
+          : `${displayName} — available in the Coastal Creations Studio shop.`,
       };
     }
   } catch {

--- a/components/store/ProductDetail.tsx
+++ b/components/store/ProductDetail.tsx
@@ -72,13 +72,22 @@ export default function ProductDetail({
   const displayPrice = activeVariation
     ? formatCents(activeVariation.priceCents)
     : null;
+  // Only prefer the variation's own name on a genuinely multi-variation item
+  // (e.g. "Mini Beach Art Kit") — Square defaults a single-variation item's
+  // one-and-only variation to a generic internal name like "Regular", which
+  // would replace a real product name ("Tiny Easel Painter Box") with
+  // meaningless placeholder text if shown unconditionally.
+  const displayName =
+    product.hasMultipleVariations && activeVariation
+      ? activeVariation.name
+      : product.name;
 
   // Default the hero to the active variation's OWN photo (e.g. the actual
   // lizard art kit, not item.images[0] — which may be a different flavor or
   // an unrelated promotional shot on multi-variation items). Once the
   // shopper picks a thumbnail, that choice takes over.
   const variationImage = activeVariation?.imageUrl
-    ? { id: `variation-${activeVariation.id}`, url: activeVariation.imageUrl, altText: activeVariation.name }
+    ? { id: `variation-${activeVariation.id}`, url: activeVariation.imageUrl, altText: displayName }
     : undefined;
   const activeImage =
     activeImageIndex === 0
@@ -94,7 +103,7 @@ export default function ProductDetail({
             {activeImage ? (
               <Image
                 src={activeImage.url}
-                alt={activeImage.altText ?? product.name}
+                alt={activeImage.altText ?? displayName}
                 fill
                 sizes="(max-width: 768px) 100vw, 50vw"
                 className="object-cover"
@@ -141,7 +150,7 @@ export default function ProductDetail({
           )}
 
           <h1 className="text-3xl font-bold text-[var(--color-primary)]">
-            {product.name}
+            {displayName}
           </h1>
 
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- **Detail page variation name fix** (#200): the product detail page's H1 and browser tab title now show the specific variation's name (e.g. "Mini Beach Art Kit") for multi-variation items, instead of the generic parent item name ("Mini Travel Art Kits") — while correctly falling back to the item's real name for single-SKU items, where Square's internal variation name is often a meaningless placeholder ("Regular").

## Test plan
- [x] `tsc --noEmit` / `eslint` / full test suite (416 tests) clean
- [x] Verified across two preview builds (caught and fixed a single-variation regression before merging)
- [ ] Preview/dev environments don't have a multi-variation item in their test catalog — recommend confirming on a Mini Travel Art Kit product page in production that the title/H1 show the specific flavor name

🤖 Generated with [Claude Code](https://claude.com/claude-code)