### PR TITLE
fix: enforce numberOfParticipants cap on Event bookings

### DIFF
--- a/.claude/code-reviews/pr-204-review.md
+++ b/.claude/code-reviews/pr-204-review.md
@@ -1,0 +1,60 @@
+# Review: PR #204 — enforce `numberOfParticipants` cap on Event bookings
+
+**Verdict: Request changes.** The fix is correctly designed and well-tested on the live checkout path, but the same capacity check on the second route it patches has a broken fallback for a missing `quantity`, and that route has no test coverage to catch it.
+
+No Jira/Confluence for this project — reviewed straight off the PR body, the repo's `AGENTS.md`, and the investigation doc at `ClaudeVault/Memory/projects/coastal-creations/2026-08-06_capacity-cap-bug.md` in the second-brain repo.
+
+## Summary
+
+An 11th signup landed on a 10-cap class because `numberOfParticipants` was only ever a client-side "Sold Out" badge — no server route enforced it. This PR adds `lib/checkout/eventAvailability.ts` (mirroring the existing `reservationAvailability.ts` pattern) and wires it into both routes that create an Event booking: the live `POST /api/checkout/booking` and the older `POST /api/customer`.
+
+The fix on the primary/live route is solid and covered by new tests. The fix on the second route has a real logic gap in exactly the dimension the bug was about — capacity silently not enforced — that happens to be masked today by an unrelated throw elsewhere, not by design.
+
+## Validation
+
+| Check | Result |
+|---|---|
+| `pnpm run test:run` | 49 files / 426 tests passed (matches PR's claimed test plan) |
+| `pnpm run typecheck` | clean |
+| `pnpm run build` | clean |
+| `pnpm run lint` | 0 errors, 47 pre-existing warnings, none in touched files |
+
+## Issues
+
+### High — `app/api/customer/route.ts`: capacity check silently passes when `quantity` is omitted
+
+`app/api/customer/route.ts:42` destructures `quantity` straight off `request.json()` with no fallback, then passes it unguarded into `validateEventCapacity(currentCount, quantity, ...)` at `app/api/customer/route.ts:326-330`. Contrast with the sibling route, which normalizes `booking.quantity ?? 1` before the same call (`app/api/checkout/booking/route.ts:154`).
+
+**Failure scenario:** `POST /api/customer` with `{ event: "<full-event-id>", eventType: "Event", billingInfo: {...} }` and `quantity` omitted entirely. `validateEventCapacity(10, undefined, 10)` computes `availableSpots = 0` and checks `undefined > 0`, which is `false` in JS — so the function returns `null` ("capacity OK") for a fully-booked event. Verified directly:
+
+```
+result with quantity=undefined at 10/10 cap: null   // should be "sold out"
+```
+
+This does **not** currently produce an oversold `Customer` record — a few lines later, `computeEventChargeCents` → `validateCount()` in `lib/checkout/eventPricing.ts:72-82` independently throws `PriceIntegrityError` on the same `undefined` value, and the route's catch block turns that into a 400. But that's an incidental backstop from an unrelated module, not something this capacity check relies on by design — the two checks aren't linked, and the failure mode this PR exists to prevent (capacity check reporting "OK" when the event is full) is present in this file's logic right now. Any future change to `validateCount`'s strictness or to the ordering of these two checks would silently reopen the exact bug this PR closes, on the exact route the investigation doc names as one of the two culprits.
+
+Fix: apply the same `quantity ?? 1` (or explicit numeric validation) before the capacity check that `app/api/checkout/booking/route.ts` already uses.
+
+**Compounding gap — no test would catch this today.** There is no test file anywhere in the repo for `app/api/customer/route.ts`'s `POST` handler (confirmed — only client-hook mocks under `__tests__/hooks/mutations/use-create-customer.test.ts` exist, which don't touch the route itself). `bookingRoute.test.ts` got a dedicated 3-test block for this exact scenario on the sibling route; the route this bug actually lives in got none. This is precisely how it shipped.
+
+### Low — `lib/checkout/eventAvailability.ts:39`: `||` treats an explicit cap of `0` as "unset"
+
+```ts
+const cap = numberOfParticipants || DEFAULT_CAPACITY;
+```
+
+If an event is ever configured with `numberOfParticipants: 0` (e.g. "registration not yet open"), this silently falls back to a cap of 20 instead of correctly blocking every booking. Currently unreachable — the admin event form doesn't allow entering 0 — but it's a one-character fix (`??` instead of `||`) for a real edge case in shared validation logic, cheap enough to just take.
+
+## What's done well
+
+- `eventAvailability.ts` correctly mirrors `reservationAvailability.ts`'s shape — a pure `validate*` function plus a separate async count helper — and stays fully typed with no `any`.
+- Both routes place the capacity check **before** the Square charge, matching the codebase's existing "no charge on failure" principle (see the Reservation check it's modeled on).
+- `lib/checkout/eventAvailability.ts`'s counting (`Customer.find({ event: eventId })`, no `refundStatus` filter) is a documented, intentional match to the existing client-side count in `EventsContainer.tsx` — not a new policy, and not flagged here per that.
+- The known count-then-insert (non-atomic) limitation is honestly disclosed in the PR body and investigation doc, with the right context for why it's out of scope — not re-flagged here.
+- `bookingRoute.test.ts`'s new capacity tests correctly assert `paymentsCreate`/`customerCreate` are never called on rejection — the right thing to check for a pre-charge gate.
+- Logging follows the repo's `[FILENAME-FUNCTION]` convention consistently in both routes.
+- Root-cause writeup (linked from the PR body) is thorough and the fix's scope (excluding `PrivateEvent`, matching `EventCard`'s existing 20-default) is well-justified.
+
+## Recommendation
+
+Fix the High finding — apply `quantity ?? 1` (or equivalent explicit validation) in `app/api/customer/route.ts` before the capacity check, and add a test for the omitted-`quantity` case on that route (mirroring the sold-out test already written for `bookingRoute.test.ts`). The `||`/`??` nit is a trivial include-while-you're-in-there fix, not a blocker on its own.

