### PR TITLE
fix(store): cap Add to Cart at tracked stock, clear cart on browser close

### DIFF
--- a/__tests__/store/CartProvider.test.tsx
+++ b/__tests__/store/CartProvider.test.tsx
@@ -50,7 +50,7 @@ function createWrapper(): ({ children }: { children: ReactNode }) => ReactNode {
 
 describe("CartProvider — cart operations", () => {
   beforeEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
   });
 
   it("starts with an empty cart", () => {
@@ -231,12 +231,12 @@ describe("CartProvider — cart operations", () => {
   });
 });
 
-describe("CartProvider — localStorage persistence", () => {
+describe("CartProvider — sessionStorage persistence", () => {
   beforeEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
   });
 
-  it("persists cart to localStorage when items change", () => {
+  it("persists cart to sessionStorage when items change", () => {
     const { result } = renderHook(() => useCart(), {
       wrapper: createWrapper(),
     });
@@ -245,14 +245,14 @@ describe("CartProvider — localStorage persistence", () => {
       result.current.addItem(mockProduct, mockVariation);
     });
 
-    const stored = localStorage.getItem("cc_cart");
+    const stored = sessionStorage.getItem("cc_cart");
     expect(stored).not.toBeNull();
     const parsed = JSON.parse(stored!);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].squareVariationId).toBe("VAR1");
   });
 
-  it("hydrates cart from localStorage on mount", () => {
+  it("hydrates cart from sessionStorage on mount", () => {
     const savedItems = [
       {
         squareCatalogItemId: "ITEM1",
@@ -264,7 +264,7 @@ describe("CartProvider — localStorage persistence", () => {
         quantity: 3,
       },
     ];
-    localStorage.setItem("cc_cart", JSON.stringify(savedItems));
+    sessionStorage.setItem("cc_cart", JSON.stringify(savedItems));
 
     const { result } = renderHook(() => useCart(), {
       wrapper: createWrapper(),
@@ -277,8 +277,8 @@ describe("CartProvider — localStorage persistence", () => {
     expect(result.current.items[0].quantity).toBe(3);
   });
 
-  it("handles corrupted localStorage gracefully", () => {
-    localStorage.setItem("cc_cart", "not-valid-json{{{");
+  it("handles corrupted sessionStorage gracefully", () => {
+    sessionStorage.setItem("cc_cart", "not-valid-json{{{");
 
     expect(() => {
       renderHook(() => useCart(), {

--- a/components/store/AddToCartButton.tsx
+++ b/components/store/AddToCartButton.tsx
@@ -4,7 +4,8 @@ import { useState, useCallback } from "react";
 import type { ReactElement, CSSProperties } from "react";
 import { FaCheck } from "react-icons/fa";
 import { FaShoppingCart } from "react-icons/fa";
-import { useCart } from "./CartProvider";
+import toast from "react-hot-toast";
+import { useCart, useVariationCartStatus } from "./CartProvider";
 import type { StoreProductSummary } from "@/lib/types/storeTypes";
 
 interface AddToCartButtonProps {
@@ -28,22 +29,32 @@ export function AddToCartButton({
   const [added, setAdded] = useState(false);
 
   const variation = product.defaultVariation;
-  const soldOut = product.availability === "sold_out" || !variation;
+  // Truly sold out (Square stock is 0) vs. cartExhausted (stock exists but this
+  // shopper's cart already holds every unit of it) get distinct treatment below —
+  // "Sold Out" would wrongly suggest no one can buy it right now.
+  const isSoldOut = product.availability === "sold_out" || !variation;
+  const cartStatus = useVariationCartStatus(variation);
+  const cartExhausted = !isSoldOut && cartStatus.atCap;
+  const blocked = isSoldOut || cartExhausted;
 
   // Adding an item does NOT open the cart drawer — that was disruptive while
   // browsing. The cart icon badge animates as feedback, and the button itself
   // flips to "Added!"; opening the drawer is reserved for clicking the cart.
   const handleClick = useCallback(() => {
-    if (added || !variation || soldOut) return;
+    if (added) return;
+    if (!variation || blocked) {
+      if (cartExhausted) toast.error("Sorry, no more items available.");
+      return;
+    }
     addItem(product, variation);
     setAdded(true);
     setTimeout(() => setAdded(false), 1800);
-  }, [added, variation, soldOut, product, addItem]);
+  }, [added, variation, blocked, cartExhausted, product, addItem]);
 
   return (
     <button
       onClick={handleClick}
-      disabled={soldOut}
+      disabled={blocked}
       className={`relative overflow-hidden disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
       style={style}
     >
@@ -54,8 +65,10 @@ export function AddToCartButton({
             <FaCheck className={iconClassName} />
             Added!
           </>
-        ) : soldOut ? (
+        ) : isSoldOut ? (
           "Sold Out"
+        ) : cartExhausted ? (
+          "Max in Cart"
         ) : (
           <>
             {showCartIcon && <FaShoppingCart className={iconClassName} />}

--- a/components/store/CartProvider.tsx
+++ b/components/store/CartProvider.tsx
@@ -14,6 +14,7 @@ import type {
   StoreProduct,
   StoreProductVariation,
 } from "@/lib/types/storeTypes";
+import { clientAvailabilityAfterCart } from "@/lib/utils/catalogHelpers";
 
 const CART_STORAGE_KEY = "cc_cart";
 
@@ -167,4 +168,36 @@ export function useCart(): CartContextValue {
   const ctx = useContext(CartContext);
   if (!ctx) throw new Error("[useCart] must be used inside CartProvider");
   return ctx;
+}
+
+interface VariationCartStatus {
+  cartQuantity: number;
+  /** True once this variation's cart quantity already equals its tracked stock. */
+  atCap: boolean;
+  availability: StoreProductVariation["availability"] | undefined;
+  /** "Only N remaining" / "Sold out", recomputed against the cart — null when fully in stock. */
+  label: string | null;
+}
+
+/**
+ * Cart-aware view of a single variation's availability. Square's stock count is a
+ * snapshot from page load; this subtracts what the shopper already has in their
+ * cart so the UI (badges, Add to Cart buttons) reflects what's actually left to add,
+ * not just what was left when the page rendered.
+ */
+export function useVariationCartStatus(
+  variation: StoreProductVariation | null | undefined
+): VariationCartStatus {
+  const { items } = useCart();
+
+  if (!variation) {
+    return { cartQuantity: 0, atCap: false, availability: undefined, label: null };
+  }
+
+  const cartQuantity =
+    items.find((i) => i.squareVariationId === variation.id)?.quantity ?? 0;
+  const { availability, label } = clientAvailabilityAfterCart(variation, cartQuantity);
+  const atCap = variation.availability !== "sold_out" && availability === "sold_out";
+
+  return { cartQuantity, atCap, availability, label };
 }

--- a/components/store/CartProvider.tsx
+++ b/components/store/CartProvider.tsx
@@ -52,22 +52,25 @@ export function CartProvider({ children }: CartProviderProps): ReactElement {
   const [items, setItems] = useState<CartItem[]>([]);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
-  // Hydrate from localStorage on mount (client-only)
+  // Hydrate from sessionStorage on mount (client-only). sessionStorage (not
+  // localStorage) is deliberate: it survives reloads/navigation within the
+  // same tab but is wiped once the tab/browser closes, so an abandoned cart
+  // doesn't linger indefinitely across visits.
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
-      const raw = localStorage.getItem(CART_STORAGE_KEY);
+      const raw = sessionStorage.getItem(CART_STORAGE_KEY);
       if (raw) setItems(JSON.parse(raw) as CartItem[]);
     } catch {
       // corrupted storage — start fresh
     }
   }, []);
 
-  // Persist to localStorage whenever items change
+  // Persist to sessionStorage whenever items change
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
-      localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+      sessionStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
     } catch {
       // storage full or private mode — fail silently
     }

--- a/components/store/ProductDetail.tsx
+++ b/components/store/ProductDetail.tsx
@@ -4,11 +4,11 @@ import type { ReactElement } from "react";
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Image from "next/image";
+import toast from "react-hot-toast";
 import { useProduct } from "@/hooks/queries/use-products";
-import { useCart } from "@/components/store/CartProvider";
+import { useCart, useVariationCartStatus } from "@/components/store/CartProvider";
 import { Badge, Button } from "@/components/ui";
 import { formatCents } from "@/lib/utils/moneyHelpers";
-import { buildAvailabilityLabel } from "@/lib/utils/catalogHelpers";
 import type { StoreProductAvailability } from "@/lib/types/storeTypes";
 
 interface ProductDetailProps {
@@ -39,6 +39,21 @@ export default function ProductDetail({
   // am I even buying" confusion the grid change was meant to remove.
   const requestedVariationId = useSearchParams().get("variation");
 
+  // Priority: the flavor the card was clicked from (?variation=), then the
+  // stock-aware default (never a sold-out variation just because it happens
+  // to be ordinal 0 — product.variations is ordinal-sorted, so variations[0]
+  // alone would silently land on a sold-out flavor whenever it's first,
+  // showing "Sold Out" on load even though other flavors are in stock).
+  // Computed ahead of the loading/error early returns (rather than after)
+  // because useVariationCartStatus below is a hook and must run every render.
+  const requestedVariation =
+    product && requestedVariationId
+      ? product.variations.find((v) => v.id === requestedVariationId)
+      : undefined;
+  const activeVariation =
+    requestedVariation ?? product?.defaultVariation ?? product?.variations[0] ?? null;
+  const cartStatus = useVariationCartStatus(activeVariation);
+
   if (isLoading) {
     return (
       <div className="container mx-auto px-4 py-16 flex justify-center">
@@ -59,16 +74,6 @@ export default function ProductDetail({
     );
   }
 
-  // Priority: the flavor the card was clicked from (?variation=), then the
-  // stock-aware default (never a sold-out variation just because it happens
-  // to be ordinal 0 — product.variations is ordinal-sorted, so variations[0]
-  // alone would silently land on a sold-out flavor whenever it's first,
-  // showing "Sold Out" on load even though other flavors are in stock).
-  const requestedVariation = requestedVariationId
-    ? product.variations.find((v) => v.id === requestedVariationId)
-    : undefined;
-  const activeVariation =
-    requestedVariation ?? product.defaultVariation ?? product.variations[0] ?? null;
   const displayPrice = activeVariation
     ? formatCents(activeVariation.priceCents)
     : null;
@@ -161,13 +166,12 @@ export default function ProductDetail({
             )}
             {activeVariation && (
               <Badge
-                variant={availabilityVariant[activeVariation.availability]}
+                variant={
+                  availabilityVariant[cartStatus.availability ?? activeVariation.availability]
+                }
                 showDot={false}
               >
-                {buildAvailabilityLabel(
-                  activeVariation.availability,
-                  activeVariation.inStockQuantity ?? 0
-                ) ?? undefined}
+                {cartStatus.label ?? undefined}
               </Badge>
             )}
           </div>
@@ -181,22 +185,31 @@ export default function ProductDetail({
           {/* Add to cart */}
           <div className="mt-2">
             {(() => {
+              // Truly sold out (Square stock is 0) vs. cartExhausted (stock
+              // exists but the shopper's cart already holds all of it) get
+              // distinct labels — "Sold Out" would wrongly suggest no one can
+              // buy it, when really this shopper's cart already claimed it all.
               const isSoldOut = activeVariation?.availability === "sold_out";
-              const canAddToCart = !!activeVariation && !isSoldOut;
+              const cartExhausted = !isSoldOut && cartStatus.atCap;
+              const canAddToCart = !!activeVariation && !isSoldOut && !cartExhausted;
               return (
                 <Button
                   variant="primary"
                   disabled={!canAddToCart}
                   className="w-full"
                   onClick={() => {
-                    if (!canAddToCart || !product) return;
+                    if (!activeVariation || !product) return;
+                    if (!canAddToCart) {
+                      toast.error("Sorry, no more items available.");
+                      return;
+                    }
                     // Don't auto-open the cart drawer on add — the cart icon
                     // badge animates as feedback; opening is reserved for the
                     // cart icon itself (consistent with the shop grid).
-                    addItem(product, activeVariation!);
+                    addItem(product, activeVariation);
                   }}
                 >
-                  {isSoldOut ? "Sold Out" : "Add to Cart"}
+                  {isSoldOut ? "Sold Out" : cartExhausted ? "Max in Cart" : "Add to Cart"}
                 </Button>
               );
             })()}

--- a/components/store/ShopListRow.tsx
+++ b/components/store/ShopListRow.tsx
@@ -8,6 +8,7 @@ import type { ReactElement } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { AddToCartButton } from "./AddToCartButton";
+import { useVariationCartStatus } from "./CartProvider";
 import { formatPriceRange } from "@/lib/utils/catalogHelpers";
 import type { StoreProductSummary } from "@/lib/types/storeTypes";
 
@@ -20,7 +21,10 @@ export default function ShopListRow({
   product,
   priority = false,
 }: ShopListRowProps): ReactElement {
-  const tag = product.availabilityLabel;
+  // Re-derived against the cart so the badge counts down as units get added,
+  // instead of showing the stock count from whenever the page first loaded.
+  const cartStatus = useVariationCartStatus(product.defaultVariation);
+  const tag = product.defaultVariation ? cartStatus.label : product.availabilityLabel;
   // The slug always resolves to the parent Square item; a variation id pins
   // the detail page to the specific flavor this card represents (relevant
   // for multi-variation items, harmless no-op for single-variation ones).

--- a/components/store/ShopProductCard.tsx
+++ b/components/store/ShopProductCard.tsx
@@ -10,6 +10,7 @@ import type { ReactElement } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { AddToCartButton } from "./AddToCartButton";
+import { useVariationCartStatus } from "./CartProvider";
 import { formatPriceRange } from "@/lib/utils/catalogHelpers";
 import type { StoreProductSummary } from "@/lib/types/storeTypes";
 
@@ -22,8 +23,13 @@ export default function ShopProductCard({
   product,
   priority = false,
 }: ShopProductCardProps): ReactElement {
-  const tag = product.availabilityLabel;
-  const soldOut = product.availability === "sold_out";
+  // Re-derived against the cart so the badge counts down as units get added,
+  // instead of showing the stock count from whenever the page first loaded.
+  const cartStatus = useVariationCartStatus(product.defaultVariation);
+  const tag = product.defaultVariation ? cartStatus.label : product.availabilityLabel;
+  const soldOut = product.defaultVariation
+    ? cartStatus.availability === "sold_out"
+    : product.availability === "sold_out";
   // The slug always resolves to the parent Square item; a variation id pins
   // the detail page to the specific flavor this card represents (relevant
   // for multi-variation items, harmless no-op for single-variation ones).

--- a/e2e/checkout-gift.spec.ts
+++ b/e2e/checkout-gift.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-// Seed a cart in localStorage (key cc_cart) before the app hydrates, then reach
+// Seed a cart in sessionStorage (key cc_cart) before the app hydrates, then reach
 // checkout via the cart's "Proceed to Checkout" link (client nav keeps cart
 // state — a hard nav to /checkout can bounce to /cart before hydration).
 const CART_ITEM = {
@@ -19,7 +19,7 @@ const CART_ITEM = {
 test.describe("store checkout — gift shipping", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript((item) => {
-      window.localStorage.setItem("cc_cart", JSON.stringify([item]));
+      window.sessionStorage.setItem("cc_cart", JSON.stringify([item]));
     }, CART_ITEM);
   });
 

--- a/lib/utils/catalogHelpers.ts
+++ b/lib/utils/catalogHelpers.ts
@@ -14,7 +14,7 @@ import type {
 import { createProductSlug } from "@/lib/utils/slugify";
 import { formatCents } from "@/lib/utils/moneyHelpers";
 
-const LOW_STOCK_THRESHOLD = 5;
+export const LOW_STOCK_THRESHOLD = 5;
 
 /**
  * Square category-name prefix that controls Shop visibility. The merchant adds an
@@ -141,6 +141,33 @@ export function buildAvailabilityLabel(
   if (availability === "sold_out") return "Sold out";
   if (availability === "low_stock") return `Only ${remaining} remaining`;
   return null;
+}
+
+/**
+ * Re-derives a variation's availability/label after subtracting whatever the
+ * shopper already holds in their own cart. Square's stock count (and the
+ * availability/label derived from it) is fetched once per page load and never
+ * knows about the cart — without this, "Only 2 remaining" stays put even after
+ * both units are sitting in the cart, and Add to Cart keeps accepting clicks
+ * past what's actually available. This is a client-side reservation view only;
+ * it never writes to Square inventory (that happens at checkout).
+ */
+export function clientAvailabilityAfterCart(
+  variation: Pick<StoreProductVariation, "availability" | "inStockQuantity">,
+  cartQuantity: number
+): { availability: StoreProductAvailability; label: string | null } {
+  if (variation.availability === "sold_out" || variation.inStockQuantity === undefined) {
+    return {
+      availability: variation.availability,
+      label: buildAvailabilityLabel(variation.availability, variation.inStockQuantity ?? 0),
+    };
+  }
+
+  const remaining = Math.max(0, variation.inStockQuantity - cartQuantity);
+  const availability: StoreProductAvailability =
+    remaining <= 0 ? "sold_out" : remaining <= LOW_STOCK_THRESHOLD ? "low_stock" : "available";
+
+  return { availability, label: buildAvailabilityLabel(availability, remaining) };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add to Cart (both the product detail page and the shop grid/list cards) had no cap check at all — clicking past a variation's tracked stock silently kept "succeeding" with no feedback, even though `CartProvider` already clamped the underlying quantity. The "Only N remaining" badge was a static snapshot from page load and never reflected what was already sitting in the cart.
- `catalogHelpers.clientAvailabilityAfterCart()` + `CartProvider.useVariationCartStatus()` now re-derive a variation's availability/label by subtracting cart quantity from tracked stock (client-side reservation view only — Square inventory is untouched until checkout).
- The Add to Cart control now disables and reads "Max in Cart" once the cap is hit (vs. "Sold Out" for genuinely zero stock), and a toast fires if a click still lands past the cap (covers a fast double-click racing the disabled state).
- Cart persistence switched from `localStorage` to `sessionStorage` — still survives reloads/navigation while shopping, but clears once the tab/browser closes instead of lingering indefinitely.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean (no new warnings)
- [x] `pnpm run build` — succeeds
- [x] `pnpm run test:run` — 48 files / 416 tests, all green (incl. updated `CartProvider` unit tests + `checkout-gift` e2e seeding for the sessionStorage switch)
- [x] Manually reproduced the original bug and verified the fix live in-browser: Monstera Leaves kit (2 in stock) — badge counts 2 → 1 → "Sold out", button disables to "Max in Cart", cart quantity stays pinned at 2 through repeated clicks; grid card shows the same live badge
- [ ] Ben: click through the cart flow once more locally before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)