--- a/__tests__/checkout/bookingRoute.test.ts
+++ b/__tests__/checkout/bookingRoute.test.ts
@@ -23,7 +23,28 @@ vi.mock("@/lib/square/gift-cards", () => ({
 }));
 
 const customerCreate = vi.fn();
-vi.mock("@/lib/models/Customer", () => ({ default: { create: (...a: unknown[]) => customerCreate(...a) } }));
+const customerFind = vi.fn();
+vi.mock("@/lib/models/Customer", () => ({
+  default: {
+    create: (...a: unknown[]) => customerCreate(...a),
+    find: (...a: unknown[]) => customerFind(...a),
+  },
+}));
+
+const eventFindById = vi.fn();
+vi.mock("@/lib/models/Event", () => ({
+  default: { findById: (...a: unknown[]) => eventFindById(...a) },
+}));
+
+// Existing bookings summed by getEventParticipantCount — default to none so
+// tests that don't care about capacity aren't affected by it.
+function mockExistingBookings(quantities: number[]) {
+  customerFind.mockReturnValue({
+    select: () => ({
+      lean: () => Promise.resolve(quantities.map((quantity) => ({ quantity }))),
+    }),
+  });
+}
 
 const reservationFindById = vi.fn();
 const reservationBulkWrite = vi.fn();
@@ -82,6 +103,8 @@ beforeEach(() => {
   resolveUserSquareCustomerId.mockResolvedValue("acct_cust_1");
   cardGetCard.mockResolvedValue({ id: "ccof:1", customerId: "acct_cust_1" });
   cardCreateCard.mockResolvedValue({ id: "ccof:new" });
+  eventFindById.mockResolvedValue({ numberOfParticipants: 20 });
+  mockExistingBookings([]);
 });
 
 const SIGNED_IN = { id: "user_1", email: "u@example.com", isAdmin: false, role: "customer" };
@@ -164,6 +187,41 @@ describe("POST /api/checkout/booking", () => {
     const res = await POST(req({ booking: BOOKING, contact: CONTACT }));
     expect(res.status).toBe(400);
     expect(paymentsCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/checkout/booking — event capacity", () => {
+  it("rejects (400) and never charges when the event is already full", async () => {
+    eventFindById.mockResolvedValue({ numberOfParticipants: 10 });
+    mockExistingBookings(Array(10).fill(1)); // 10/10 already booked
+    const res = await POST(req({ paymentToken: "cnon:tok", booking: BOOKING, contact: CONTACT }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toMatch(/sold out/i);
+    expect(paymentsCreate).not.toHaveBeenCalled();
+    expect(customerCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows a booking that exactly fills the last spot", async () => {
+    eventFindById.mockResolvedValue({ numberOfParticipants: 10 });
+    mockExistingBookings(Array(9).fill(1)); // 9/10 booked, this is #10
+    const res = await POST(req({ paymentToken: "cnon:tok", booking: BOOKING, contact: CONTACT }));
+
+    expect(res.status).toBe(200);
+    expect(customerCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply the Event capacity check to Reservation bookings", async () => {
+    const res = await POST(
+      req({
+        paymentToken: "cnon:tok",
+        booking: { eventId: "ev1", eventType: "Reservation", quantity: 1, selectedDates: [{ date: "2026-08-25", numberOfParticipants: 1 }] },
+        contact: CONTACT,
+      })
+    );
+
+    expect(eventFindById).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/checkout/customerRoute.test.ts
+++ b/__tests__/checkout/customerRoute.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// --- Mock every dependency the route orchestrates ---
+vi.mock("@/lib/mongoose", () => ({ connectMongo: vi.fn() }));
+
+const getSessionUser = vi.fn();
+vi.mock("@/lib/auth/guards", () => ({
+  getSessionUser: (...a: unknown[]) => getSessionUser(...a),
+}));
+
+const findOrCreateCustomer = vi.fn();
+vi.mock("@/lib/square/customers", () => ({
+  squareCustomerService: { findOrCreateCustomer: (...a: unknown[]) => findOrCreateCustomer(...a) },
+}));
+
+const customerSave = vi.fn();
+const customerFind = vi.fn();
+vi.mock("@/lib/models/Customer", () => {
+  class CustomerMock {
+    constructor(doc: Record<string, unknown>) {
+      Object.assign(this, doc);
+    }
+    save = () => customerSave(this);
+    static find = (...a: unknown[]) => customerFind(...a);
+  }
+  return { default: CustomerMock };
+});
+
+// Existing bookings summed by getEventParticipantCount — default to none so
+// tests that don't care about capacity aren't affected by it.
+function mockExistingBookings(quantities: number[]) {
+  customerFind.mockReturnValue({
+    select: () => ({
+      lean: () => Promise.resolve(quantities.map((quantity) => ({ quantity }))),
+    }),
+  });
+}
+
+const eventFindById = vi.fn();
+vi.mock("@/lib/models/Event", () => ({
+  default: { findById: (...a: unknown[]) => eventFindById(...a) },
+}));
+
+vi.mock("@/lib/models/PrivateEvent", () => ({
+  default: { findById: vi.fn() },
+}));
+
+vi.mock("@/lib/models/Reservations", () => ({
+  default: { findById: vi.fn(), bulkWrite: vi.fn() },
+}));
+
+import { POST } from "@/app/api/customer/route";
+
+const BILLING_INFO = {
+  firstName: "Ada",
+  lastName: "Lovelace",
+  emailAddress: "ada@example.com",
+  phoneNumber: "+16095551234",
+};
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/customer", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionUser.mockResolvedValue(null);
+  findOrCreateCustomer.mockResolvedValue({ customerId: "sqcust_1", isNew: true });
+  customerSave.mockImplementation((doc: unknown) => Promise.resolve(doc));
+  eventFindById.mockResolvedValue({ price: 50, numberOfParticipants: 10 });
+  mockExistingBookings([]);
+});
+
+describe("POST /api/customer — event capacity", () => {
+  it("rejects (400, sold out) and never saves when the event is full, even with quantity omitted from the request", async () => {
+    // Regression test for the High finding on PR #204: `quantity` reached
+    // validateEventCapacity() unguarded, and `undefined > availableSpots` is
+    // `false` in JS — so an omitted quantity silently passed the capacity
+    // check on a fully-booked event. Without the `quantity ?? 1` fix, this
+    // request would still 400 (a downstream pricing throw catches it) but
+    // with "Invalid quantity", not "sold out" — asserting the message proves
+    // the capacity check itself is what's rejecting it.
+    mockExistingBookings(Array(10).fill(1)); // 10/10 already booked
+    const res = await POST(req({ event: "ev1", eventType: "Event", billingInfo: BILLING_INFO }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toMatch(/sold out/i);
+    expect(customerSave).not.toHaveBeenCalled();
+  });
+
+  it("still books normally with a valid quantity when there's room (fix didn't break the happy path)", async () => {
+    mockExistingBookings(Array(9).fill(1)); // 9/10 booked, this is #10
+    const res = await POST(
+      req({ event: "ev1", eventType: "Event", quantity: 1, billingInfo: BILLING_INFO })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(customerSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("omitting quantity entirely is still rejected (400, invalid quantity) — the fix only corrects the capacity check's own reasoning, it doesn't make omitted quantity a valid request", async () => {
+    mockExistingBookings(Array(9).fill(1)); // room available — capacity check passes either way
+    const res = await POST(req({ event: "ev1", eventType: "Event", billingInfo: BILLING_INFO }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toMatch(/invalid quantity/i);
+    expect(customerSave).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/checkout/eventAvailability.test.ts
+++ b/__tests__/checkout/eventAvailability.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { validateEventCapacity } from "@/lib/checkout/eventAvailability";
+
+describe("validateEventCapacity", () => {
+  it("returns null when there's enough room", () => {
+    expect(validateEventCapacity(9, 1, 10)).toBeNull();
+  });
+
+  it("allows a booking that exactly fills the last spot(s)", () => {
+    expect(validateEventCapacity(8, 2, 10)).toBeNull();
+  });
+
+  it("rejects when the requested quantity exceeds remaining spots", () => {
+    // 10 - 9 = 1 spot left; asking for 2.
+    expect(validateEventCapacity(9, 2, 10)).toMatch(/Only 1 spot left/);
+  });
+
+  it("reports sold out (not '0 spots left') when there's no room at all", () => {
+    expect(validateEventCapacity(10, 1, 10)).toMatch(/sold out/i);
+  });
+
+  it("rejects the exact bug that was reported: 11th signup against a 10 cap", () => {
+    expect(validateEventCapacity(10, 1, 10)).not.toBeNull();
+  });
+
+  it("falls back to a cap of 20 when numberOfParticipants is unset (matches EventCard's display fallback)", () => {
+    expect(validateEventCapacity(19, 1, undefined)).toBeNull();
+    expect(validateEventCapacity(20, 1, undefined)).toMatch(/sold out/i);
+  });
+
+  it("pluralizes the spots-left message correctly", () => {
+    expect(validateEventCapacity(8, 3, 10)).toMatch(/Only 2 spots left/);
+    expect(validateEventCapacity(9, 2, 10)).toMatch(/Only 1 spot left\./);
+  });
+});

--- a/__tests__/checkout/eventAvailability.test.ts
+++ b/__tests__/checkout/eventAvailability.test.ts
@@ -28,6 +28,10 @@ describe("validateEventCapacity", () => {
     expect(validateEventCapacity(20, 1, undefined)).toMatch(/sold out/i);
   });
 
+  it("treats an explicit cap of 0 as sold out, not as unset (0 !== undefined)", () => {
+    expect(validateEventCapacity(0, 1, 0)).toMatch(/sold out/i);
+  });
+
   it("pluralizes the spots-left message correctly", () => {
     expect(validateEventCapacity(8, 3, 10)).toMatch(/Only 2 spots left/);
     expect(validateEventCapacity(9, 2, 10)).toMatch(/Only 1 spot left\./);

--- a/app/api/checkout/booking/route.ts
+++ b/app/api/checkout/booking/route.ts
@@ -10,6 +10,8 @@
  *   1. PRICE INTEGRITY: recompute the charge server-side from the DB (resolveBookingCharge);
  *      a client-supplied price is never trusted.
  *   2. Reservations: validate day/time-slot availability BEFORE charging.
+ *   2b. Events: validate the numberOfParticipants cap BEFORE charging (see
+ *       lib/checkout/eventAvailability.ts).
  *   3. Link/create the Square customer (non-fatal).
  *   4. Charge Square for the card portion (skipped when free or fully gift-card-covered).
  *   5. Redeem the applied gift card.
@@ -22,6 +24,7 @@
 import { NextResponse } from "next/server";
 import { connectMongo } from "@/lib/mongoose";
 import Customer from "@/lib/models/Customer";
+import Event from "@/lib/models/Event";
 import Reservation from "@/lib/models/Reservations";
 import { getSquareClient } from "@/lib/square/client";
 import { squareCustomerService } from "@/lib/square/customers";
@@ -39,6 +42,10 @@ import {
   type SelectedReservationDate,
   type ReservationDoc,
 } from "@/lib/checkout/reservationAvailability";
+import {
+  getEventParticipantCount,
+  validateEventCapacity,
+} from "@/lib/checkout/eventAvailability";
 
 interface SelectedOption {
   categoryName: string;
@@ -128,6 +135,30 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
       if (availabilityError) {
         return NextResponse.json({ error: availabilityError }, { status: 400 });
+      }
+    }
+
+    // 2b. Event capacity — validate BEFORE charging, same principle as the
+    // Reservation check above. PrivateEvent has no numberOfParticipants
+    // field/concept, so this only applies to eventType "Event". Previously
+    // unenforced here (or in the legacy /api/customer route) — the cap was
+    // only ever a client-side "Sold Out" UI badge (EventCard.tsx).
+    if (eventType === "Event") {
+      const event = await Event.findById(booking.eventId);
+      if (!event) {
+        return NextResponse.json({ error: "Event not found" }, { status: 404 });
+      }
+      const currentCount = await getEventParticipantCount(booking.eventId);
+      const capacityError = validateEventCapacity(
+        currentCount,
+        booking.quantity ?? 1,
+        event.numberOfParticipants
+      );
+      if (capacityError) {
+        console.error(
+          `[API-CHECKOUT-BOOKING-POST] Capacity exceeded for event ${booking.eventId}: ${capacityError}`
+        );
+        return NextResponse.json({ error: capacityError }, { status: 400 });
       }
     }
 

--- a/app/api/customer/route.ts
+++ b/app/api/customer/route.ts
@@ -11,6 +11,10 @@ import {
   computePrivateEventChargeCents,
   computeReservationChargeCents,
 } from "@/lib/checkout/eventPricing";
+import {
+  getEventParticipantCount,
+  validateEventCapacity,
+} from "@/lib/checkout/eventAvailability";
 import { PriceIntegrityError } from "@/lib/checkout/errors";
 import mongoose from "mongoose";
 import dayjs from "dayjs";
@@ -311,6 +315,25 @@ export async function POST(request: NextRequest) {
         },
         { status: 404 }
       );
+    }
+
+    // Capacity check — PrivateEvent has no numberOfParticipants field/concept,
+    // so this only applies to eventType "Event". Previously the cap was only
+    // enforced as a client-side "Sold Out" UI badge (EventCard.tsx), never
+    // re-checked here, which is how Sew and Surf Class oversold 11/10.
+    if (eventType !== "PrivateEvent") {
+      const currentCount = await getEventParticipantCount(eventId);
+      const capacityError = validateEventCapacity(
+        currentCount,
+        quantity,
+        (event as { numberOfParticipants?: number }).numberOfParticipants
+      );
+      if (capacityError) {
+        console.error(
+          `[CUSTOMER-API-POST] Capacity exceeded for event ${eventId}: ${capacityError}`
+        );
+        return NextResponse.json({ error: capacityError }, { status: 400 });
+      }
     }
 
     // Recompute `total` from the event/private-event doc so a tampered client

--- a/app/api/customer/route.ts
+++ b/app/api/customer/route.ts
@@ -323,9 +323,13 @@ export async function POST(request: NextRequest) {
     // re-checked here, which is how Sew and Surf Class oversold 11/10.
     if (eventType !== "PrivateEvent") {
       const currentCount = await getEventParticipantCount(eventId);
+      // `quantity` is unvalidated request input here (validateCount() below only
+      // runs after this check) — `undefined > availableSpots` is `false` in JS, so
+      // an omitted quantity would silently pass a full event. Normalize the same
+      // way /api/checkout/booking/route.ts does before its capacity check.
       const capacityError = validateEventCapacity(
         currentCount,
-        quantity,
+        quantity ?? 1,
         (event as { numberOfParticipants?: number }).numberOfParticipants
       );
       if (capacityError) {

--- a/lib/checkout/eventAvailability.ts
+++ b/lib/checkout/eventAvailability.ts
@@ -6,7 +6,9 @@
  *
  * Default cap of 20 when `numberOfParticipants` is unset matches EventCard's
  * existing display fallback (`event.numberOfParticipants || 20`) — parity
- * with current user-facing behavior, not a new policy.
+ * with current user-facing behavior, not a new policy. Unlike that display
+ * fallback, this check uses `??` rather than `||`: an explicitly configured
+ * `numberOfParticipants: 0` must mean "not open for booking," not "unset."
  */
 import Customer from "@/lib/models/Customer";
 
@@ -36,7 +38,7 @@ export function validateEventCapacity(
   requestedQuantity: number,
   numberOfParticipants: number | undefined
 ): string | null {
-  const cap = numberOfParticipants || DEFAULT_CAPACITY;
+  const cap = numberOfParticipants ?? DEFAULT_CAPACITY;
   const availableSpots = cap - currentCount;
 
   if (requestedQuantity > availableSpots) {

--- a/lib/checkout/eventAvailability.ts
+++ b/lib/checkout/eventAvailability.ts
@@ -1,0 +1,49 @@
+/**
+ * Event capacity: the server-side check the Reservation booking path already
+ * had (see reservationAvailability.ts) but the Event/PrivateEvent path never
+ * did — `numberOfParticipants` was enforced only as a client-side "Sold Out"
+ * badge (EventCard.tsx), never re-checked when the booking is actually saved.
+ *
+ * Default cap of 20 when `numberOfParticipants` is unset matches EventCard's
+ * existing display fallback (`event.numberOfParticipants || 20`) — parity
+ * with current user-facing behavior, not a new policy.
+ */
+import Customer from "@/lib/models/Customer";
+
+const DEFAULT_CAPACITY = 20;
+
+/**
+ * Sum of `quantity` across existing bookings for an event — the same
+ * definition EventsContainer.tsx uses client-side to compute
+ * `eventParticipantCounts` (no refundStatus filter), kept consistent here.
+ */
+export async function getEventParticipantCount(
+  eventId: string
+): Promise<number> {
+  const bookings = await Customer.find({ event: eventId })
+    .select("quantity")
+    .lean();
+
+  return bookings.reduce((sum, booking) => sum + (booking.quantity || 0), 0);
+}
+
+/**
+ * Validate that `requestedQuantity` more participants still fit under the
+ * event's cap. Returns an error message string if not, or null when OK.
+ */
+export function validateEventCapacity(
+  currentCount: number,
+  requestedQuantity: number,
+  numberOfParticipants: number | undefined
+): string | null {
+  const cap = numberOfParticipants || DEFAULT_CAPACITY;
+  const availableSpots = cap - currentCount;
+
+  if (requestedQuantity > availableSpots) {
+    return availableSpots > 0
+      ? `Not enough spots available. Only ${availableSpots} spot${availableSpots === 1 ? "" : "s"} left.`
+      : `This event is sold out.`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Sew and Surf Class (`numberOfParticipants: 10`) had an 11th signup land **5 days after** the class filled — not a race condition, the cap was never enforced server-side. `numberOfParticipants` was only ever a client-side "Sold Out" badge (`EventCard.tsx`); neither booking route that creates a `Customer` record for `eventType: "Event"` had any capacity check (the Reservation booking type already had this via `reservationAvailability.ts`).
- Adds `lib/checkout/eventAvailability.ts` (mirrors the existing Reservation pattern: a DB helper to sum existing bookings + a pure `validateEventCapacity` function) and wires it into both places a booking gets created for `eventType: "Event"`:
  - `POST /api/customer` — before `Customer.save()`
  - `POST /api/checkout/booking` — before Square is charged (so a sold-out signup never gets billed)
- `PrivateEvent` bookings are unaffected — that model has no `numberOfParticipants` field/concept.
- Default cap of 20 when `numberOfParticipants` is unset matches `EventCard`'s existing display fallback (`event.numberOfParticipants || 20`) — parity with current behavior, not a new policy.

**Known limitation:** this is a count-then-insert check, not a fully atomic increment-with-guard — the Reservation path's own pre-save check has the same shape (its `$inc` bulkWrite is atomic per date, but the availability check before it isn't). Two people completing checkout for the last spot at the exact same instant could still both get through. That's a materially narrower issue than the one reported (a 5-day-old, always-open hole) and out of scope here; a fully atomic version would need a stored counter on `Event` mirroring `Reservation.dailyAvailability[].currentBookings`.

Full investigation + evidence: `ClaudeVault/Memory/projects/coastal-creations/2026-08-06_capacity-cap-bug.md` in the second-brain repo.

## Test plan

- [x] `pnpm vitest run` — 49 files / 426 tests pass (added 7 new tests in `eventAvailability.test.ts`, extended `bookingRoute.test.ts` with 3 capacity-specific cases + mocks for `Event.findById` / `Customer.find` that the existing suite didn't have)
- [x] `pnpm run build` — clean, no type errors
- [ ] Ashley/Ben: decide what to do about the real 11th Surf & Sew booking (Brooke Hoffner, $50, Square payment `jTztGMAgJKHQfCjVlSJOxDDsoP9YY`) — honor it, refund, or make room

🤖 Generated with [Claude Code](https://claude.com/claude-code)
